### PR TITLE
fix: make Order.payment_method_last_4 a str to preserve leading zeros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased](https://github.com/alexdlaird/amazon-orders/compare/4.4.7...HEAD)
 
+### Changed
+
+- `Order.payment_method_last_4` is now a `str` rather than an `int`, preserving leading zeros.
+
 ### Fixed
 
 - `Shipment.items` and `Order.items` from the Order history page no longer omit Items when a Shipment holds more than one.

--- a/amazonorders/entity/order.py
+++ b/amazonorders/entity/order.py
@@ -98,8 +98,10 @@ class Order(Parsable):
         #: The Order payment method. Only populated when ``full_details`` is ``True``. For Whole Foods Market
         #: orders this is the card brand of the first payment method on the receipt (e.g. "Visa").
         self.payment_method: Optional[str] = self._if_full_details(self._parse_payment_method())
-        #: The Order payment method's last 4 digits. Only populated when ``full_details`` is ``True``.
-        self.payment_method_last_4: Optional[int] = self._if_full_details(self._parse_payment_method_last_4())
+        #: The Order payment method's last digits, preserved verbatim (e.g. leading zeros).
+        #: Only populated when ``full_details`` is ``True``.
+        self.payment_method_last_4: Optional[str] = self._if_full_details(
+            self.safe_parse(self._parse_payment_method_last_4))
         #: The Order subtotal. Only populated when ``full_details`` is ``True``.
         self.subtotal: Optional[float] = self._if_full_details(self._parse_subtotal())
         #: The Order shipping total. Only populated when ``full_details`` is ``True``.
@@ -218,12 +220,22 @@ class Order(Parsable):
         return self.safe_simple_parse(selector=self.config.selectors.FIELD_ORDER_PAYMENT_METHOD_SELECTOR,
                                       attr_name="alt")
 
-    def _parse_payment_method_last_4(self) -> Optional[int]:
+    def _parse_payment_method_last_4(self) -> Optional[str]:
         if self.is_whole_foods:
-            return self.safe_simple_parse(
-                selector=self.config.selectors.FIELD_ORDER_WHOLE_FOODS_PAYMENT_LAST_4_SELECTOR, prefix_split="*")
-        return self.safe_simple_parse(selector=self.config.selectors.FIELD_ORDER_PAYMENT_METHOD_LAST_4_SELECTOR,
-                                      prefix_split="ending in")
+            for tag in util.select(self.parsed,
+                                   self.config.selectors.FIELD_ORDER_WHOLE_FOODS_PAYMENT_LAST_4_SELECTOR):
+                match = re.search(r"\*\s*(\d+)", tag.text)
+                if match:
+                    return match.group(1)
+
+            return None
+
+        for tag in util.select(self.parsed, self.config.selectors.FIELD_ORDER_PAYMENT_METHOD_LAST_4_SELECTOR):
+            match = re.search(r"ending in\s+(\d+)", tag.text)
+            if match:
+                return match.group(1)
+
+        return None
 
     def _parse_subtotal(self) -> Optional[float]:
         if self.is_whole_foods:

--- a/tests/testcase.py
+++ b/tests/testcase.py
@@ -398,7 +398,7 @@ class TestCase(unittest.TestCase):
         if full_details:
             self.assertEqual(date(2025, 1, 31), order.items[0].return_eligible_date)
             self.assertEqual("American Express", order.payment_method)
-            self.assertEqual(1234, order.payment_method_last_4)
+            self.assertEqual("1234", order.payment_method_last_4)
             self.assertEqual(27.98, order.subtotal)
             self.assertEqual(0.00, order.shipping_total)
             self.assertEqual(26.58, order.total_before_tax)
@@ -425,7 +425,7 @@ class TestCase(unittest.TestCase):
 
         if full_details:
             self.assertEqual("American Express", order.payment_method)
-            self.assertEqual(1234, order.payment_method_last_4)
+            self.assertEqual("1234", order.payment_method_last_4)
             self.assertEqual(10.00, order.subtotal)
             self.assertEqual(10.00, order.total_before_tax)
             self.assertEqual(0.00, order.estimated_tax)
@@ -472,7 +472,7 @@ class TestCase(unittest.TestCase):
         if full_details:
             self.assertEqual(date(2024, 11, 25), order.items[0].return_eligible_date)
             self.assertEqual("American Express", order.payment_method)
-            self.assertEqual(1234, order.payment_method_last_4)
+            self.assertEqual("1234", order.payment_method_last_4)
             self.assertEqual(43.49, order.subtotal)
             self.assertEqual(0.00, order.shipping_total)
             self.assertEqual(-2.17, order.subscription_discount)
@@ -514,7 +514,7 @@ class TestCase(unittest.TestCase):
 
         if full_details:
             self.assertEqual("Prime Visa", order.payment_method)
-            self.assertEqual(1111, order.payment_method_last_4)
+            self.assertEqual("1111", order.payment_method_last_4)
             self.assertEqual(57.69, order.subtotal)
             self.assertEqual(2.99, order.shipping_total)
             self.assertEqual(57.69, order.total_before_tax)

--- a/tests/unit/entity/test_order.py
+++ b/tests/unit/entity/test_order.py
@@ -167,6 +167,34 @@ class TestOrder(UnitTestCase):
         # THEN
         self.assertEqual(order.gift_card, -2.37)
 
+    def test_order_payment_method_last_4_preserves_leading_zeros(self):
+        # GIVEN
+        with open(os.path.join(self.RESOURCES_DIR, "orders", "order-amazon-discount-snippet.html"),
+                  "r",
+                  encoding="utf-8") as f:
+            parsed = BeautifulSoup(f.read().replace("ending in 1234", "ending in 0123"),
+                                   self.test_config.bs4_parser)
+
+        # WHEN
+        order = Order(parsed, self.test_config, full_details=True)
+
+        # THEN
+        self.assertEqual("0123", order.payment_method_last_4)
+
+    def test_order_payment_method_last_4_none_when_absent(self):
+        # GIVEN
+        with open(os.path.join(self.RESOURCES_DIR, "orders", "order-amazon-discount-snippet.html"),
+                  "r",
+                  encoding="utf-8") as f:
+            parsed = BeautifulSoup(f.read().replace("ending in 1234", ""),
+                                   self.test_config.bs4_parser)
+
+        # WHEN
+        order = Order(parsed, self.test_config, full_details=True)
+
+        # THEN
+        self.assertIsNone(order.payment_method_last_4)
+
     def test_order_missing_grand_total_raises_exception_by_default(self):
         # GIVEN
         with open(os.path.join(self.RESOURCES_DIR, "orders", "order-missing-grand-total-snippet.html"),

--- a/tests/unit/test_orders.py
+++ b/tests/unit/test_orders.py
@@ -507,7 +507,7 @@ class TestOrders(UnitTestCase):
         fopo_order = next(order for order in orders if order.order_number == "777-5719845-2377811")
         # The receipt's first payment method maps onto the existing Order payment fields
         self.assertEqual("Visa", fopo_order.payment_method)
-        self.assertEqual(9790, fopo_order.payment_method_last_4)
+        self.assertEqual("9790", fopo_order.payment_method_last_4)
         self.assertEqual(27.96, fopo_order.subtotal)
         self.assertEqual(0.54, fopo_order.estimated_tax)
         # An ASINLESS line item (no Amazon detail page) still parses, with a title but no link


### PR DESCRIPTION
### Description

`Order.payment_method_last_4` is parsed through `util.to_type()`, which coerces the masked
digits to an `int` and **silently drops leading zeros** — a card ending in `0123` comes back
as `123`. Since the last four are an identifier rather than a quantity, this changes the field
from `Optional[int]` to `Optional[str]` and parses the digits directly: a dedicated
`_parse_payment_method_last_4` reads the tag text and splits on `"ending in"`, bypassing
`to_type` so the value is preserved verbatim. This also aligns the field with the new
`Transaction.payment_method_last_4` (#88), which is a `str` for the same reason.

This is the breaking half you flagged on #84 — *"It'd unfortunately be a breaking change on the
existing field … would get to in for the next release."* No rush; happy for it to ride whenever
you're cutting a breaking release. If you'd rather not break the existing field at all, I can
instead add a new `str` field and deprecate the `int` one — just say the word.

**Migration:** code comparing this numerically (`payment_method_last_4 == 1234`) must switch to
string comparison (`== "1234"`). The value is usually the card's last three or four digits.

Closes #87

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a schema change
- [ ] This change requires a documentation update

### Testing Done

Added two focused unit tests in `tests/unit/entity/test_order.py`:
- `test_order_payment_method_last_4_preserves_leading_zeros` — masks a card as `0123` and asserts
  `"0123"` (the old `int` parsing returned `123`).
- `test_order_payment_method_last_4_none_when_absent` — asserts `None` when there are no masked digits.

Also updated the four shared assertions in `tests/testcase.py` from the bare-int form to strings;
the `assertEqual(4, len(str(order.payment_method_last_4)))` assertions are unaffected.

`make test` → 178 passed, 2 skipped.

### Checklist

- [x] I have added tests that prove my change works as expected, and `make test` passes with no new errors or warnings
- [x] I have run `make check` to ensure no new errors or warnings
- [x] I have updated the docs, if applicable, and run `make docs` to ensure no new errors or warnings
- [x] I have performed a self-review of my own code
- [x] I have commented my code in particularly hard-to-understand areas