### PR TITLE
Parse current Amazon item price and image-card title markup

### DIFF
--- a/amazonorders/entity/item.py
+++ b/amazonorders/entity/item.py
@@ -30,8 +30,12 @@ class Item(Parsable):
         super().__init__(parsed, config)
 
         #: The Item title.
-        self.title: str = self.safe_simple_parse(selector=self.config.selectors.FIELD_ITEM_TITLE_SELECTOR,
-                                                 required=True)
+        self.title: str = (
+            self.safe_simple_parse(selector=self.config.selectors.FIELD_ITEM_TITLE_SELECTOR)
+            or self.safe_simple_parse(selector=self.config.selectors.FIELD_ITEM_TITLE_IMG_SELECTOR,
+                                      attr_name="alt",
+                                      required=True)
+        )
         #: The Item link.
         self.link: str = self.safe_simple_parse(selector=self.config.selectors.FIELD_ITEM_LINK_SELECTOR,
                                                 attr_name="href", required=True)

--- a/amazonorders/selectors.py
+++ b/amazonorders/selectors.py
@@ -114,12 +114,15 @@ class Selectors:
                                     "span.product-image__qty"]
     FIELD_ITEM_TITLE_SELECTOR = ["[data-component='itemTitle']",
                                  ".yohtmlc-item a", ".yohtmlc-product-title"]
+    FIELD_ITEM_TITLE_IMG_SELECTOR = ".product-grid-image img"
     FIELD_ITEM_LINK_SELECTOR = ["[data-component='itemTitle'] a",
                                 ".yohtmlc-item a",
                                 "a:has(> .yohtmlc-product-title)",
-                                ".yohtmlc-product-title a"]
+                                ".yohtmlc-product-title a",
+                                ".product-grid-image a"]
     FIELD_ITEM_TAG_ITERATOR_SELECTOR = [".yohtmlc-item div"]
-    FIELD_ITEM_PRICE_SELECTOR = ["[data-component='unitPrice'] .a-text-price :not(.a-offscreen)",
+    FIELD_ITEM_PRICE_SELECTOR = ["[data-component='unitPrice'] .a-text-price .a-offscreen",
+                                 "[data-component='unitPrice'] .a-text-price :not(.a-offscreen)",
                                  ".yohtmlc-item .a-color-price"]
     FIELD_ITEM_SELLER_SELECTOR = ["[data-component='orderedMerchant']"] + FIELD_ITEM_TAG_ITERATOR_SELECTOR
     FIELD_ITEM_RETURN_SELECTOR = ["[data-component='itemReturnEligibility']"] + FIELD_ITEM_TAG_ITERATOR_SELECTOR

--- a/tests/unit/entity/test_item.py
+++ b/tests/unit/entity/test_item.py
@@ -40,6 +40,55 @@ class TestItem(UnitTestCase):
         self.assertEqual(item.title, "Item Title")
         self.assertEqual(item.price, 1234.99)
 
+    def test_price_from_order_details_unit_price_offscreen(self):
+        # GIVEN
+        html = """
+<div class="a-fixed-left-grid a-spacing-none">
+    <div data-component="itemTitle">
+        <a href="/dp/B0CFPJYX7P?ref_=ppx_hzod_title_dt_b_fed_asin_title_0_0">
+            All-new Amazon Kindle Paperwhite
+        </a>
+    </div>
+    <div data-component="unitPrice">
+        <span class="a-price a-text-price" data-a-size="s" data-a-color="base">
+            <span class="a-offscreen">$99.99</span>
+            <span aria-hidden="true">$99.99</span>
+        </span>
+    </div>
+</div>
+"""
+        parsed = BeautifulSoup(html, self.test_config.bs4_parser)
+
+        # WHEN
+        item = Item(parsed, self.test_config)
+
+        # THEN
+        self.assertEqual(item.title, "All-new Amazon Kindle Paperwhite")
+        self.assertEqual(item.price, 99.99)
+
+    def test_title_and_link_from_history_image_card(self):
+        # GIVEN
+        html = """
+<div class="a-fixed-right-grid-col item-box" style="float:left;">
+    <div class="product-grid-image">
+        <a class="a-link-normal" href="/dp/B0CFPJYX7P?ref=ppx_yo2ov_dt_b_fed_asin_title" tabindex="-1">
+            <img alt="All-new Amazon Kindle Paperwhite"
+                 src="https://m.media-amazon.com/images/I/example._SS142_.jpg" />
+        </a>
+    </div>
+</div>
+"""
+        parsed = BeautifulSoup(html, self.test_config.bs4_parser)
+
+        # WHEN
+        item = Item(parsed, self.test_config)
+
+        # THEN
+        self.assertEqual(item.title, "All-new Amazon Kindle Paperwhite")
+        self.assertEqual(
+            item.link,
+            "https://www.amazon.com/dp/B0CFPJYX7P?ref=ppx_yo2ov_dt_b_fed_asin_title")
+
     def test_title_starts_with_ampersand_use_lxml(self):
         # GIVEN
         lxml_config = AmazonOrdersConfig(data={


### PR DESCRIPTION
## Summary
- parse current order-details item prices from the `.a-offscreen` unit price span
- parse image-only history item cards using the product image `alt` text and image link
- cover both current markup shapes with mocked unit tests

## Why
Amazon can render item prices in the clean `.a-offscreen` span under `data-component="unitPrice"`, while some history cards render only an image card with the product title in the image `alt` attribute. These shapes can otherwise leave `Item.price` empty or make history parsing fail on a required item title.

## Tests
- `uv run --python 3.12 python -m pytest tests/unit/entity/test_item.py`
- `uv run --python 3.12 python -m pytest tests/unit/entity/test_item.py tests/unit/entity/test_order.py tests/unit/test_orders.py`
- Live sanity with existing Amazon cookies: last-30-days history parsed 65 orders / 68 items, all with titles; direct detail page parsed 2 item prices.