### PR TITLE
Support configurable domain for non-.com Amazon sites

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,10 @@ This package works by parsing data from Amazon's consumer-facing website. A peri
 to ensure its stability, but as Amazon provides no official API to use, this package may break at any time (so check
 often to ensure you're on the latest version).
 
-Only the English, `.com` version of Amazon is officially supported.
+Only the English, `.com` version of Amazon is officially supported. Other Amazon domains can be
+targeted by passing `domain` to [`AmazonSession`](https://amazon-orders.readthedocs.io/api.html#amazonorders.session.AmazonSession)
+(or `--domain` on the CLI), and other English-based sites may work by chance — see
+[Known Limitations](https://amazon-orders.readthedocs.io/index.html#known-limitations) for details.
 
 ## Installation
 

--- a/amazonorders/cli.py
+++ b/amazonorders/cli.py
@@ -59,6 +59,9 @@ class IOClick(IODefault):
               help="The max auth loop attempts to make (successes and failures), passing this overrides config value.")
 @click.option("--output-dir",
               help="The directory where any output files should be produced, passing this overrides config value.")
+@click.option("--domain",
+              help="The Amazon domain to target (e.g. amazon.com, amazon.co.uk, amazon.com.au). "
+                   "Defaults to amazon.com.")
 @click.pass_context
 def amazon_orders_cli(ctx: Context,
                       **kwargs: Any) -> None:
@@ -90,6 +93,8 @@ def amazon_orders_cli(ctx: Context,
         data["output_dir"] = kwargs["output_dir"]
     if kwargs.get("max_auth_attempts"):
         data["max_auth_attempts"] = kwargs["max_auth_attempts"]
+    if kwargs.get("domain"):
+        data["domain"] = kwargs["domain"]
     ctx.obj["conf"] = AmazonOrdersConfig(config_path=kwargs.get("config_path"),
                                          data=data)
 

--- a/amazonorders/conf.py
+++ b/amazonorders/conf.py
@@ -1,3 +1,4 @@
+import inspect
 import logging
 import os
 import threading
@@ -87,17 +88,37 @@ class AmazonOrdersConfig:
             if not os.path.exists(cookie_jar_dir):
                 os.makedirs(cookie_jar_dir)
 
-        constants_class_split = self.constants_class.split(".")
         selectors_class_split = self.selectors_class.split(".")
         order_class_split = self.order_class.split(".")
         shipment_class_split = self.shipment_class.split(".")
         item_class_split = self.item_class.split(".")
 
-        self.constants = util.load_class(constants_class_split[:-1], constants_class_split[-1])()
+        self.constants = self._instantiate_constants()
         self.selectors = util.load_class(selectors_class_split[:-1], selectors_class_split[-1])()
         self.order_cls = util.load_class(order_class_split[:-1], order_class_split[-1])
         self.shipment_cls = util.load_class(shipment_class_split[:-1], shipment_class_split[-1])
         self.item_cls = util.load_class(item_class_split[:-1], item_class_split[-1])
+
+    def _instantiate_constants(self) -> Any:
+        constants_class_split = self.constants_class.split(".")
+        constants_cls = util.load_class(constants_class_split[:-1], constants_class_split[-1])
+        # Pass ``self`` only when the constants class accepts a config arg, to keep backward
+        # compatibility with existing zero-arg ``constants_class`` subclasses.
+        init_params = inspect.signature(constants_cls.__init__).parameters
+        if len(init_params) > 1:
+            return constants_cls(self)
+        return constants_cls()
+
+    def set_domain(self,
+                   domain: str) -> None:
+        """
+        Set the active Amazon domain and rebuild :attr:`~constants` so URL-derived attributes and
+        region-sensitive headers reflect the change.
+
+        :param domain: The Amazon domain (e.g. ``amazon.com.au``) or full URL.
+        """
+        self._data["domain"] = domain
+        self.constants = self._instantiate_constants()
 
     def __getattr__(self,
                     key: str) -> Any:
@@ -113,13 +134,12 @@ class AmazonOrdersConfig:
     def __setstate__(self,
                      state: Dict[str, Any]) -> None:
         self._data = state
-        constants_class_split = self.constants_class.split(".")
         selectors_class_split = self.selectors_class.split(".")
         order_class_split = self.order_class.split(".")
         shipment_class_split = self.shipment_class.split(".")
         item_class_split = self.item_class.split(".")
 
-        self.constants = util.load_class(constants_class_split[:-1], constants_class_split[-1])()
+        self.constants = self._instantiate_constants()
         self.selectors = util.load_class(selectors_class_split[:-1], selectors_class_split[-1])()
         self.order_cls = util.load_class(order_class_split[:-1], order_class_split[-1])
         self.shipment_cls = util.load_class(shipment_class_split[:-1], shipment_class_split[-1])

--- a/amazonorders/constants.py
+++ b/amazonorders/constants.py
@@ -2,7 +2,32 @@ __copyright__ = "Copyright (c) 2024-2025 Alex Laird"
 __license__ = "MIT"
 
 import os
-from urllib.parse import urlencode
+from typing import Optional, TYPE_CHECKING
+from urllib.parse import urlencode, urlparse
+
+if TYPE_CHECKING:
+    from amazonorders.conf import AmazonOrdersConfig
+
+#: ``Accept-Language`` values for English-locale Amazon sites, keyed by the TLD suffix that
+#: follows ``amazon.``. Looked up dynamically from the user-supplied domain; unknown TLDs keep
+#: the base ``en-US`` value. This map only governs the ``Accept-Language`` header — it is not
+#: a list of supported sites and does not affect any other authentication behavior.
+_REGION_LANGUAGES = {
+    "ca": "en-CA,en;q=0.9,en-US;q=0.8",
+    "co.uk": "en-GB,en;q=0.9,en-US;q=0.8",
+    "com.au": "en-AU,en;q=0.9,en-US;q=0.8",
+    "in": "en-IN,en;q=0.9,en-US;q=0.8",
+    "sg": "en-SG,en;q=0.9,en-US;q=0.8",
+}
+
+
+def _normalize_base_url(value: str) -> str:
+    value = value.strip().rstrip("/")
+    if value.startswith(("http://", "https://")):
+        return value
+    if value.startswith("www."):
+        return f"https://{value}"
+    return f"https://www.{value}"
 
 
 class Constants:
@@ -14,15 +39,25 @@ class Constants:
         from amazonorders.conf import AmazonOrdersConfig
 
         config = AmazonOrdersConfig(data={"constants_class": "my_module.MyConstants"})
+
+    URLs and the URL-shaped headers (``Origin``, ``Host``, ``Referer``) are derived from the active
+    Amazon domain. ``Accept-Language`` is adjusted for a small set of English-locale TLDs. The domain
+    is resolved in this precedence order:
+
+    1. The ``domain`` key on :class:`~amazonorders.conf.AmazonOrdersConfig`.
+    2. The ``AMAZON_BASE_URL`` environment variable.
+    3. The default, ``amazon.com``.
+
+    Only the English, ``.com`` site is officially supported. Other domains may work, but values like
+    ``openid.assoc_handle`` are not adjusted automatically — subclass and set ``constants_class`` to
+    override them if a non-``.com`` site requires it.
     """
 
     ##########################################################################
-    # General URL
+    # General URL (defaults; overridden in ``__init__`` when a domain is set)
     ##########################################################################
 
-    BASE_URL = os.environ.get("AMAZON_BASE_URL")
-    if not BASE_URL:
-        BASE_URL = "https://www.amazon.com"
+    BASE_URL = "https://www.amazon.com"
 
     ##########################################################################
     # URLs for AmazonSession
@@ -69,7 +104,7 @@ class Constants:
         "Dpr": "2",
         "Ect": "4g",
         "Origin": BASE_URL,
-        "Host": BASE_URL.strip("https://"),
+        "Host": urlparse(BASE_URL).netloc,
         "Priority": "u=0, i",
         "Referer": f"{SIGN_IN_URL}?{urlencode(SIGN_IN_QUERY_PARAMS)}",
         "Rtt": "0",
@@ -102,6 +137,54 @@ class Constants:
     ##########################################################################
 
     CURRENCY_SYMBOL = os.environ.get("AMAZON_CURRENCY_SYMBOL", "$")
+
+    def __init__(self,
+                 config: Optional["AmazonOrdersConfig"] = None) -> None:
+        domain = None
+        if config is not None:
+            domain = config._data.get("domain")
+        if not domain:
+            domain = os.environ.get("AMAZON_BASE_URL")
+        if domain:
+            self._apply_domain(domain)
+
+    def _apply_domain(self,
+                      domain: str) -> None:
+        """
+        Override the URL-derived attributes for the given Amazon domain.
+
+        :param domain: The Amazon domain (e.g. ``amazon.com.au``) or full URL (e.g. ``https://www.amazon.com.au``).
+        """
+        base_url = _normalize_base_url(domain)
+
+        # Read non-URL fields from the class so subclass-level overrides (assoc_handle,
+        # Accept-Language, etc.) are preserved; only rewrite the URL-shaped values.
+        sign_in_query_params = dict(type(self).SIGN_IN_QUERY_PARAMS)
+        sign_in_query_params["openid.return_to"] = f"{base_url}/?ref_=nav_custrec_signin"
+
+        sign_in_url = f"{base_url}/ap/signin"
+
+        self.BASE_URL = base_url
+        self.SIGN_IN_URL = sign_in_url
+        self.SIGN_IN_QUERY_PARAMS = sign_in_query_params
+        self.SIGN_IN_CLAIM_URL = f"{base_url}/ax/claim"
+        self.SIGN_OUT_URL = f"{base_url}/gp/flex/sign-out.html"
+        self.ORDER_HISTORY_URL = f"{base_url}/your-orders/orders"
+        self.ORDER_DETAILS_URL = f"{base_url}/gp/your-account/order-details"
+        self.TRANSACTION_HISTORY_URL = f"{base_url}{self.TRANSACTION_HISTORY_ROUTE}"
+
+        host = urlparse(base_url).netloc.lower().split(":")[0]
+        if host.startswith("www."):
+            host = host[len("www."):]
+        tld = host[len("amazon."):] if host.startswith("amazon.") else ""
+
+        headers = dict(type(self).BASE_HEADERS)
+        headers["Origin"] = base_url
+        headers["Host"] = urlparse(base_url).netloc
+        headers["Referer"] = f"{sign_in_url}?{urlencode(sign_in_query_params)}"
+        if tld in _REGION_LANGUAGES:
+            headers["Accept-Language"] = _REGION_LANGUAGES[tld]
+        self.BASE_HEADERS = headers
 
     def format_currency(self,
                         amount: float) -> str:

--- a/amazonorders/constants.py
+++ b/amazonorders/constants.py
@@ -20,6 +20,16 @@ _REGION_LANGUAGES = {
     "sg": "en-SG,en;q=0.9,en-US;q=0.8",
 }
 
+#: ``CURRENCY_SYMBOL`` values for English-locale Amazon sites where the storefront actually
+#: prefixes prices with a non-``$`` symbol. amazon.com.au and amazon.ca render prices as
+#: plain ``$`` (single-currency context), so they keep the default and are intentionally
+#: omitted here. Skipped when ``AMAZON_CURRENCY_SYMBOL`` is set.
+_REGION_CURRENCIES = {
+    "co.uk": "£",
+    "in": "₹",
+    "sg": "S$",
+}
+
 
 def _normalize_base_url(value: str) -> str:
     value = value.strip().rstrip("/")
@@ -41,8 +51,9 @@ class Constants:
         config = AmazonOrdersConfig(data={"constants_class": "my_module.MyConstants"})
 
     URLs and the URL-shaped headers (``Origin``, ``Host``, ``Referer``) are derived from the active
-    Amazon domain. ``Accept-Language`` is adjusted for a small set of English-locale TLDs. The domain
-    is resolved in this precedence order:
+    Amazon domain. ``Accept-Language`` and ``CURRENCY_SYMBOL`` are adjusted for a small set of
+    English-locale TLDs (``CURRENCY_SYMBOL`` only when ``AMAZON_CURRENCY_SYMBOL`` is unset). The
+    domain is resolved in this precedence order:
 
     1. The ``domain`` key on :class:`~amazonorders.conf.AmazonOrdersConfig`.
     2. The ``AMAZON_BASE_URL`` environment variable.
@@ -185,6 +196,9 @@ class Constants:
         if tld in _REGION_LANGUAGES:
             headers["Accept-Language"] = _REGION_LANGUAGES[tld]
         self.BASE_HEADERS = headers
+
+        if not os.environ.get("AMAZON_CURRENCY_SYMBOL") and tld in _REGION_CURRENCIES:
+            self.CURRENCY_SYMBOL = _REGION_CURRENCIES[tld]
 
     def format_currency(self,
                         amount: float) -> str:

--- a/amazonorders/entity/parsable.py
+++ b/amazonorders/entity/parsable.py
@@ -187,6 +187,10 @@ class Parsable:
         """
         Clean up a currency, stripping non-numeric values and returning it as a primitive.
 
+        Recognizes the ``$``, ``£``, ``€``, and ``₹`` symbols (and leading currency-code
+        letters such as ``A$`` or ``CDN$``), accepts accounting-style negatives in parentheses
+        (e.g. ``($1.99)``), and treats a literal ``FREE`` as ``0.0``.
+
         :param value: The currency to parse.
         :return: The currency as a primitive.
         """
@@ -197,7 +201,14 @@ class Parsable:
             return None
 
         value = value.strip()
-        value = re.sub("[a-zA-Z$£€,]+", "", value)
+
+        if value.lower() == "free":
+            return 0.0
+
+        if value.startswith("(") and value.endswith(")"):
+            value = "-" + value[1:-1]
+
+        value = re.sub("[a-zA-Z$£€₹,]+", "", value)
         currency = util.to_type(value)
 
         if isinstance(currency, str):

--- a/amazonorders/session.py
+++ b/amazonorders/session.py
@@ -74,9 +74,12 @@ class AmazonSession:
                  io: IODefault = IODefault(),
                  config: Optional[AmazonOrdersConfig] = None,
                  auth_forms: Optional[List] = None,
-                 otp_secret_key: Optional[str] = None) -> None:
+                 otp_secret_key: Optional[str] = None,
+                 domain: Optional[str] = None) -> None:
         if not config:
-            config = AmazonOrdersConfig()
+            config = AmazonOrdersConfig(data={"domain": domain} if domain else None)
+        elif domain:
+            config.set_domain(domain)
         if not auth_forms:
             auth_forms = [ClaimForm(config),
                           IntentForm(config),

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -108,12 +108,18 @@ Known Limitations
 -----------------
 
 - Non-English, non-``.com`` versions of Amazon are unsupported
-    - Some have reported success with some non-``.com`` sites (ex. ``amazon.ca`` in Canada), so other similar
-      English-based versions of Amazon may work by chance. However, we do not run nightly regressions against
-      other versions of the site, and as such do not say they are officially supported.
-    - If you fork the repo, set ``AMAZON_BASE_URL`` with an English, non-``.com`` version of the site, and use
-      your own credentials with the ``integration.yml`` workflow to setup a nightly regression run, please
-      `contact us <mailto:contact@alexlaird.com>`_ and we will start mentioning support for that version of the site.
+    - Pass ``domain`` to :class:`~amazonorders.session.AmazonSession` (or set ``domain`` in
+      :class:`~amazonorders.conf.AmazonOrdersConfig`, or pass ``--domain`` on the CLI) to point at another
+      Amazon site. URLs and the URL-shaped headers (``Origin``, ``Host``, ``Referer``) are rewritten from
+      the domain, and ``Accept-Language`` is adjusted for a small set of English-locale TLDs, so other
+      English-based versions of Amazon (ex. ``amazon.ca``) may work by chance. Other values such as the
+      OpenID ``assoc_handle`` are not adjusted — subclass :class:`~amazonorders.constants.Constants` and
+      set ``constants_class`` to override them if a particular site requires it. The ``AMAZON_BASE_URL``
+      environment variable continues to work as a fallback.
+    - We do not run nightly regressions against non-``.com`` versions of the site, and as such do not say
+      they are officially supported. If you fork the repo, point the ``integration.yml`` workflow at a
+      different domain with your own credentials, please `contact us <mailto:contact@alexlaird.com>`_ and
+      we will start mentioning support for that version of the site.
     - See `issue #15 <https://github.com/alexdlaird/amazon-orders/issues/15>`_ for more details.
 - Some Captchas are unsupported
     - While some Captchas can be auto-solved, and static image-based ones are opened so the user can manually input


### PR DESCRIPTION
Adds a `domain` config key (with `--domain` CLI flag and `domain` kwarg on `AmazonSession`) so non-`.com` Amazon sites can be targeted without mutating env vars. URLs and the URL-shaped headers derive from the domain. `Accept-Language` is adjusted for English-locale TLDs; `CURRENCY_SYMBOL` is adjusted for `co.uk`, `in`, and `sg` — the three storefronts whose live HTML actually prefixes prices with a non-`$` symbol (verified against real pages). `amazon.com.au` and `amazon.ca` render plain `$`, so they keep the default. `AMAZON_BASE_URL` and `AMAZON_CURRENCY_SYMBOL` env vars still work.

Also fixes `to_currency` to strip `₹`, handle accounting-style parens negatives (`($1.99)` → `-1.99`), and treat `FREE` as `0.0`; and fixes a long-standing `Host` header bug from `BASE_URL.strip("https://")` (charset strip vs prefix strip).

Only the English `.com` site is officially supported. Users targeting other sites can still subclass `Constants` for further overrides (e.g. `openid.assoc_handle`) via the existing `constants_class` extension point.

Refs #15.

## Test plan

- [x] All existing tests pass
- [x] Verified currency rendering on amazon.com.au, .co.uk, .ca, .in, .sg against live HTML
- [ ] Unit tests for new `to_currency` edge cases and per-domain overrides (follow-up)