### PR TITLE
fix: Added extra selectors for order num and date

### DIFF
--- a/amazonorders/selectors.py
+++ b/amazonorders/selectors.py
@@ -101,7 +101,6 @@ class Selectors:
                                         "[data-component='orderDate']",
                                         "span.order-date-invoice-item",
                                         "div.a-span3"]
-
     FIELD_ORDER_PAYMENT_METHOD_SELECTOR = "img.pmts-payment-credit-card-instrument-logo"
     FIELD_ORDER_PAYMENT_METHOD_LAST_4_SELECTOR = "span:has(img.pmts-payment-credit-card-instrument-logo):last-child"
     FIELD_ORDER_SUBTOTALS_TAG_ITERATOR_SELECTOR = ["[data-component='orderSubtotals'] div.a-row",

--- a/amazonorders/selectors.py
+++ b/amazonorders/selectors.py
@@ -90,6 +90,7 @@ class Selectors:
 
     FIELD_ORDER_DETAILS_LINK_SELECTOR = "a.yohtmlc-order-details-link"
     FIELD_ORDER_NUMBER_SELECTOR = ["[data-component='briefOrderInfo'] div.a-column",
+                                   "[data-component='orderId']",
                                    ".order-date-invoice-item bdi[dir='ltr']",
                                    "bdi[dir='ltr']",
                                    "span[dir='ltr']"]
@@ -97,8 +98,10 @@ class Selectors:
                                         "div.order-header div.a-column.a-span2",
                                         "div.order-header div.a-col-left .a-span9"]
     FIELD_ORDER_PLACED_DATE_SELECTOR = ["[data-component='briefOrderInfo'] div.a-column",
+                                        "[data-component='orderDate']",
                                         "span.order-date-invoice-item",
                                         "div.a-span3"]
+
     FIELD_ORDER_PAYMENT_METHOD_SELECTOR = "img.pmts-payment-credit-card-instrument-logo"
     FIELD_ORDER_PAYMENT_METHOD_LAST_4_SELECTOR = "span:has(img.pmts-payment-credit-card-instrument-logo):last-child"
     FIELD_ORDER_SUBTOTALS_TAG_ITERATOR_SELECTOR = ["[data-component='orderSubtotals'] div.a-row",


### PR DESCRIPTION
### Description

Fetching specific order number was failing. See #39 for details. Issue was neither of these were getting fetched (maybe due to some change on amazon order's webpage)

I added extra selectors for order number and order date. These selectors should be more robust too.

![Screenshot 2025-02-19 at 3 27 00 PM](https://github.com/user-attachments/assets/a685ec0b-7337-4a68-a85c-07fc8f72a70b)


Fixes #39

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a schema change
- [ ] This change requires a documentation update

### Testing Done
Ran `make local`, `make test`, `make test-integration`, and `make check`, all passes.

```
$ make test-integration

tests/integration/test_integration_generic.py::TestIntegrationGeneric::test_get_order PASSED
tests/integration/test_integration_generic.py::TestIntegrationGeneric::test_get_order_does_not_exist PASSED
tests/integration/test_integration_generic.py::TestIntegrationGeneric::test_get_order_history PASSED
tests/integration/test_integration_generic.py::TestIntegrationGeneric::test_get_order_history_full_details PASSED
tests/integration/test_integration_generic.py::TestIntegrationGeneric::test_get_transactions PASSED
tests/integration/test_integration_json.py::TestIntegrationJSON::test_json SKIPPED (parameterized input is empty)

========================================================= 5 passed, 1 skipped in 132.03s (0:02:12) =========================================================
```

Integration test was failing before the change
```
$ make test-integration
...

tests/integration/test_integration_generic.py::TestIntegrationGeneric::test_get_order FAILED
tests/integration/test_integration_generic.py::TestIntegrationGeneric::test_get_order_does_not_exist PASSED
tests/integration/test_integration_generic.py::TestIntegrationGeneric::test_get_order_history PASSED
tests/integration/test_integration_generic.py::TestIntegrationGeneric::test_get_order_history_full_details PASSED
tests/integration/test_integration_generic.py::TestIntegrationGeneric::test_get_transactions PASSED
tests/integration/test_integration_json.py::TestIntegrationJSON::test_json SKIPPED (parameterized input is empty)
```

A clear and concise description of the new tests added to validate the change as well as any manual testing done.

### Checklist

- [x] I have added tests that prove my change works as expected, and `make test` passes with no new errors or warnings
- [x] I have run `make check` to ensure no new errors or warnings
- [x] I have updated the docs, if applicable, and run `make docs` to ensure no new errors or warnings
- [x] I have performed a self-review of my own code
- [x] I have commented my code in particularly hard-to-understand areas
