### PR TITLE
feat: add Transaction.payment_method_last_4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   - `PlaywrightJSAuthForm` is a best-effort handler for the JS robot-detection page.
   - `PlaywrightManualWafForm` opens a **visible** browser window for manual WAF CAPTCHA solving — a free alternative to the paid `[waf]` extras for local/interactive use.
 - `browser` config key and `AMAZON_BROWSER` environment variable to select between `chromium` (default) and `firefox` browser fingerprints.
+- `Transaction.payment_method_last_4`, the masked card digits parsed from `payment_method` (for example, `"Visa ****1234"` becomes `"1234"`), mirroring the existing field on `Order`.
 
 ### Changed
 

--- a/amazonorders/entity/transaction.py
+++ b/amazonorders/entity/transaction.py
@@ -32,6 +32,11 @@ class Transaction(Parsable):
         self.payment_method: str = self.safe_simple_parse(
             selector=self.config.selectors.FIELD_TRANSACTION_PAYMENT_METHOD_SELECTOR
         )
+        #: The Transaction payment method's last digits, parsed from :attr:`payment_method` (for example,
+        #: ``"Visa ****1234"`` becomes ``"1234"``). ``None`` when :attr:`payment_method` has no masked digits.
+        #: Kept as a ``str`` to preserve leading zeros and shorter masks (for example, ``"... ***863"``
+        #: becomes ``"863"``).
+        self.payment_method_last_4: Optional[str] = self.safe_parse(self._parse_payment_method_last_4)
         #: The Transaction grand total.
         self.grand_total: float = self.safe_parse(self._parse_grand_total)
         #: The Transaction was a refund or not.
@@ -91,3 +96,11 @@ class Transaction(Parsable):
             value = f"{self.config.constants.ORDER_DETAILS_URL}?orderID={self.order_number}"
 
         return value
+
+    def _parse_payment_method_last_4(self) -> Optional[str]:
+        if not self.payment_method:
+            return None
+
+        match = re.search(r"\*+(\d+)$", self.payment_method)
+
+        return match.group(1) if match else None

--- a/tests/unit/entity/test_transaction.py
+++ b/tests/unit/entity/test_transaction.py
@@ -23,6 +23,7 @@ class TestTransaction(UnitTestCase):
         # THEN
         self.assertEqual(transaction.completed_date, date(2024, 1, 1))
         self.assertEqual(transaction.payment_method, "My Payment Method")
+        self.assertIsNone(transaction.payment_method_last_4)
         self.assertEqual(transaction.order_number, "123-4567890-1234567")
         self.assertEqual(transaction.order_details_link,
                          "https://www.amazon.com/gp/css/summary/edit.html?orderID=123-4567890-1234567")  # noqa
@@ -46,6 +47,7 @@ class TestTransaction(UnitTestCase):
         # THEN
         self.assertEqual(transaction.completed_date, date(2024, 1, 1))
         self.assertEqual(transaction.payment_method, "My Payment Method")
+        self.assertIsNone(transaction.payment_method_last_4)
         self.assertEqual(transaction.order_number, "123-4567890-1234567")
         self.assertEqual(transaction.order_details_link,
                          "https://www.amazon.com/gp/css/summary/edit.html?orderID=123-4567890-1234567")  # noqa

--- a/tests/unit/test_transactions.py
+++ b/tests/unit/test_transactions.py
@@ -71,6 +71,7 @@ class TestTransactions(UnitTestCase):
         transaction = transactions[0]
         self.assertEqual(transaction.completed_date, datetime.date(2024, 10, 11))
         self.assertEqual(transaction.payment_method, "Visa ****1234")
+        self.assertEqual(transaction.payment_method_last_4, "1234")
         self.assertEqual(transaction.grand_total, -45.19)
         self.assertFalse(transaction.is_refund)
         self.assertEqual(transaction.order_number, "123-4567890-1234567")
@@ -143,6 +144,7 @@ class TestTransactions(UnitTestCase):
         transaction = transactions[0]
         self.assertEqual(transaction.completed_date, datetime.date(2025, 2, 28))
         self.assertEqual(transaction.payment_method, "WELLS FARGO BANK NATIONAL ASSOCIATION ***863")
+        self.assertEqual(transaction.payment_method_last_4, "863")
         self.assertEqual(transaction.grand_total, 55.96)
         self.assertTrue(transaction.is_refund)
         self.assertEqual(transaction.order_number, "0000000019080621061")
@@ -209,6 +211,7 @@ class TestTransactions(UnitTestCase):
         transaction = transactions[0]
         self.assertEqual(transaction.completed_date, datetime.date(2025, 2, 12))
         self.assertEqual(transaction.payment_method, "Prime Visa ****1111")
+        self.assertEqual(transaction.payment_method_last_4, "1111")
         self.assertEqual(transaction.grand_total, -26.29)
         self.assertFalse(transaction.is_refund)
         self.assertEqual(transaction.order_number, "234-8832881-7100260")
@@ -218,6 +221,7 @@ class TestTransactions(UnitTestCase):
         transaction = transactions[1]
         self.assertEqual(transaction.completed_date, datetime.date(2025, 2, 7))
         self.assertEqual(transaction.payment_method, "Prime Visa ****1111")
+        self.assertEqual(transaction.payment_method_last_4, "1111")
         self.assertEqual(transaction.grand_total, 43.94)
         self.assertTrue(transaction.is_refund)
         self.assertEqual(transaction.order_number, "234-3017692-4601031")


### PR DESCRIPTION
### Description

Exposes the masked card digits on the `Transaction` entity, parsed from the existing `payment_method`
string (e.g. `"Visa ****1234"` → `"1234"`), mirroring the existing `Order.payment_method_last_4` field so
consumers no longer have to parse the string themselves.

The value is kept as `Optional[str]` (rather than `int`, as on `Order`) to preserve leading zeros and
shorter masks such as `"WELLS FARGO BANK NATIONAL ASSOCIATION ***863"` → `"863"`. Returns `None` when
`payment_method` has no masked digits. Derived via `re.search(r"\*+(\d+)$", ...)` through the existing
`safe_parse` helper — the transactions page only renders the combined string, so there is no separate
element to select.

Per your comment on #84, this is the additive, non-breaking half; the matching breaking change to
`Order.payment_method_last_4` (`int` → `str`) is a separate follow-up (#87).

Closes #84

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a schema change
- [ ] This change requires a documentation update

### Testing Done

Extended the existing unit tests; no new fixtures needed:
- `tests/unit/test_transactions.py`: assert `payment_method_last_4` is `"1234"` (Visa), `"863"` (the
  3-digit Wells Fargo mask) and `"1111"` (both Prime Visa transactions).
- `tests/unit/entity/test_transaction.py`: assert `None` for the "My Payment Method" fixture (no digits).

`make test` → 139 passed, 2 skipped. The new field auto-publishes via its `#:` docstring (`docs/api.rst`
already `automodule`s the entity).

### Checklist

- [x] I have added tests that prove my change works as expected, and `make test` passes with no new errors or warnings
- [x] I have run `make check` to ensure no new errors or warnings
- [x] I have updated the docs, if applicable, and run `make docs` to ensure no new errors or warnings
- [x] I have performed a self-review of my own code
- [x] I have commented my code in particularly hard-to-understand areas