### PR TITLE
feat: add parse methods for already-fetched Order and Transaction HTML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased](https://github.com/alexdlaird/amazon-orders/compare/4.4.7...HEAD)
 
+### Added
+
+- `AmazonOrders.parse_order_history()`, `AmazonOrders.parse_order_details()`, and `AmazonTransactions.parse_transactions()`, which parse already-fetched page HTML without a session.
+
 ### Fixed
 
 - `Shipment.items` and `Order.items` from the Order history page no longer omit Items when a Shipment holds more than one.

--- a/amazonorders/orders.py
+++ b/amazonorders/orders.py
@@ -9,7 +9,7 @@ import re
 from typing import Any, Callable, List, Optional
 from urllib.parse import quote
 
-from bs4 import Tag
+from bs4 import BeautifulSoup, Tag
 
 from amazonorders import util
 from amazonorders.conf import AmazonOrdersConfig
@@ -60,6 +60,39 @@ class AmazonOrders:
         self.debug: bool = debug
         if self.debug:
             logger.setLevel(logging.DEBUG)
+
+    @staticmethod
+    def parse_order_history(html: str,
+                            config: AmazonOrdersConfig) -> List[Order]:
+        """
+        Parse an already-fetched Amazon Order history page into Orders, without a session driving the
+        fetch — useful for parsing HTML obtained elsewhere (a browser, a proxy, a fixture) and for
+        network-free testing.
+
+        :param html: The Order history page HTML to parse.
+        :param config: The config providing the selectors and entity classes used for parsing.
+        :return: A list of the parsed Orders.
+        """
+        parsed = BeautifulSoup(html, config.bs4_parser)
+        order_tags = util.select(parsed, config.selectors.ORDER_HISTORY_ENTITY_SELECTOR)
+        return [config.order_cls(tag, config, index=i) for i, tag in enumerate(order_tags)]
+
+    @staticmethod
+    def parse_order_details(html: str,
+                            config: AmazonOrdersConfig) -> Order:
+        """
+        Parse an already-fetched Amazon Order details page into an Order, without a session driving the
+        fetch — useful for parsing HTML obtained elsewhere and for network-free testing.
+
+        :param html: The Order details page HTML to parse.
+        :param config: The config providing the selectors and entity classes used for parsing.
+        :return: The parsed Order.
+        """
+        parsed = BeautifulSoup(html, config.bs4_parser)
+        order_details_tag = util.select_one(parsed, config.selectors.ORDER_DETAILS_ENTITY_SELECTOR)
+        if not order_details_tag:
+            raise AmazonOrdersError("Could not parse Order details. Check if Amazon changed the HTML.")
+        return config.order_cls(order_details_tag, config, full_details=True)
 
     def get_order(self,
                   order_id: str,

--- a/amazonorders/orders.py
+++ b/amazonorders/orders.py
@@ -63,36 +63,56 @@ class AmazonOrders:
 
     @staticmethod
     def parse_order_history(html: str,
-                            config: AmazonOrdersConfig) -> List[Order]:
+                            config: AmazonOrdersConfig,
+                            start_index: int = 0) -> List[Order]:
         """
         Parse an already-fetched Amazon Order history page into Orders, without a session driving the
         fetch — useful for parsing HTML obtained elsewhere (a browser, a proxy, a fixture) and for
         network-free testing.
 
+        A page with no Orders is returned as an empty list only when the page's own Order count
+        confirms the window is empty at ``start_index``; otherwise it raises, since that is a page
+        that failed to render.
+
         :param html: The Order history page HTML to parse.
         :param config: The config providing the selectors and entity classes used for parsing.
+        :param start_index: The index of the first Order on the page within its window, seeding
+            :attr:`~amazonorders.entity.order.Order.index` the way ``get_order_history()`` does.
         :return: A list of the parsed Orders.
         """
         parsed = BeautifulSoup(html, config.bs4_parser)
         order_tags = util.select(parsed, config.selectors.ORDER_HISTORY_ENTITY_SELECTOR)
-        return [config.order_cls(tag, config, index=i) for i, tag in enumerate(order_tags)]
+
+        if not order_tags:
+            order_count = _parse_order_count(
+                util.select_one(parsed, config.selectors.ORDER_HISTORY_COUNT_SELECTOR))
+
+            if order_count is not None and order_count <= start_index:
+                return []
+            else:
+                raise AmazonOrdersError("Could not parse Order history. Check if Amazon changed the HTML.")
+
+        return [config.order_cls(tag, config, index=start_index + i) for i, tag in enumerate(order_tags)]
 
     @staticmethod
     def parse_order_details(html: str,
-                            config: AmazonOrdersConfig) -> Order:
+                            config: AmazonOrdersConfig,
+                            order_number: Optional[str] = None) -> Order:
         """
         Parse an already-fetched Amazon Order details page into an Order, without a session driving the
         fetch — useful for parsing HTML obtained elsewhere and for network-free testing.
 
         :param html: The Order details page HTML to parse.
         :param config: The config providing the selectors and entity classes used for parsing.
+        :param order_number: The Order ID the page was fetched for, used as a fallback for
+            :attr:`~amazonorders.entity.order.Order.order_number` when it cannot be parsed from the page.
         :return: The parsed Order.
         """
         parsed = BeautifulSoup(html, config.bs4_parser)
         order_details_tag = util.select_one(parsed, config.selectors.ORDER_DETAILS_ENTITY_SELECTOR)
         if not order_details_tag:
             raise AmazonOrdersError("Could not parse Order details. Check if Amazon changed the HTML.")
