### PR TITLE
Remove extra dollar sign from CLI output

### DIFF
--- a/amazonorders/cli.py
+++ b/amazonorders/cli.py
@@ -347,15 +347,15 @@ Order #{}
     if order.subtotal:
         order_str += f"\n  Subtotal: {config.constants.format_currency(order.subtotal)}"
     if order.shipping_total:
-        order_str += f"\n  Shipping Total: ${config.constants.format_currency(order.shipping_total)}"
+        order_str += f"\n  Shipping Total: {config.constants.format_currency(order.shipping_total)}"
     if order.subscription_discount:
-        order_str += f"\n  Subscription Discount: ${config.constants.format_currency(order.subscription_discount)}"
+        order_str += f"\n  Subscription Discount: {config.constants.format_currency(order.subscription_discount)}"
     if order.total_before_tax:
-        order_str += f"\n  Total Before Tax: ${config.constants.format_currency(order.total_before_tax)}"
+        order_str += f"\n  Total Before Tax: {config.constants.format_currency(order.total_before_tax)}"
     if order.estimated_tax:
-        order_str += f"\n  Estimated Tax: ${config.constants.format_currency(order.estimated_tax)}"
+        order_str += f"\n  Estimated Tax: {config.constants.format_currency(order.estimated_tax)}"
     if order.refund_total:
-        order_str += f"\n  Refund Total: ${config.constants.format_currency(order.refund_total)}"
+        order_str += f"\n  Refund Total: {config.constants.format_currency(order.refund_total)}"
 
     order_str += "\n-----------------------------------------------------------------------"
 


### PR DESCRIPTION
### Description

`format_currency` already adds a dollar sign so remove the extraneous one.

### Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a schema change
- [ ] This change requires a documentation update

### Testing Done

Manually run `amazon-orders order [myordernum]`

### Checklist

- [ ] I have added tests that prove my change works as expected, and `make test` passes with no new errors or warnings
- [ ] I have run `make check` to ensure no new errors or warnings
- [ ] I have updated the docs, if applicable, and run `make docs` to ensure no new errors or warnings
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code in particularly hard-to-understand areas
