### PR TITLE
Feature: Opt-in 2Captcha integration for Amazon WAF Captcha Challenges

### DIFF
--- a/amazonorders/captcha/__init__.py
+++ b/amazonorders/captcha/__init__.py
@@ -1,0 +1,69 @@
+"""
+CAPTCHA solving integration for Amazon WAF challenges.
+
+This module provides built-in support for 2captcha CAPTCHA solving service.
+Usage is opt-in - simply pass your API key to AmazonSession.
+
+Example::
+
+    from amazonorders.session import AmazonSession
+
+    session = AmazonSession(
+        "email@example.com",
+        "password",
+        captcha_solver="2captcha",
+        captcha_api_key="your-api-key"
+    )
+    session.login()
+"""
+
+__copyright__ = "Copyright (c) 2024-2025 Alex Laird"
+__license__ = "MIT"
+
+import logging
+from typing import TYPE_CHECKING
+
+from amazonorders.captcha.base import CaptchaSolver
+
+if TYPE_CHECKING:
+    from amazonorders.captcha.twocaptcha import TwoCaptchaSolver
+
+logger = logging.getLogger(__name__)
+
+# Lazy-loaded solver class
+_TwoCaptchaSolver = None
+
+
+def _get_twocaptcha_solver():
+    """Lazily import and return TwoCaptchaSolver class."""
+    global _TwoCaptchaSolver
+    if _TwoCaptchaSolver is None:
+        from amazonorders.captcha.twocaptcha import TwoCaptchaSolver
+        _TwoCaptchaSolver = TwoCaptchaSolver
+    return _TwoCaptchaSolver
+
+
+def get_solver(service: str, api_key: str) -> CaptchaSolver:
+    """
+    Get a CAPTCHA solver instance for the specified service.
+
+    :param service: Service name (currently only ``"2captcha"`` is supported)
+    :param api_key: API key for the service
+    :return: CaptchaSolver instance
+    :raises ValueError: If service is not supported
+    :raises ImportError: If required library is not installed
+    """
+    if service in {"2captcha"}:
+        solver_class = _get_twocaptcha_solver()
+        return solver_class(api_key)
+    else:
+        raise ValueError(
+            f"Unsupported CAPTCHA solver '{service}'. Supported: 2captcha"
+        )
+
+
+def __getattr__(name):
+    """Module-level __getattr__ for lazy loading of solver classes."""
+    if name == "TwoCaptchaSolver":
+        return _get_twocaptcha_solver()
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/amazonorders/captcha/__init__.py
+++ b/amazonorders/captcha/__init__.py
@@ -20,24 +20,7 @@ Example::
 __copyright__ = "Copyright (c) 2024-2025 Alex Laird"
 __license__ = "MIT"
 
-from typing import TYPE_CHECKING
-
 from amazonorders.captcha.base import CaptchaSolver
-
-if TYPE_CHECKING:
-    from amazonorders.captcha.twocaptcha import TwoCaptchaSolver
-
-# Lazy-loaded solver class
-_TwoCaptchaSolver = None
-
-
-def _get_twocaptcha_solver():
-    """Lazily import and return TwoCaptchaSolver class."""
-    global _TwoCaptchaSolver
-    if _TwoCaptchaSolver is None:
-        from amazonorders.captcha.twocaptcha import TwoCaptchaSolver
-        _TwoCaptchaSolver = TwoCaptchaSolver
-    return _TwoCaptchaSolver
 
 
 def get_solver(service: str, api_key: str) -> CaptchaSolver:
@@ -51,16 +34,9 @@ def get_solver(service: str, api_key: str) -> CaptchaSolver:
     :raises ImportError: If required library is not installed
     """
     if service in {"2captcha"}:
-        solver_class = _get_twocaptcha_solver()
-        return solver_class(api_key)
+        from amazonorders.captcha.twocaptcha import TwoCaptchaSolver
+        return TwoCaptchaSolver(api_key)
     else:
         raise ValueError(
             f"Unsupported CAPTCHA solver '{service}'. Supported: 2captcha"
         )
-
-
-def __getattr__(name):
-    """Module-level __getattr__ for lazy loading of solver classes."""
-    if name == "TwoCaptchaSolver":
-        return _get_twocaptcha_solver()
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/amazonorders/captcha/__init__.py
+++ b/amazonorders/captcha/__init__.py
@@ -20,15 +20,12 @@ Example::
 __copyright__ = "Copyright (c) 2024-2025 Alex Laird"
 __license__ = "MIT"
 
-import logging
 from typing import TYPE_CHECKING
 
 from amazonorders.captcha.base import CaptchaSolver
 
 if TYPE_CHECKING:
     from amazonorders.captcha.twocaptcha import TwoCaptchaSolver
-
-logger = logging.getLogger(__name__)
 
 # Lazy-loaded solver class
 _TwoCaptchaSolver = None

--- a/amazonorders/captcha/base.py
+++ b/amazonorders/captcha/base.py
@@ -1,0 +1,48 @@
+"""
+Base class for CAPTCHA solver implementations.
+"""
+
+__copyright__ = "Copyright (c) 2024-2025 Alex Laird"
+__license__ = "MIT"
+
+from abc import ABC, abstractmethod
+from typing import Dict, Optional
+
+
+class CaptchaSolver(ABC):
+    """
+    Abstract base class for CAPTCHA solving service integrations.
+
+    Subclasses must implement :meth:`solve_amazon_waf` to handle
+    Amazon WAF CAPTCHA challenges.
+    """
+
+    def __init__(self, api_key: str):
+        """
+        Initialize the CAPTCHA solver.
+
+        :param api_key: API key for the CAPTCHA solving service
+        """
+        self.api_key = api_key
+
+    @abstractmethod
+    def solve_amazon_waf(
+        self,
+        sitekey: str,
+        iv: str,
+        context: str,
+        page_url: str,
+        challenge_script: Optional[str] = None,
+    ) -> Dict[str, str]:
+        """
+        Solve an Amazon WAF CAPTCHA challenge.
+
+        :param sitekey: Value of 'key' from window.gokuProps
+        :param iv: Value of 'iv' from window.gokuProps
+        :param context: Value of 'context' from window.gokuProps
+        :param page_url: Full URL of the page with the CAPTCHA
+        :param challenge_script: URL of challenge.js script (optional)
+        :return: Dict containing at minimum 'existing_token' (the aws-waf-token cookie value)
+        :raises Exception: If solving fails or times out
+        """
+        pass

--- a/amazonorders/captcha/twocaptcha.py
+++ b/amazonorders/captcha/twocaptcha.py
@@ -41,13 +41,13 @@ class TwoCaptchaSolver(CaptchaSolver):
         :param api_key: 2captcha API key
         """
         super().__init__(api_key)