-        return config.order_cls(order_details_tag, config, full_details=True)
+        return config.order_cls(order_details_tag, config, full_details=True, order_number=order_number)
 
     def get_order(self,
                   order_id: str,

--- a/amazonorders/transactions.py
+++ b/amazonorders/transactions.py
@@ -5,7 +5,7 @@ import datetime
 import logging
 from typing import Dict, List, Optional, Tuple, Any
 
-from bs4 import Tag
+from bs4 import BeautifulSoup, Tag
 from dateutil import parser
 
 from amazonorders import util
@@ -81,6 +81,31 @@ class AmazonTransactions:
         self.debug: bool = debug
         if self.debug:
             logger.setLevel(logging.DEBUG)
+
+    @staticmethod
+    def parse_transactions(html: str,
+                           config: AmazonOrdersConfig) -> List[Transaction]:
+        """
+        Parse an already-fetched Amazon Transactions page into Transactions, without a session driving
+        the fetch — useful for parsing HTML obtained elsewhere (a browser, a proxy, a fixture) and for
+        network-free testing. Only the Transactions on the given page are returned; paging is a fetch
+        concern.
+
+        :param html: The Transactions page HTML to parse.
+        :param config: The config providing the selectors used for parsing.
+        :return: A list of the parsed Transactions.
+        """
+        parsed = BeautifulSoup(html, config.bs4_parser)
+
+        form_tag = util.select_one(parsed, config.selectors.TRANSACTION_HISTORY_FORM_SELECTOR)
+        if not form_tag:
+            container = util.select_one(parsed, config.selectors.TRANSACTION_HISTORY_CONTAINER_SELECTOR)
+            if container and "don't have any transactions" in container.text:
+                return []
+            raise AmazonOrdersError("Could not parse Transaction history. Check if Amazon changed the HTML.")
+
+        transactions, _next_page_data = _parse_transaction_form_tag(form_tag, config)
+        return transactions
 
     def get_transactions(self,
                          days: int = 365,

--- a/tests/resources/transactions/transaction-no-payment-method-snippet.html
+++ b/tests/resources/transactions/transaction-no-payment-method-snippet.html
@@ -1,0 +1,23 @@
+<div class="a-section a-spacing-base apx-transactions-line-item-component-container">
+    <div data-pmts-component-id="pp-nlFfdK-6" class="a-row pmts-portal-component pmts-portal-components-pp-nlFfdK-6">
+        <div class="a-column a-span9">
+        </div>
+        <div class="a-column a-span3 a-text-right a-span-last">
+            <span class="a-size-base-plus a-text-bold">-CA$12.34</span>
+        </div>
+    </div>
+    <div data-pmts-component-id="pp-nlFfdK-6" class="a-section a-spacing-none a-spacing-top-mini pmts-portal-component pmts-portal-components-pp-nlFfdK-6">
+        <div class="a-row">
+            <div class="a-column a-span12">
+                <a id="pp-nlFfdK-52" class="a-link-normal" href="https://www.amazon.com/gp/css/summary/edit.html?orderID=123-4567890-1234567">Order #123-4567890-1234567</a>
+            </div>
+        </div>
+    </div>
+    <div data-pmts-component-id="pp-nlFfdK-6" class="a-section a-spacing-none a-spacing-top-mini pmts-portal-component pmts-portal-components-pp-nlFfdK-6">
+        <div class="a-row">
+            <div class="a-column a-span12">
+                <span class="a-size-base">AMZN Mktp COM</span>
+            </div>
+        </div>
+    </div>
+</div>

--- a/tests/unit/entity/test_transaction.py
+++ b/tests/unit/entity/test_transaction.py
@@ -58,3 +58,17 @@ class TestTransaction(UnitTestCase):
         self.assertEqual(
             repr(transaction), '<Transaction 2024-01-01: "Order #123-4567890-1234567, Grand Total: 12.34">'
         )
+
+    def test_parse_no_payment_method(self):
+        # GIVEN
+        with open(os.path.join(self.RESOURCES_DIR, "transactions", "transaction-no-payment-method-snippet.html"),
+                  "r", encoding="utf-8") as f:
+            parsed = BeautifulSoup(f.read(), self.test_config.bs4_parser)
+
+        # WHEN
+        transaction = Transaction(parsed, self.test_config, date(2024, 1, 1))
+
+        # THEN
+        self.assertIsNone(transaction.payment_method)
+        self.assertIsNone(transaction.payment_method_last_4)
+        self.assertEqual(transaction.grand_total, -12.34)

--- a/tests/unit/test_orders.py
+++ b/tests/unit/test_orders.py
@@ -672,6 +672,34 @@ class TestOrders(UnitTestCase):
         self.assertIsNone(order.index)
         self.assertEqual(1, resp.call_count)
 
+    def test_parse_order_history(self):
+        # GIVEN
+        with open(os.path.join(self.RESOURCES_DIR, "orders", "order-history-2018-0.html"), "r",
+                  encoding="utf-8") as f:
+            html = f.read()
+
+        # WHEN
+        orders = AmazonOrders.parse_order_history(html, self.test_config)
+
+        # THEN
+        self.assertEqual(10, len(orders))
+        self.assert_order_112_0399923_3070642(orders[3], False)
+        self.assertEqual(3, orders[3].index)
+        self.assert_orders_list_index(orders)
+
+    def test_parse_order_details(self):
+        # GIVEN
+        order_id = "112-9685975-5907428"
+        with open(os.path.join(self.RESOURCES_DIR, "orders", f"order-details-{order_id}.html"), "r",
+                  encoding="utf-8") as f:
+            html = f.read()
+
+        # WHEN
+        order = AmazonOrders.parse_order_details(html, self.test_config)
+
+        # THEN
+        self.assert_order_112_9685975_5907428_multiple_items_shipments_sellers(order, True)
+
     @responses.activate
     def test_get_order_digital(self):
         # GIVEN

--- a/tests/unit/test_orders.py
+++ b/tests/unit/test_orders.py
@@ -708,6 +708,82 @@ class TestOrders(UnitTestCase):
         # THEN
         self.assertIn("Could not parse Order details", str(cm.exception))
 
+    def test_parse_order_history_start_index(self):
+        # GIVEN
+        with open(os.path.join(self.RESOURCES_DIR, "orders", "order-history-2018-0.html"), "r",
+                  encoding="utf-8") as f:
+            html = f.read()
+
+        # WHEN
+        orders = AmazonOrders.parse_order_history(html, self.test_config, start_index=10)
+
+        # THEN
+        self.assertEqual(10, len(orders))
+        self.assertEqual(10, orders[0].index)
+        self.assertEqual(19, orders[-1].index)
+
+    def test_parse_order_history_empty_window(self):
+        # GIVEN
+        with open(os.path.join(self.RESOURCES_DIR, "orders", "order-history-digital-2005-0.html"), "r",
+                  encoding="utf-8") as f:
+            html = f.read()
+
+        # WHEN
+        orders = AmazonOrders.parse_order_history(html, self.test_config)
+
+        # THEN
+        self.assertEqual(0, len(orders))
+
+    def test_parse_order_history_start_index_past_end(self):
+        # GIVEN
+        with open(os.path.join(self.RESOURCES_DIR, "orders", "order-history-2026-220.html"), "r",
+                  encoding="utf-8") as f:
+            html = f.read()
+
+        # WHEN
+        orders = AmazonOrders.parse_order_history(html, self.test_config, start_index=220)
+
+        # THEN
+        self.assertEqual(0, len(orders))
+
+    def test_parse_order_history_empty_page_within_window(self):
+        # GIVEN
+        with open(os.path.join(self.RESOURCES_DIR, "orders", "order-history-2026-220.html"), "r",
+                  encoding="utf-8") as f:
+            html = f.read()
+
+        # WHEN
+        with self.assertRaises(AmazonOrdersError) as cm:
+            AmazonOrders.parse_order_history(html, self.test_config)
+
+        # THEN
+        self.assertIn("Could not parse Order history", str(cm.exception))
+
+    def test_parse_order_history_unparseable(self):
+        # GIVEN
+        with open(os.path.join(self.RESOURCES_DIR, "500.html"), "r", encoding="utf-8") as f:
+            html = f.read()
+
+        # WHEN
+        with self.assertRaises(AmazonOrdersError) as cm:
+            AmazonOrders.parse_order_history(html, self.test_config)
+
+        # THEN
+        self.assertIn("Could not parse Order history", str(cm.exception))
+
+    def test_parse_order_details_order_number_fallback(self):
+        # GIVEN
+        order_id = "112-9685975-5907428"
+        with open(os.path.join(self.RESOURCES_DIR, "orders", f"order-details-{order_id}.html"), "r",
+                  encoding="utf-8") as f:
+            html = f.read().replace(order_id, "")
+
+        # WHEN
+        order = AmazonOrders.parse_order_details(html, self.test_config, order_number=order_id)
+
+        # THEN
+        self.assertEqual(order_id, order.order_number)
+
     @responses.activate
     def test_get_order_digital(self):
         # GIVEN

--- a/tests/unit/test_orders.py
+++ b/tests/unit/test_orders.py
@@ -700,6 +700,14 @@ class TestOrders(UnitTestCase):
         # THEN
         self.assert_order_112_9685975_5907428_multiple_items_shipments_sellers(order, True)
 
+    def test_parse_order_details_unparseable(self):
+        # WHEN
+        with self.assertRaises(AmazonOrdersError) as cm:
+            AmazonOrders.parse_order_details("<html></html>", self.test_config)
+
+        # THEN
+        self.assertIn("Could not parse Order details", str(cm.exception))
+
     @responses.activate
     def test_get_order_digital(self):
         # GIVEN

--- a/tests/unit/test_transactions.py
+++ b/tests/unit/test_transactions.py
@@ -121,6 +121,26 @@ class TestTransactions(UnitTestCase):
         self.assertEqual(transaction.order_number, "123-4567890-1234567")
         self.assertEqual(transaction.seller, "AMZN Mktp CA")
 
+    def test_parse_transactions_zero_transactions(self):
+        # GIVEN
+        with open(os.path.join(self.RESOURCES_DIR, "transactions", "transactions-zero-transactions.html"),
+                  "r", encoding="utf-8") as f:
+            html = f.read()
+
+        # WHEN
+        transactions = AmazonTransactions.parse_transactions(html, self.test_config)
+
+        # THEN
+        self.assertEqual([], transactions)
+
+    def test_parse_transactions_unparseable(self):
+        # WHEN
+        with self.assertRaises(AmazonOrdersError) as cm:
+            AmazonTransactions.parse_transactions("<html></html>", self.test_config)
+
+        # THEN
+        self.assertIn("Could not parse Transaction history", str(cm.exception))
+
     @responses.activate
     def test_get_transactions_errors_with_meta(self):
         # GIVEN

--- a/tests/unit/test_transactions.py
+++ b/tests/unit/test_transactions.py
@@ -103,6 +103,24 @@ class TestTransactions(UnitTestCase):
         self.assertEqual(1, resp.call_count)
         self.assertIn(f"transactionTag={order_id}", resp.calls[0].request.url)
 
+    def test_parse_transactions(self):
+        # GIVEN
+        with open(os.path.join(self.RESOURCES_DIR, "transactions", "get-transactions-snippet.html"), "r",
+                  encoding="utf-8") as f:
+            html = f.read()
+
+        # WHEN
+        transactions = AmazonTransactions.parse_transactions(html, self.test_config)
+
+        # THEN
+        self.assertEqual(2, len(transactions))
+        transaction = transactions[0]
+        self.assertEqual(transaction.payment_method, "Visa ****1234")
+        self.assertEqual(transaction.payment_method_last_4, "1234")
+        self.assertEqual(transaction.grand_total, -45.19)
+        self.assertEqual(transaction.order_number, "123-4567890-1234567")
+        self.assertEqual(transaction.seller, "AMZN Mktp CA")
+
     @responses.activate
     def test_get_transactions_errors_with_meta(self):
         # GIVEN


### PR DESCRIPTION
### Description

Adds a public, session-free API for turning already-fetched Amazon page HTML into
the same entities the library produces during a live fetch:

- `AmazonOrders.parse_order_history(html, config) -> list[Order]`
- `AmazonOrders.parse_order_details(html, config) -> Order`
- `AmazonTransactions.parse_transactions(html, config) -> list[Transaction]`

Each is a `@staticmethod` taking the page HTML and a config, and reuses the exact
selectors and entity constructors the fetch paths already use, so the parsed output
can't drift from `get_order_history()` / `get_order()` / `get_transactions()`.
`parse_transactions` shares the existing module-level `_parse_transaction_form_tag`
helper with `get_transactions`.

This is the public surface for the parse layer described in #92 — HTML in, entities
out, independent of `AmazonSession`. The methods are intentionally pure (no session,
no I/O), which also leaves the parse logic as a natural seam for later extracting the
fetch methods onto shared internal helpers.

A few design notes:
- **Page-level, not per-entity.** Only `Order` and `Transaction` are parsed from
  their own pages; nested `Item`/`Shipment`/`Recipient`/`Seller` come along inside
  the parsed `Order`.
- **`parse_transactions` returns only the current page's transactions** — paging is
  a fetch concern, so it doesn't chase the next-page token.
- **`config` is required (no default).** It's threaded into every entity constructor
  (selectors, `bs4_parser`, constants, the `*_cls` factories), and defaulting it
  would construct an `AmazonOrdersConfig()`, which has filesystem side effects;
  requiring it keeps parsing pure.

Fixes #92

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a schema change
- [ ] This change requires a documentation update

### Testing Done

Added network-free unit tests (load an existing HTML fixture, parse, assert — no
session, no HTTP mocking):

- `test_parse_order_history` / `test_parse_order_details` (`test_orders.py`) and
  `test_parse_transactions` (`test_transactions.py`) — the happy paths for the three
  new methods.
- `test_parse_order_details_unparseable`, `test_parse_transactions_unparseable`, and
  `test_parse_transactions_zero_transactions` — the not-found / empty-page branches.

Also picked up the patch-coverage follow-up you okayed for "the next PR" on #88:
`test_parse_no_payment_method` covers `Transaction.payment_method_last_4` returning
`None` when there's no payment method (the one line left uncovered there). Patch
coverage is now 100%.

`make test` passes (188 passed, 2 skipped), `make check` is clean, and `make docs`
builds with no new warnings.

### Checklist

- [x] I have added tests that prove my change works as expected, and `make test` passes with no new errors or warnings
- [x] I have run `make check` to ensure no new errors or warnings
- [x] I have updated the docs, if applicable, and run `make docs` to ensure no new errors or warnings
- [x] I have performed a self-review of my own code
- [x] I have commented my code in particularly hard-to-understand areas