### PR TITLE
feat: add order_id filter to AmazonTransactions.get_transactions()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased](https://github.com/alexdlaird/amazon-orders/compare/4.3.0...HEAD)
 
+### Added
+
+- `AmazonTransactions.get_transactions()` now accepts an optional `order_id` to return only that Order's transactions, scoped server-side via Amazon's `transactionTag` filter, instead of fetching the full feed and filtering client-side.
+
 ## [4.3.0](https://github.com/alexdlaird/amazon-orders/compare/4.2.2...4.3.0) - 2026-06-07
 
 ### Added

--- a/amazonorders/transactions.py
+++ b/amazonorders/transactions.py
@@ -85,14 +85,17 @@ class AmazonTransactions:
     def get_transactions(self,
                          days: int = 365,
                          next_page_data: Optional[Dict[str, Any]] = None,
-                         keep_paging: bool = True) -> List[Transaction]:
+                         keep_paging: bool = True,
+                         order_id: Optional[str] = None) -> List[Transaction]:
         """
-        Get Amazon Transaction history for a given number of days.
+        Get Amazon Transaction history for a given number of days, or for a single Order.
 
-        :param days: The number of days worth of Transactions to get.
+        :param days: The number of days worth of Transactions to get. Ignored when ``order_id`` is given.
         :param next_page_data: If a call to this method previously errored out, passing the exception's
             :attr:`~amazonorders.exception.AmazonOrdersError.meta` will continue paging where it left off.
         :param keep_paging: ``False`` if only one page should be fetched.
+        :param order_id: If given, only Transactions for this Amazon Order ID are returned, scoped
+            server-side via Amazon's ``transactionTag`` filter (the ``days`` window does not apply).
         :return: A list of the requested Transactions.
         """
         if not self.amazon_session.is_authenticated:
@@ -100,13 +103,16 @@ class AmazonTransactions:
 
         min_date = datetime.date.today() - datetime.timedelta(days=days)
 
+        url = self.config.constants.TRANSACTION_HISTORY_URL
+        if order_id:
+            url = f"{url}?transactionTag={order_id}"
+
         transactions: List[Transaction] = []
         first_page = True
         while first_page or keep_paging:
             first_page = False
 
-            page_response = self.amazon_session.post(self.config.constants.TRANSACTION_HISTORY_URL,
-                                                     data=next_page_data)
+            page_response = self.amazon_session.post(url, data=next_page_data)
             self.amazon_session.check_response(page_response, meta=next_page_data)
 
             form_tag = util.select_one(page_response.parsed,
@@ -125,7 +131,7 @@ class AmazonTransactions:
             )
 
             for transaction in loaded_transactions:
-                if transaction.completed_date >= min_date:
+                if order_id or transaction.completed_date >= min_date:
                     transactions.append(transaction)
                 else:
                     next_page_data = None

--- a/tests/unit/test_transactions.py
+++ b/tests/unit/test_transactions.py
@@ -81,6 +81,33 @@ class TestTransactions(UnitTestCase):
         self.assertEqual(1, resp.call_count)
 
     @responses.activate
+    @patch("amazonorders.transactions.datetime", wraps=datetime)
+    def test_get_transactions_by_order_id(self, mock_today):
+        # GIVEN
+        # today is well over a year after the snippet's transactions, so without order scoping the
+        # date window would drop them — getting them back proves order_id bypasses the days filter.
+        mock_today.date.today.return_value = datetime.date(2026, 1, 1)
+        self.amazon_session.is_authenticated = True
+        order_id = "123-4567890-1234567"
+        with open(os.path.join(self.RESOURCES_DIR, "transactions", "get-transactions-snippet.html"), "r",
+                  encoding="utf-8") as f:
+            resp = responses.add(
+                responses.POST,
+                f"{self.test_config.constants.TRANSACTION_HISTORY_URL}?transactionTag={order_id}",
+                body=f.read(),
+                status=200,
+            )
+
+        # WHEN
+        transactions = self.amazon_transactions.get_transactions(order_id=order_id, keep_paging=False)
+
+        # THEN
+        self.assertEqual(2, len(transactions))
+        self.assertEqual(order_id, transactions[0].order_number)
+        self.assertEqual(1, resp.call_count)
+        self.assertIn(f"transactionTag={order_id}", resp.calls[0].request.url)
+
+    @responses.activate
     def test_get_transactions_errors_with_meta(self):
         # GIVEN
         self.amazon_session.is_authenticated = True


### PR DESCRIPTION
### Description

`AmazonTransactions.get_transactions()` only supported a date-windowed global feed, so getting one
order's charges meant paging months of history and filtering by `order_number` client-side. This adds an
optional `order_id` that scopes the feed server-side via Amazon's existing `transactionTag` query
parameter on the same `/cpe/yourpayments/transactions` route — the parameter the order page's "View
related transactions" link already uses. When `order_id` is given, the `days` window doesn't apply, so an
order older than the window still returns its charges. Returns the existing `List[Transaction]`. Read-only.

Closes #85

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a schema change
- [ ] This change requires a documentation update

### Testing Done

Added `test_get_transactions_by_order_id`: asserts the request carries `?transactionTag=<order_id>`, the
response parses to `Transaction`s, and the `days` window is bypassed (a >1-year-old transaction still
returns). Also verified against a live account that `POST …?transactionTag=<order>` returns only that
order's transactions, in the same form/date/line-item structure the parser expects. `make test` → 177 passed, 2 skipped.

### Checklist

- [x] I have added tests that prove my change works as expected, and `make test` passes with no new errors or warnings
- [x] I have run `make check` to ensure no new errors or warnings
- [x] I have updated the docs, if applicable, and run `make docs` to ensure no new errors or warnings
- [x] I have performed a self-review of my own code
- [x] I have commented my code in particularly hard-to-understand areas