-        
+
         if not TWOCAPTCHA_AVAILABLE:
             raise ImportError(
                 "2captcha-python library is required for 2captcha support. "
                 "Install with: pip install amazon-orders[twocaptcha]"
             )
-        
+
         self.solver = OfficialTwoCaptcha(api_key)
 
     def solve_amazon_waf(
@@ -70,14 +70,14 @@ class TwoCaptchaSolver(CaptchaSolver):
         :raises Exception: If submission fails or solving times out
         """
         logger.debug(f"Submitting Amazon WAF CAPTCHA to 2captcha for {page_url}")
-        
+
         try:
             # Convert parameters to the format expected by the official library
             # Map our parameter names to the official library parameter names
             kwargs = {}
             if challenge_script:
                 kwargs['challenge_script'] = challenge_script
-            
+
             result = self.solver.amazon_waf(
                 sitekey=sitekey,
                 iv=iv,
@@ -85,15 +85,15 @@ class TwoCaptchaSolver(CaptchaSolver):
                 url=page_url,
                 **kwargs
             )
-            
+
             logger.debug("CAPTCHA solved successfully by 2captcha")
-            
+
             # The official library returns the solution directly, we need to format it
             # to match the expected return format
             return {
                 "existing_token": json.loads(result.get("code", "{}")).get("existing_token")
             }
-            
+
         except Exception as e:
             logger.error(f"2captcha solving failed: {str(e)}")
             raise AmazonOrdersError(f"2captcha solving failed: {str(e)}")

--- a/amazonorders/captcha/twocaptcha.py
+++ b/amazonorders/captcha/twocaptcha.py
@@ -30,18 +30,8 @@ class TwoCaptchaSolver(CaptchaSolver):
     """
     CAPTCHA solver using 2captcha.com service via official 2captcha-python library.
 
-    Example::
-
-        from amazonorders.captcha import TwoCaptchaSolver
-
-        solver = TwoCaptchaSolver("your-api-key")
-        result = solver.solve_amazon_waf(
-            sitekey="AQIDAHjcYu...",
-            iv="CgAHazE...",
-            context="aaaa...",
-            page_url="https://www.amazon.com/..."
-        )
-        # result["existing_token"] contains the aws-waf-token cookie value
+    This solver is used internally by :class:`~amazonorders.session.AmazonSession`
+    when configured with ``captcha_solver="2captcha"``.
     """
 
     def __init__(self, api_key: str):

--- a/amazonorders/captcha/twocaptcha.py
+++ b/amazonorders/captcha/twocaptcha.py
@@ -1,0 +1,109 @@
+"""
+2captcha.com CAPTCHA solver implementation using official 2captcha-python library.
+
+This module provides integration with 2captcha.com for solving Amazon WAF CAPTCHAs.
+See https://2captcha.com/2captcha-api#amazon_waf for API documentation.
+"""
+
+__copyright__ = "Copyright (c) 2024-2025 Alex Laird"
+__license__ = "MIT"
+
+import logging
+import json
+from typing import Dict, Optional
+
+from amazonorders.captcha.base import CaptchaSolver
+from amazonorders.exception import AmazonOrdersError
+
+logger = logging.getLogger(__name__)
+
+# Try to import the official library
+try:
+    from twocaptcha import TwoCaptcha as OfficialTwoCaptcha
+    TWOCAPTCHA_AVAILABLE = True
+except ImportError:
+    TWOCAPTCHA_AVAILABLE = False
+    OfficialTwoCaptcha = None
+
+
+class TwoCaptchaSolver(CaptchaSolver):
+    """
+    CAPTCHA solver using 2captcha.com service via official 2captcha-python library.
+
+    Example::
+
+        from amazonorders.captcha import TwoCaptchaSolver
+
+        solver = TwoCaptchaSolver("your-api-key")
+        result = solver.solve_amazon_waf(
+            sitekey="AQIDAHjcYu...",
+            iv="CgAHazE...",
+            context="aaaa...",
+            page_url="https://www.amazon.com/..."
+        )
+        # result["existing_token"] contains the aws-waf-token cookie value
+    """
+
+    def __init__(self, api_key: str):
+        """
+        Initialize the 2captcha solver.
+
+        :param api_key: 2captcha API key
+        """
+        super().__init__(api_key)
+        
+        if not TWOCAPTCHA_AVAILABLE:
+            raise ImportError(
+                "2captcha-python library is required for 2captcha support. "
+                "Install with: pip install amazon-orders[twocaptcha]"
+            )
+        
+        self.solver = OfficialTwoCaptcha(api_key)
+
+    def solve_amazon_waf(
+        self,
+        sitekey: str,
+        iv: str,
+        context: str,
+        page_url: str,
+        challenge_script: Optional[str] = None,
+    ) -> Dict[str, str]:
+        """
+        Solve Amazon WAF CAPTCHA via 2captcha.com using official library.
+
+        :param sitekey: Value of 'key' from window.gokuProps
+        :param iv: Value of 'iv' from window.gokuProps
+        :param context: Value of 'context' from window.gokuProps
+        :param page_url: Full URL of the page with the CAPTCHA
+        :param challenge_script: URL of challenge.js script (optional but recommended)
+        :return: Dict with 'captcha_voucher' and 'existing_token'
+        :raises Exception: If submission fails or solving times out
+        """
+        logger.debug(f"Submitting Amazon WAF CAPTCHA to 2captcha for {page_url}")
+        
+        try:
+            # Convert parameters to the format expected by the official library
+            # Map our parameter names to the official library parameter names
+            kwargs = {}
+            if challenge_script:
+                kwargs['challenge_script'] = challenge_script
+            
+            result = self.solver.amazon_waf(
+                sitekey=sitekey,
+                iv=iv,
+                context=context,
+                url=page_url,
+                **kwargs
+            )
+            
+            logger.debug("CAPTCHA solved successfully by 2captcha")
+            
+            # The official library returns the solution directly, we need to format it
+            # to match the expected return format
+            return {
+                "existing_token": json.loads(result.get("code", "{}")).get("existing_token")
+            }
+            
+        except Exception as e:
+            logger.error(f"2captcha solving failed: {str(e)}")
+            raise AmazonOrdersError(f"2captcha solving failed: {str(e)}")

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -30,6 +30,24 @@ Session Management
     :private-members:
     :show-inheritance:
 
+CAPTCHA Solving (Opt-In)
+------------------------
+
+.. automodule:: amazonorders.captcha
+    :members:
+    :private-members:
+    :show-inheritance:
+
+.. automodule:: amazonorders.captcha.base
+    :members:
+    :private-members:
+    :show-inheritance:
+
+.. automodule:: amazonorders.captcha.twocaptcha
+    :members:
+    :private-members:
+    :show-inheritance:
+
 Configuration
 -------------
 .. automodule:: amazonorders.conf

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -118,8 +118,11 @@ Known Limitations
 - Some Captchas are unsupported
     - While some Captchas can be auto-solved, and static image-based ones are opened so the user can manually input
       the solution, interactive Captchas—like `Amazon's puzzle-based Captchas <https://docs.aws.amazon.com/waf/latest/developerguide/waf-captcha-puzzle-examples.html>`_
-      —require JavaScript to solve, and will block ``amazon-orders`` from being able to login.
-    - See the troubleshooting steps for `reducing Captcha challenge frequency <troubleshooting.html#captcha-blocking-login>`_ for recommended workarounds.
+      —require JavaScript to solve, and ``amazon-orders`` cannot solve them natively.
+    - An **opt-in workaround** is available for advanced users via third-party paid CAPTCHA solving services
+      (you bring your own API key; ``amazon-orders`` is not affiliated with these services).
+      See `Using a Third-Party CAPTCHA Solving Service <troubleshooting.html#using-a-third-party-captcha-solving-service-opt-in>`_ for details.
+    - See also the troubleshooting steps for `reducing Captcha challenge frequency <troubleshooting.html#captcha-blocking-login>`_.
     - See `issue #45 <https://github.com/alexdlaird/amazon-orders/issues/45>`_ for more details.
 - Device not remembered for OTP
     - Amazon will sometimes re-prompt for OTP even when a device has been remembered.

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -70,6 +70,30 @@ Captcha challenges:
     - Captcha challenges are more often presented to unknown devices. If possible, first manually login from a browser on
       the device on which you're using ``amazon-orders``.
 
+Using a Third-Party CAPTCHA Solving Service (Opt-In)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+For users who continue to encounter Amazon WAF CAPTCHA challenges that block login, ``amazon-orders`` offers
+**opt-in** integration with third-party CAPTCHA solving services. This is a workaround for advanced users
+who need fully automated login.
+
+.. important::
+
+    - This feature is **opt-in only** and disabled by default.
+    - Third-party CAPTCHA solving services are **paid services** with their own pricing and terms.
+    - **You must provide your own API key** from the service provider.
+    - ``amazon-orders`` is **not affiliated with** any third-party CAPTCHA solving service.
+    - **No support is offered** for issues related to third-party services; consult their documentation directly.
+    - The ``amazon-orders`` library itself remains free and open source.
+
+Currently supported services:
+
+- `2captcha <https://2captcha.com/>`_ - Requires the optional dependency: ``pip install amazon-orders[twocaptcha]``
+
+To enable, pass ``captcha_solver`` and ``captcha_api_key`` to :class:`~amazonorders.session.AmazonSession`,
+or set the ``AMAZON_CAPTCHA_SOLVER`` and ``AMAZON_CAPTCHA_API_KEY`` environment variables. See
+:class:`~amazonorders.session.AmazonSession` and :mod:`~amazonorders.captcha` for API details.
+
 Slow Parsing / Malformed Data
 -----------------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,9 @@ docs = [
     "types-PyYAML",
     "types-python-dateutil",
 ]
+twocaptcha = [
+    "2captcha-python>=1.0",
+]
 
 [project.scripts]
 amazon-orders = "amazonorders.cli:amazon_orders_cli"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,3 +120,7 @@ exclude = "scripts/*,docs/*,venv/*,build/*,dist/*,.egg-info/*,.mypy_cache/*"
 [[tool.mypy.overrides]]
 module = "amazoncaptcha.*"
 ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "twocaptcha.*"
+ignore_missing_imports = true

--- a/tests/resources/auth/waf-challenge.html
+++ b/tests/resources/auth/waf-challenge.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title></title>
+    <style>
+        body {
+            font-family: "Arial";
+        }
+    </style>
+    <script type="text/javascript">
+    window.awsWafCookieDomainList = [];
+    window.gokuProps = {
+"key":"AQIDAHjcYu/GjX+QlghicBgQ/7bFaQZ+m5FKCMDnO+vTbNg96AF9ZO7knldUHP8/4v89DrtSAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMdMda3UYhahVsCXvUAgEQgDuVdMhHcUEmAgLaAz3dl+bxRFCsbgw6H8Od+h9kjx73yBqg0YpijoxCxbxmsKvqxC3U9oY9araV+F5RKA==",
+          "iv":"EkQxkQFMIwAAAodQ",
+          "context":"OUMUjAHWcbEo6RW2ybooHwCYWfhTbMbqRE9FpEclRPj6ekNJhMK1elhmXOFpqAtAKYt+L6GrBL0GXXYGecwmc4mlncuWd0ZMZf7S805ljfgdMbhtDUns169TAJd3ACMHtx+Iz+jwj3SQxd5mxlI1oaYoOSnpaIOaeaNXGguH9waTyBx2/VIpr9LWkSH0zAPDjTfeg0+wsm2B+SYivdrKvvXE6iV/FvTvIoaq7F94Z8KWDAtZX08L2AKfVMKqQIvwpCkFars5IUzeYcaGc5XxHSLrgLopBgMJmjMr67H/5TPZXjF51IFj8dMRac0cQ+J4zW5TGwySaNWhZtl7q7/98mtSBw1QMN+3ncJ/acPU7cr9MbdZlSnS07UhVUw0A/iP6K32k6+b"
+};
+    </script>
+    <script src="https://1c5c1ecf7303.a481e94e.us-east-2.token.awswaf.com/1c5c1ecf7303/d6a7a58005ec/04c5ab18cd2d/challenge.js"></script>
+</head>
+<body>
+    <div id="challenge-container"></div>
+    <script type="text/javascript">
+        AwsWafIntegration.saveReferrer();
+        AwsWafIntegration.checkForceRefresh().then((forceRefresh) => {
+            if (forceRefresh) {
+                AwsWafIntegration.forceRefreshToken().then(() => {
+                    window.location.reload(true);
+                });
+            } else {
+                AwsWafIntegration.getToken().then(() => {
+                    window.location.reload(true);
+                });
+            }
+        });
+    </script>
+    <noscript>
+        <h1>JavaScript is disabled</h1>
+        In order to continue, we need to verify that you're not a robot.
+        This requires JavaScript. Enable JavaScript and then reload the page.
+    </noscript>
+</body>
+</html>

--- a/tests/unit/test_captcha.py
+++ b/tests/unit/test_captcha.py
@@ -1,0 +1,491 @@
+__copyright__ = "Copyright (c) 2024-2025 Alex Laird"
+__license__ = "MIT"
+
+import os
+import unittest
+from unittest.mock import patch, MagicMock, Mock
+
+import responses
+from bs4 import BeautifulSoup
+
+from amazonorders.captcha import CaptchaSolver, get_solver
+from amazonorders.exception import AmazonOrdersError, AmazonOrdersAuthError
+from amazonorders.forms import AmazonWafForm
+from amazonorders.session import AmazonSession
+from tests.unittestcase import UnitTestCase
+
+
+class TestGetSolver(UnitTestCase):
+    """Tests for the get_solver function."""
+
+    @patch("amazonorders.captcha.twocaptcha.TWOCAPTCHA_AVAILABLE", True)
+    @patch("amazonorders.captcha.twocaptcha.OfficialTwoCaptcha")
+    def test_get_solver_twocaptcha(self, mock_twocaptcha_class):
+        """Test that get_solver returns TwoCaptchaSolver for '2captcha'."""
+        mock_twocaptcha_class.return_value = MagicMock()
+
+        solver = get_solver("2captcha", "test-api-key")
+
+        self.assertEqual(solver.api_key, "test-api-key")
+        mock_twocaptcha_class.assert_called_once_with("test-api-key")
+
+    def test_get_solver_invalid_service(self):
+        """Test that get_solver raises ValueError for unknown service."""
+        with self.assertRaises(ValueError) as cm:
+            get_solver("unknown-service", "test-api-key")
+        self.assertIn("Unsupported CAPTCHA solver", str(cm.exception))
+        self.assertIn("unknown-service", str(cm.exception))
+
+    def test_get_solver_rejects_twocaptcha_alias(self):
+        """Test that 'twocaptcha' (without hyphen) is not accepted - must use '2captcha'."""
+        with self.assertRaises(ValueError) as cm:
+            get_solver("twocaptcha", "test-api-key")
+        self.assertIn("Unsupported CAPTCHA solver", str(cm.exception))
+
+
+class TestTwoCaptchaSolver(UnitTestCase):
+    """Tests for TwoCaptchaSolver."""
+
+    @patch("amazonorders.captcha.twocaptcha.TWOCAPTCHA_AVAILABLE", True)
+    @patch("amazonorders.captcha.twocaptcha.OfficialTwoCaptcha")
+    def test_solve_amazon_waf_success(self, mock_twocaptcha_class):
+        """Test successful WAF CAPTCHA solving."""
+        # Setup mock - 2captcha API returns token nested in JSON-encoded "code" field
+        mock_solver_instance = MagicMock()
+        mock_solver_instance.amazon_waf.return_value = {
+            "code": '{"captcha_voucher": "voucher-value", "existing_token": "waf-token-value"}'
+        }
+        mock_twocaptcha_class.return_value = mock_solver_instance
+
+        from amazonorders.captcha.twocaptcha import TwoCaptchaSolver
+        solver = TwoCaptchaSolver("test-api-key")
+        result = solver.solve_amazon_waf(
+            sitekey="test-sitekey",
+            iv="test-iv",
+            context="test-context",
+            page_url="https://www.amazon.com/test",
+            challenge_script="https://example.com/challenge.js"
+        )
+
+        self.assertEqual(result["existing_token"], "waf-token-value")
+        mock_solver_instance.amazon_waf.assert_called_once_with(
+            sitekey="test-sitekey",
+            iv="test-iv",
+            context="test-context",
+            url="https://www.amazon.com/test",
+            challenge_script="https://example.com/challenge.js"
+        )
+
+    @patch("amazonorders.captcha.twocaptcha.TWOCAPTCHA_AVAILABLE", True)
+    @patch("amazonorders.captcha.twocaptcha.OfficialTwoCaptcha")
+    def test_solve_amazon_waf_failure(self, mock_twocaptcha_class):
+        """Test handling of solving failure."""
+        mock_solver_instance = MagicMock()
+        mock_solver_instance.amazon_waf.side_effect = Exception("ERROR_KEY_DOES_NOT_EXIST")
+        mock_twocaptcha_class.return_value = mock_solver_instance
+
+        from amazonorders.captcha.twocaptcha import TwoCaptchaSolver
+        solver = TwoCaptchaSolver("invalid-key")
+        with self.assertRaises(AmazonOrdersError) as cm:
+            solver.solve_amazon_waf(
+                sitekey="test-sitekey",
+                iv="test-iv",
+                context="test-context",
+                page_url="https://www.amazon.com/test"
+            )
+        self.assertIn("2captcha solving failed", str(cm.exception))
+
+
+class TestAmazonSessionCaptchaIntegration(UnitTestCase):
+    """Tests for AmazonSession captcha solver integration."""
+
+    @patch("amazonorders.captcha.twocaptcha.TWOCAPTCHA_AVAILABLE", True)
+    @patch("amazonorders.captcha.twocaptcha.OfficialTwoCaptcha")
+    def test_session_with_captcha_solver_string(self, mock_twocaptcha_class):
+        """Test that AmazonSession accepts captcha_solver as string."""
+        mock_twocaptcha_class.return_value = MagicMock()
+
+        session = AmazonSession(
+            "test@example.com",
+            "password",
+            config=self.test_config,
+            captcha_solver="2captcha",
+            captcha_api_key="test-api-key"
+        )
+
+        # Verify AmazonWafForm was added to auth_forms
+        from amazonorders.forms import AmazonWafForm
+        waf_forms = [f for f in session.auth_forms if isinstance(f, AmazonWafForm)]
+        self.assertEqual(len(waf_forms), 1)
+
+    def test_session_without_captcha_solver(self):
+        """Test that AmazonSession works without captcha_solver (backwards compatible)."""
+        session = AmazonSession(
+            "test@example.com",
+            "password",
+            config=self.test_config
+        )
+
+        # Verify AmazonWafForm was NOT added
+        from amazonorders.forms import AmazonWafForm
+        waf_forms = [f for f in session.auth_forms if isinstance(f, AmazonWafForm)]
+        self.assertEqual(len(waf_forms), 0)
+
+    def test_session_captcha_solver_string_without_api_key(self):
+        """Test that AmazonSession raises error when captcha_solver string provided without api_key."""
+        with self.assertRaises(AmazonOrdersError) as cm:
+            AmazonSession(
+                "test@example.com",
+                "password",
+                config=self.test_config,
+                captcha_solver="2captcha"
+                # Missing captcha_api_key
+            )
+        self.assertIn("captcha_api_key is required", str(cm.exception))
+
+    def test_session_captcha_solver_invalid_type(self):
+        """Test that AmazonSession raises error for invalid captcha_solver type."""
+        with self.assertRaises(AmazonOrdersError) as cm:
+            AmazonSession(
+                "test@example.com",
+                "password",
+                config=self.test_config,
+                captcha_solver=12345,  # type: ignore  # Invalid type - intentional for test
+                captcha_api_key="test"
+            )
+        self.assertIn("must be a service name", str(cm.exception))
+
+    @patch.dict(os.environ, {"AMAZON_CAPTCHA_SOLVER": "2captcha", "AMAZON_CAPTCHA_API_KEY": "env-api-key"})
+    @patch("amazonorders.captcha.twocaptcha.TWOCAPTCHA_AVAILABLE", True)
+    @patch("amazonorders.captcha.twocaptcha.OfficialTwoCaptcha")
+    def test_session_captcha_from_environment(self, mock_twocaptcha_class):
+        """Test that AmazonSession reads captcha config from environment variables."""
+        mock_twocaptcha_class.return_value = MagicMock()
+
+        session = AmazonSession(
+            "test@example.com",
+            "password",
+            config=self.test_config
+        )
+
+        # Verify AmazonWafForm was added from env vars
+        from amazonorders.forms import AmazonWafForm
+        waf_forms = [f for f in session.auth_forms if isinstance(f, AmazonWafForm)]
+        self.assertEqual(len(waf_forms), 1)
+
+    @patch("amazonorders.captcha.twocaptcha.TWOCAPTCHA_AVAILABLE", True)
+    @patch("amazonorders.captcha.twocaptcha.OfficialTwoCaptcha")
+    def test_waf_form_inserted_before_js_blocker(self, mock_twocaptcha_class):
+        """Test that AmazonWafForm is inserted before JSAuthBlocker."""
+        mock_twocaptcha_class.return_value = MagicMock()
+
+        session = AmazonSession(
+            "test@example.com",
+            "password",
+            config=self.test_config,
+            captcha_solver="2captcha",
+            captcha_api_key="test-api-key"
+        )
+
+        from amazonorders.forms import AmazonWafForm, JSAuthBlocker
+
+        # Find positions
+        waf_index = None
+        blocker_index = None
+        for i, form in enumerate(session.auth_forms):
+            if isinstance(form, AmazonWafForm):
+                waf_index = i
+            if isinstance(form, JSAuthBlocker):
+                blocker_index = i
+
+        self.assertIsNotNone(waf_index, "AmazonWafForm should be in auth_forms")
+        self.assertIsNotNone(blocker_index, "JSAuthBlocker should be in auth_forms")
+        self.assertLess(waf_index, blocker_index, "AmazonWafForm should come before JSAuthBlocker")
+
+
+class TestAmazonWafForm(UnitTestCase):
+    """Tests for AmazonWafForm detection, filling, submission, and clearing."""
+
+    def setUp(self):
+        super().setUp()
+        self.amazon_session = AmazonSession(
+            "test@example.com",
+            "password",
+            config=self.test_config
+        )
+
+    def test_select_form_detects_goku_props(self):
+        """Test that AmazonWafForm correctly detects WAF challenge pages with gokuProps."""
+        # GIVEN
+        with open(os.path.join(self.RESOURCES_DIR, "auth", "waf-challenge.html"), "r", encoding="utf-8") as f:
+            waf_html = f.read()
+
+        parsed = BeautifulSoup(waf_html, "html.parser")
+        mock_solver = MagicMock()
+        waf_form = AmazonWafForm(self.test_config, solver=mock_solver)
+
+        # WHEN
+        result = waf_form.select_form(self.amazon_session, parsed)
+
+        # THEN
+        self.assertTrue(result)
+        self.assertIsNotNone(waf_form._goku_props)
+        self.assertIn("key", waf_form._goku_props)
+        self.assertIn("iv", waf_form._goku_props)
+        self.assertIn("context", waf_form._goku_props)
+        self.assertIsNotNone(waf_form._challenge_script)
+        self.assertIn("challenge.js", waf_form._challenge_script)
+
+    def test_select_form_ignores_non_waf_pages(self):
+        """Test that AmazonWafForm returns False for pages without gokuProps."""
+        # GIVEN
+        with open(os.path.join(self.RESOURCES_DIR, "auth", "signin.html"), "r", encoding="utf-8") as f:
+            regular_html = f.read()
+
+        parsed = BeautifulSoup(regular_html, "html.parser")
+        mock_solver = MagicMock()
+        waf_form = AmazonWafForm(self.test_config, solver=mock_solver)
+
+        # WHEN
+        result = waf_form.select_form(self.amazon_session, parsed)
+
+        # THEN
+        self.assertFalse(result)
+        self.assertIsNone(waf_form._goku_props)
+
+    def test_select_form_rejects_incomplete_goku_props(self):
+        """Test that AmazonWafForm returns False if gokuProps is incomplete (missing required keys)."""
+        # GIVEN - HTML with incomplete gokuProps (missing 'context')
+        incomplete_html = '''
+        <html><script>
+        window.gokuProps = {
+            "key": "somekey",
+            "iv": "someiv"
+        };
+        </script></html>
+        '''
+        parsed = BeautifulSoup(incomplete_html, "html.parser")
+        mock_solver = MagicMock()
+        waf_form = AmazonWafForm(self.test_config, solver=mock_solver)
+
+        # WHEN
+        result = waf_form.select_form(self.amazon_session, parsed)
+
+        # THEN
+        self.assertFalse(result)
+        self.assertIsNone(waf_form._goku_props)
+
+    def test_fill_form_populates_data(self):
+        """Test that AmazonWafForm.fill_form() correctly populates form data."""
+        # GIVEN - successful select_form
+        with open(os.path.join(self.RESOURCES_DIR, "auth", "waf-challenge.html"), "r", encoding="utf-8") as f:
+            waf_html = f.read()
+
+        parsed = BeautifulSoup(waf_html, "html.parser")
+        mock_solver = MagicMock()
+        waf_form = AmazonWafForm(self.test_config, solver=mock_solver)
+        waf_form.select_form(self.amazon_session, parsed)
+
+        # WHEN
+        waf_form.fill_form()
+
+        # THEN
+        self.assertIsNotNone(waf_form.data)
+        self.assertIn("goku_props", waf_form.data)
+        self.assertIn("challenge_script", waf_form.data)
+        self.assertEqual(waf_form.data["goku_props"], waf_form._goku_props)
+        self.assertEqual(waf_form.data["challenge_script"], waf_form._challenge_script)
+
+    def test_fill_form_raises_without_select_form(self):
+        """Test that fill_form() raises error if select_form() wasn't called first."""
+        # GIVEN
+        mock_solver = MagicMock()
+        waf_form = AmazonWafForm(self.test_config, solver=mock_solver)
+
+        # WHEN/THEN
+        with self.assertRaises(AmazonOrdersError) as cm:
+            waf_form.fill_form()
+        self.assertIn("select_form", str(cm.exception))
+
+    @responses.activate
+    def test_submit_calls_solver_and_sets_cookie(self):
+        """Test that AmazonWafForm.submit() calls solver and sets aws-waf-token cookie."""
+        # GIVEN
+        with open(os.path.join(self.RESOURCES_DIR, "auth", "waf-challenge.html"), "r", encoding="utf-8") as f:
+            waf_html = f.read()
+
+        parsed = BeautifulSoup(waf_html, "html.parser")
+        mock_solver = MagicMock()
+        mock_solver.solve_amazon_waf.return_value = {"existing_token": "test-waf-token-12345"}
+
+        waf_form = AmazonWafForm(self.test_config, solver=mock_solver)
+        waf_form.select_form(self.amazon_session, parsed)
+        waf_form.fill_form()
+
+        # Mock response for the retry request
+        mock_last_response = Mock()
+        mock_last_response.url = "https://www.amazon.com/some-page"
+
+        with open(os.path.join(self.RESOURCES_DIR, "index.html"), "r", encoding="utf-8") as f:
+            responses.add(
+                responses.GET,
+                "https://www.amazon.com/some-page",
+                body=f.read(),
+                status=200,
+            )
+
+        # WHEN
+        waf_form.submit(mock_last_response)
+
+        # THEN - verify solver was called with correct params
+        mock_solver.solve_amazon_waf.assert_called_once()
+        call_kwargs = mock_solver.solve_amazon_waf.call_args[1]
+        self.assertEqual(call_kwargs["sitekey"], waf_form._goku_props["key"])
+        self.assertEqual(call_kwargs["iv"], waf_form._goku_props["iv"])
+        self.assertEqual(call_kwargs["context"], waf_form._goku_props["context"])
+        self.assertEqual(call_kwargs["page_url"], "https://www.amazon.com/some-page")
+
+        # Verify cookie was set on the session
+        cookie_names = [c.name for c in self.amazon_session.session.cookies]
+        self.assertIn("aws-waf-token", cookie_names)
+
+    def test_submit_raises_on_missing_token(self):
+        """Test that AmazonWafForm.submit() raises error if solver returns no existing_token."""
+        # GIVEN
+        with open(os.path.join(self.RESOURCES_DIR, "auth", "waf-challenge.html"), "r", encoding="utf-8") as f:
+            waf_html = f.read()
+
+        parsed = BeautifulSoup(waf_html, "html.parser")
+        mock_solver = MagicMock()
+        mock_solver.solve_amazon_waf.return_value = {}  # No existing_token!
+
+        waf_form = AmazonWafForm(self.test_config, solver=mock_solver)
+        waf_form.select_form(self.amazon_session, parsed)
+        waf_form.fill_form()
+
+        mock_last_response = Mock()
+        mock_last_response.url = "https://www.amazon.com/test"
+
+        # WHEN/THEN
+        with self.assertRaises(AmazonOrdersAuthError) as cm:
+            waf_form.submit(mock_last_response)
+        self.assertIn("existing_token", str(cm.exception))
+
+    def test_submit_raises_without_fill_form(self):
+        """Test that submit() raises error if fill_form() wasn't called first."""
+        # GIVEN
+        mock_solver = MagicMock()
+        waf_form = AmazonWafForm(self.test_config, solver=mock_solver)
+
+        mock_last_response = Mock()
+        mock_last_response.url = "https://www.amazon.com/test"
+
+        # WHEN/THEN
+        with self.assertRaises(AmazonOrdersError) as cm:
+            waf_form.submit(mock_last_response)
+        self.assertIn("fill_form", str(cm.exception))
+
+    def test_clear_form_resets_state(self):
+        """Test that clear_form() properly resets all WAF form state."""
+        # GIVEN
+        with open(os.path.join(self.RESOURCES_DIR, "auth", "waf-challenge.html"), "r", encoding="utf-8") as f:
+            waf_html = f.read()
+
+        parsed = BeautifulSoup(waf_html, "html.parser")
+        mock_solver = MagicMock()
+        waf_form = AmazonWafForm(self.test_config, solver=mock_solver)
+        waf_form.select_form(self.amazon_session, parsed)
+        waf_form.fill_form()
+
+        # Verify state exists before clear
+        self.assertIsNotNone(waf_form._html)
+        self.assertIsNotNone(waf_form._goku_props)
+        self.assertIsNotNone(waf_form._challenge_script)
+        self.assertIsNotNone(waf_form.data)
+        self.assertIsNotNone(waf_form.amazon_session)
+
+        # WHEN
+        waf_form.clear_form()
+
+        # THEN
+        self.assertIsNone(waf_form._html)
+        self.assertIsNone(waf_form._goku_props)
+        self.assertIsNone(waf_form._challenge_script)
+        self.assertIsNone(waf_form.amazon_session)
+        self.assertIsNone(waf_form.data)
+
+
+class TestAmazonSessionWafLoginFlow(UnitTestCase):
+    """Tests for AmazonSession login flow with WAF challenge (mocked)."""
+
+    @responses.activate
+    @patch("amazonorders.captcha.twocaptcha.TWOCAPTCHA_AVAILABLE", True)
+    @patch("amazonorders.captcha.twocaptcha.OfficialTwoCaptcha")
+    def test_login_with_waf_challenge_solved(self, mock_twocaptcha_class):
+        """Test full login flow when WAF challenge is encountered and solved via 2captcha."""
+        # GIVEN - mock the 2captcha solver
+        mock_solver_instance = MagicMock()
+        mock_solver_instance.amazon_waf.return_value = {
+            "code": '{"captcha_voucher": "voucher", "existing_token": "solved-waf-token"}'
+        }
+        mock_twocaptcha_class.return_value = mock_solver_instance
+
+        # Create session with captcha solver
+        session = AmazonSession(
+            "test@example.com",
+            "password",
+            config=self.test_config,
+            captcha_solver="2captcha",
+            captcha_api_key="test-api-key"
+        )
+
+        # Step 1: Initial home page (unauthenticated)
+        with open(os.path.join(self.RESOURCES_DIR, "auth", "unauth-index.html"), "r", encoding="utf-8") as f:
+            responses.add(
+                responses.GET,
+                self.test_config.constants.BASE_URL,
+                body=f.read(),
+                status=200,
+            )
+
+        # Step 2: Sign-in page returns WAF challenge
+        with open(os.path.join(self.RESOURCES_DIR, "auth", "waf-challenge.html"), "r", encoding="utf-8") as f:
+            responses.add(
+                responses.GET,
+                self.test_config.constants.SIGN_IN_URL,
+                body=f.read(),
+                status=200,
+            )
+
+        # Step 3: After WAF solved, retry returns normal sign-in page
+        with open(os.path.join(self.RESOURCES_DIR, "auth", "signin.html"), "r", encoding="utf-8") as f:
+            responses.add(
+                responses.GET,
+                self.test_config.constants.SIGN_IN_URL,
+                body=f.read(),
+                status=200,
+            )
+
+        # Step 4: Sign-in POST succeeds with authenticated page
+        with open(os.path.join(self.RESOURCES_DIR, "orders", "order-history-2018-0.html"), "r", encoding="utf-8") as f:
+            responses.add(
+                responses.POST,
+                self.test_config.constants.SIGN_IN_URL,
+                body=f.read(),
+                status=200,
+            )
+
+        # WHEN
+        session.login()
+
+        # THEN
+        self.assertTrue(session.is_authenticated)
+        # Verify the solver was called
+        mock_solver_instance.amazon_waf.assert_called_once()
+        # Verify aws-waf-token cookie was set
+        cookie_names = [c.name for c in session.session.cookies]
+        self.assertIn("aws-waf-token", cookie_names)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_captcha.py
+++ b/tests/unit/test_captcha.py
@@ -8,7 +8,7 @@ from unittest.mock import patch, MagicMock, Mock
 import responses
 from bs4 import BeautifulSoup
 
-from amazonorders.captcha import CaptchaSolver, get_solver
+from amazonorders.captcha import get_solver
 from amazonorders.exception import AmazonOrdersError, AmazonOrdersAuthError
 from amazonorders.forms import AmazonWafForm
 from amazonorders.session import AmazonSession


### PR DESCRIPTION
### Description

PR adds opt-in support for using 2captcha.com to solve Amazon WAF interactive/javascript challenges. Users only need to configure two new optional settings, the name of the service (2captcha) and their api key.

The solution is meant to be expandable to more services, such as Anti-Captcha. I tried implementing Anti-Captcha support as well but ran into issues despite the API being nearly identical. I abandoned that to propose this solution and get feedback.

Fixes #45

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a schema change
- [x] This change requires a documentation update

### Testing Done

I have tested with my own account credentials and have been able to successfully retrieve orders/transactions after bypassing an Amazon WAF captcha challenge. Previously I could never get past this, even with the suggestions in this library's troubleshooting steps. 

- tests/unit/test_captcha.py added with unit tests for new functionality
- Tested that if user configures optional service but doesn't have 2captcha-python installed, they receive an error message indicating they need to install the 2captcha python library
- If user doesn't configure optional service, 2captcha-python library is not required (optional dependency lazy loaded)

### Checklist

- [x] I have added tests that prove my change works as expected, and `make test` passes with no new errors or warnings
- [x] I have run `make check` to ensure no new errors or warnings
- [x] I have updated the docs, if applicable, and run `make docs` to ensure no new errors or warnings
- [x] I have performed a self-review of my own code
- [x] I have commented my code in particularly hard-to-understand areas
