### PR TITLE
feat: parse Whole Foods Market (FOPO) orders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,15 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Added
 
 - `request_timeout` config key (defaults to `None`) controlling the timeout passed to each HTTP request.
+- `Order.is_whole_foods`, identifying Whole Foods Market purchases (in-store/FOPO purchases and Whole Foods receipt orders).
+- `Order.item_count`, the number of items in a purchase when Amazon summarizes the count instead of listing the items (e.g. Whole Foods Market and eGift orders).
+- Full-details support for Whole Foods Market in-store purchases: when `full_details=True`, these orders are fetched from their dedicated `/fopo/order-details` page (which the standard order-details endpoint does not serve) and populate `items` (title, price, image, link, and whole-unit `quantity`), `subtotal`, `estimated_tax`, `payment_method`, and `payment_method_last_4`.
 
 ### Changed
 
 - `Order.order_number` now uses the caller-supplied value as a fallback when the order number cannot be parsed from the details page; previously documented but unintuitive behavior.
+- `Order.grand_total` is now populated for Whole Foods Market orders from the order history page (previously skipped as an unsupported order type).
+- `Item.link` is now optional (`None` for line items without an Amazon detail page, such as ASINLESS Whole Foods Market items) rather than raising when no link is present.
 
 ## [4.4.1](https://github.com/alexdlaird/amazon-orders/compare/4.4.0...4.4.1) - 2026-07-04
 

--- a/amazonorders/entity/item.py
+++ b/amazonorders/entity/item.py
@@ -2,11 +2,13 @@ __copyright__ = "Copyright (c) 2024-2025 Alex Laird"
 __license__ = "MIT"
 
 import logging
+import re
 from datetime import date
 from typing import Optional, TypeVar
 
 from bs4 import Tag
 
+from amazonorders import util
 from amazonorders.conf import AmazonOrdersConfig
 from amazonorders.entity.parsable import Parsable
 from amazonorders.entity.seller import Seller
@@ -32,9 +34,10 @@ class Item(Parsable):
         #: The Item title.
         self.title: str = self.safe_simple_parse(selector=self.config.selectors.FIELD_ITEM_TITLE_SELECTOR,
                                                  required=True)
-        #: The Item link.
-        self.link: str = self.safe_simple_parse(selector=self.config.selectors.FIELD_ITEM_LINK_SELECTOR,
-                                                attr_name="href", required=True)
+        #: The Item link. ``None`` for items without an Amazon detail page (e.g. ASINLESS Whole Foods
+        #: Market line items).
+        self.link: Optional[str] = self.safe_simple_parse(selector=self.config.selectors.FIELD_ITEM_LINK_SELECTOR,
+                                                          attr_name="href")
         #: The Item price.
         self.price: Optional[float] = self.to_currency(
             self.safe_simple_parse(selector=self.config.selectors.FIELD_ITEM_PRICE_SELECTOR)
@@ -57,9 +60,9 @@ class Item(Parsable):
         self.image_link: Optional[str] = self.safe_simple_parse(
             selector=self.config.selectors.FIELD_ITEM_IMG_LINK_SELECTOR,
             attr_name="src")
-        #: The Item quantity.
-        self.quantity: Optional[int] = self.safe_simple_parse(
-            selector=self.config.selectors.FIELD_ITEM_QUANTITY_SELECTOR)
+        #: The Item quantity. For items sold by weight (e.g. Whole Foods Market produce priced per
+        #: pound, rendered as "Qty: 0.31 lb"), which have no whole-unit count, this is ``None``.
+        self.quantity: Optional[int] = self.safe_parse(self._parse_quantity)
 
     def __repr__(self) -> str:
         return f"<Item: \"{self.title}\">"
@@ -70,3 +73,17 @@ class Item(Parsable):
     def __lt__(self,
                other: ItemEntity) -> bool:
         return self.title < other.title
+
+    def _parse_quantity(self) -> Optional[int]:
+        value = self.simple_parse(self.config.selectors.FIELD_ITEM_QUANTITY_SELECTOR)
+        if isinstance(value, int):
+            return value
+
+        # Whole Foods Market line items render quantity as "Qty: 1" (a whole count) or "Qty: 0.31 lb"
+        # (sold by weight, which has no integer quantity).
+        for tag in util.select(self.parsed, self.config.selectors.FIELD_ITEM_WHOLE_FOODS_QUANTITY_SELECTOR):
+            match = re.fullmatch(r"Qty:\s*(\d+)", tag.get_text(strip=True))
+            if match:
+                return int(match.group(1))
+
+        return None

--- a/amazonorders/entity/order.py
+++ b/amazonorders/entity/order.py
@@ -3,6 +3,7 @@ __license__ = "MIT"
 
 import json
 import logging
+import re
 from datetime import date
 from typing import Any, List, Optional, TypeVar, Union
 
@@ -52,6 +53,13 @@ class Order(Parsable):
         self.cancelled: bool = clone.cancelled if clone else bool(
             self.parsed and util.select(self.parsed, self.config.selectors.ORDER_SKIP_TOTALS))
 
+        #: ``True`` if this is a Whole Foods Market purchase (an in-store/FOPO purchase or a Whole Foods receipt
+        #: order). Unlike other unsupported order types, these expose a :attr:`grand_total` and (often) an
+        #: :attr:`item_count` on the history page, so those fields are populated; per-item details, however, are
+        #: only available on the Whole Foods receipt page and are not yet parsed, so :attr:`items` stays empty.
+        self.is_whole_foods: bool = clone.is_whole_foods if clone else bool(
+            self.parsed and util.select(self.parsed, self.config.selectors.ORDER_WHOLE_FOODS))
+
         #: The Order Shipments.
         self.shipments: List[Shipment] = clone.shipments if clone else self._parse_shipments()
         #: The Order Items.
@@ -82,19 +90,19 @@ class Order(Parsable):
             parse_date=True)
         #: The Order Recipients.
         self.recipient: Recipient = clone.recipient if clone else self.safe_parse(self._parse_recipient)
+        #: The number of items in the purchase, when Amazon summarizes the count instead of listing the items
+        #: (e.g. Whole Foods Market orders show "N items in this purchase"). ``None`` when no such summary is shown.
+        self.item_count: Optional[int] = clone.item_count if clone else self.safe_parse(self._parse_item_count)
 
         # Fields below this point are only populated if `full_details` is True
 
-        #: The Order payment method. Only populated when ``full_details`` is ``True``.
-        self.payment_method: Optional[str] = self._if_full_details(
-            self.safe_simple_parse(selector=self.config.selectors.FIELD_ORDER_PAYMENT_METHOD_SELECTOR,
-                                   attr_name="alt"))
+        #: The Order payment method. Only populated when ``full_details`` is ``True``. For Whole Foods Market
+        #: orders this is the card brand of the first payment method on the receipt (e.g. "Visa").
+        self.payment_method: Optional[str] = self._if_full_details(self._parse_payment_method())
         #: The Order payment method's last 4 digits. Only populated when ``full_details`` is ``True``.
-        self.payment_method_last_4: Optional[int] = self._if_full_details(
-            self.safe_simple_parse(selector=self.config.selectors.FIELD_ORDER_PAYMENT_METHOD_LAST_4_SELECTOR,
-                                   prefix_split="ending in"))
+        self.payment_method_last_4: Optional[int] = self._if_full_details(self._parse_payment_method_last_4())
         #: The Order subtotal. Only populated when ``full_details`` is ``True``.
-        self.subtotal: Optional[float] = self._if_full_details(self._parse_currency("subtotal"))
+        self.subtotal: Optional[float] = self._if_full_details(self._parse_subtotal())
         #: The Order shipping total. Only populated when ``full_details`` is ``True``.
         self.shipping_total: Optional[float] = self._if_full_details(self._parse_currency("shipping"))
         #: The Order free shipping. Only populated when ``full_details`` is ``True``.
@@ -115,8 +123,9 @@ class Order(Parsable):
             else subscription_discount
         #: The Order total before tax. Only populated when ``full_details`` is ``True``.
         self.total_before_tax: Optional[float] = self._if_full_details(self._parse_currency("before tax"))
-        #: The Order estimated tax. Only populated when ``full_details`` is ``True``.
-        self.estimated_tax: Optional[float] = self._if_full_details(self._parse_currency("estimated tax"))
+        #: The Order estimated tax. Only populated when ``full_details`` is ``True``. For Whole Foods Market
+        #: orders this is the "Tax and Fees" total from the receipt.
+        self.estimated_tax: Optional[float] = self._if_full_details(self._parse_estimated_tax())
         #: The Order refund total. Only populated when ``full_details`` is ``True``.
         self.refund_total: Optional[float] = self._if_full_details(self._parse_currency("refund total"))
         #: The Multibuy discount. Only populated when ``full_details`` is ``True``.
@@ -167,8 +176,9 @@ class Order(Parsable):
         if len(util.select(self.parsed, self.config.selectors.ORDER_SKIP_TOTALS)) > 0:
             return None
 
-        # Skip totals parsing for unsupported order types (Fresh, Whole Foods, physical stores)
-        if len(util.select(self.parsed, self.config.selectors.ORDER_SKIP_ITEMS)) > 0:
+        # Skip totals parsing for unsupported order types (Amazon Fresh, physical stores). Whole Foods Market
+        # orders also match ORDER_SKIP_ITEMS, but they expose a grand total on the history page, so parse it.
+        if not self.is_whole_foods and len(util.select(self.parsed, self.config.selectors.ORDER_SKIP_ITEMS)) > 0:
             return None
 
         value = self.simple_parse(self.config.selectors.FIELD_ORDER_GRAND_TOTAL_SELECTOR)
@@ -192,6 +202,42 @@ class Order(Parsable):
                 logger.warning(err_msg)
 
         return value
+
+    def _parse_whole_foods_amount(self,
+                                  selector: str) -> Optional[float]:
+        return self.to_currency(self.simple_parse(selector))
+
+    def _parse_payment_method(self) -> Optional[str]:
+        if self.is_whole_foods:
+            return self.safe_simple_parse(
+                selector=self.config.selectors.FIELD_ORDER_WHOLE_FOODS_PAYMENT_METHOD_SELECTOR)
+        return self.safe_simple_parse(selector=self.config.selectors.FIELD_ORDER_PAYMENT_METHOD_SELECTOR,
+                                      attr_name="alt")
+
+    def _parse_payment_method_last_4(self) -> Optional[int]:
+        if self.is_whole_foods:
+            return self.safe_simple_parse(
+                selector=self.config.selectors.FIELD_ORDER_WHOLE_FOODS_PAYMENT_LAST_4_SELECTOR, prefix_split="*")
+        return self.safe_simple_parse(selector=self.config.selectors.FIELD_ORDER_PAYMENT_METHOD_LAST_4_SELECTOR,
+                                      prefix_split="ending in")
+
+    def _parse_subtotal(self) -> Optional[float]:
+        if self.is_whole_foods:
+            return self._parse_whole_foods_amount(self.config.selectors.FIELD_ORDER_WHOLE_FOODS_SUBTOTAL_SELECTOR)
+        return self._parse_currency("subtotal")
+
+    def _parse_estimated_tax(self) -> Optional[float]:
+        if self.is_whole_foods:
+            return self._parse_whole_foods_amount(self.config.selectors.FIELD_ORDER_WHOLE_FOODS_TAX_SELECTOR)
+        return self._parse_currency("estimated tax")
+
+    def _parse_item_count(self) -> Optional[int]:
+        for tag in util.select(self.parsed, self.config.selectors.FIELD_ORDER_ITEM_COUNT_SELECTOR):
+            match = re.search(r"(\d+)\s+items?\s+in this purchase", tag.text)
+            if match:
+                return int(match.group(1))
+
+        return None
 
     def _parse_recipient(self) -> Optional[Recipient]:
         # At least for now, we don't populate Recipient data for digital orders

--- a/amazonorders/orders.py
+++ b/amazonorders/orders.py
@@ -208,7 +208,17 @@ class AmazonOrders:
         order: Order = self.config.order_cls(order_tag, self.config, index=current_index)
 
         if full_details:
-            if len(util.select(order.parsed, self.config.selectors.ORDER_SKIP_ITEMS)) > 0:
+            if order.is_whole_foods:
+                # Whole Foods orders are served by a dedicated details page (the in-store/FOPO page or the
+                # receipt page), never the standard order-details endpoint, so only fetch full details when
+                # the history page linked us to one of those routes.
+                link = order.order_details_link or ""
+                if "/fopo/order-details" in link or "/wholefoodsmarket/receipts/order/" in link:
+                    order = self._get_whole_foods_order(order, link)
+                else:
+                    logger.warning(f"Order {order.order_number} is a Whole Foods Market order whose details "
+                                   f"page could not be located, so it was left partially populated.")
+            elif len(util.select(order.parsed, self.config.selectors.ORDER_SKIP_ITEMS)) > 0:
                 logger.warning(f"Order {order.order_number} was partially populated, "
                                f"since it is an unsupported Order type.")
             elif not order.order_number:
@@ -218,6 +228,33 @@ class AmazonOrders:
                 order = self.get_order(order.order_number, clone=order)
 
         return order
+
+    def _get_whole_foods_order(self,
+                               order: Order,
+                               url: str) -> Order:
+        """
+        Fetch and parse a Whole Foods Market order's dedicated details page (the in-store/FOPO
+        ``/fopo/order-details`` page or the ``/wholefoodsmarket/receipts/order`` receipt page),
+        which the standard Order details endpoint does not serve. The history-derived ``order`` is
+        used as the ``clone`` so its fields are preserved and enriched with the per-item details.
+
+        :param order: The Whole Foods Market Order parsed from the history page.
+        :param url: The Whole Foods Market details page URL to fetch.
+        :return: The Order, enriched with full details if they could be parsed.
+        """
+        details_response = self.amazon_session.get(url)
+        self.amazon_session.check_response(details_response, meta={"index": order.index})
+
+        details_tag = util.select_one(details_response.parsed,
+                                      self.config.selectors.ORDER_DETAILS_ENTITY_SELECTOR)
+
+        if not details_tag:
+            logger.warning(f"Could not parse Whole Foods Market details for Order {order.order_number}, "
+                           f"so it was left partially populated.")
+            return order
+
+        return self.config.order_cls(details_tag, self.config, full_details=True, clone=order,
+                                     order_number=order.order_number)
 
     async def _async_wrapper(self,
                              func: Callable,

--- a/amazonorders/selectors.py
+++ b/amazonorders/selectors.py
@@ -86,22 +86,39 @@ class Selectors:
                                      "div.order"]
     ORDER_HISTORY_COUNT_SELECTOR = ".js-yo-container span.num-orders"
     ORDER_DETAILS_ENTITY_SELECTOR = ["div#orderDetails",
-                                     "div#ordersContainer"]
+                                     "div#ordersContainer",
+                                     # The Whole Foods Market in-store (FOPO) order details page
+                                     "div#odp-main-section"]
     ITEM_ENTITY_SELECTOR = ["[data-component='purchasedItems'] .a-fixed-left-grid",
                             "div:has(> div.yohtmlc-item)",
-                            ".item-box"]
+                            ".item-box",
+                            # Whole Foods Market in-store (FOPO) order details line items
+                            "div.a-row.a-spacing-base:has(img.ufpo-itemListWidget-image)"]
     SHIPMENT_ENTITY_SELECTOR = ["[data-component='orderCard'] [data-component='shipments'] .a-box",
                                 "div.shipment",
                                 "div.delivery-box"]
     # Selectors defined here mean we don't have a reliable way to parse all details in an Order, so Items and
     # Shipments will be skipped
     ORDER_SKIP_ITEMS = [
-        # Identifies an Amazon Fresh order
+        # Identifies an Amazon Fresh order (also matched by Whole Foods in-store purchases, which
+        # render the same brand-logo box; those are distinguished via ORDER_WHOLE_FOODS below)
         ".brand-info-box .brand-logo img",
-        # Identifies a Whole Foods Market order
+        # Identifies a Whole Foods Market receipt order
         "a.yohtmlc-order-details-link[href^='/wholefoodsmarket']",
         # Identifies an order from a physical Amazon store
         Selector("div.yohtmlc-shipment-status-primaryText", "Purchased at Amazon")
+    ]
+    # Selectors that identify a Whole Foods Market purchase. In-store (FOPO) purchases link to
+    # ``/fopo/order-details`` and tag the shipment "Purchased at Whole Foods Market"; receipt orders
+    # link to the external ``/wholefoodsmarket/receipts/order`` page. Unlike the ORDER_SKIP_ITEMS
+    # entries, these orders expose a grand total (and often an item count) on the history page, so
+    # those fields are parsed even though per-item details require the Whole Foods receipt page.
+    ORDER_WHOLE_FOODS = [
+        "a[href*='/wholefoodsmarket/receipts/order/']",
+        "a[href*='/fopo/order-details']",
+        Selector("div.yohtmlc-shipment-status-primaryText", text_contains="Whole Foods Market"),
+        # The item list widget on the Whole Foods in-store (FOPO) order details page
+        "img.ufpo-itemListWidget-image"
     ]
     # Selectors defined here mean the Order will not have parsable totals
     ORDER_SKIP_TOTALS = [
@@ -115,19 +132,30 @@ class Selectors:
     # CSS selectors for Item fields
     #####################################
 
-    FIELD_ITEM_IMG_LINK_SELECTOR = "a img"
+    # The trailing entries (``ufpo``/``a-span10``) match Whole Foods Market in-store (FOPO) line items
+    FIELD_ITEM_IMG_LINK_SELECTOR = ["a img",
+                                    "img.ufpo-itemListWidget-image"]
     FIELD_ITEM_QUANTITY_SELECTOR = [".od-item-view-qty",
                                     "span.item-view-qty",
                                     "span.product-image__qty"]
+    # Whole Foods Market in-store (FOPO) line items render quantity as "Qty: 1" / "Qty: 0.31 lb"; the
+    # whole-count value (if any) is extracted from the matching span in ``Item._parse_quantity``.
+    FIELD_ITEM_WHOLE_FOODS_QUANTITY_SELECTOR = ["span.a-size-small"]
     FIELD_ITEM_TITLE_SELECTOR = ["[data-component='itemTitle']",
-                                 ".yohtmlc-item a", ".yohtmlc-product-title"]
+                                 ".yohtmlc-item a", ".yohtmlc-product-title",
+                                 "div.a-column.a-span10 > a",
+                                 # Whole Foods Market line items without an Amazon detail page (ASINLESS)
+                                 # render the title in a span rather than a link
+                                 "div.a-column.a-span10 > span"]
     FIELD_ITEM_LINK_SELECTOR = ["[data-component='itemTitle'] a",
                                 ".yohtmlc-item a",
                                 "a:has(> .yohtmlc-product-title)",
-                                ".yohtmlc-product-title a"]
+                                ".yohtmlc-product-title a",
+                                "div.a-column.a-span10 > a"]
     FIELD_ITEM_TAG_ITERATOR_SELECTOR = [".yohtmlc-item div"]
     FIELD_ITEM_PRICE_SELECTOR = ["[data-component='unitPrice'] .a-text-price :not(.a-offscreen)",
-                                 ".yohtmlc-item .a-color-price"]
+                                 ".yohtmlc-item .a-color-price",
+                                 "div.a-section.a-text-right span.a-size-small"]
     FIELD_ITEM_SELLER_SELECTOR = ["[data-component='orderedMerchant']"] + FIELD_ITEM_TAG_ITERATOR_SELECTOR
     FIELD_ITEM_RETURN_SELECTOR = ["[data-component='itemReturnEligibility']"] + FIELD_ITEM_TAG_ITERATOR_SELECTOR
 
@@ -138,7 +166,10 @@ class Selectors:
     FIELD_ORDER_DETAILS_LINK_SELECTOR = ["a.yohtmlc-order-details-link",
                                          # Would like to use this or similar, but not yet sure how consistent it is
                                          # ".order-header__header-link-list-item:first-of-type a"
-                                         ]
+                                         # Whole Foods Market receipt orders and in-store (FOPO) purchases link to
+                                         # dedicated detail pages rather than the standard order-details endpoint
+                                         "a[href*='/wholefoodsmarket/receipts/order/']",
+                                         "a[href*='/fopo/order-details']"]
     FIELD_ORDER_NUMBER_SELECTOR = ["[data-component='orderId']",
                                    "[data-component='briefOrderInfo'] div.a-column",
                                    ".order-date-invoice-item :is(bdi, span)[dir='ltr']",
@@ -146,7 +177,15 @@ class Selectors:
                                    ":is(bdi, span)[dir='ltr']"]
     FIELD_ORDER_GRAND_TOTAL_SELECTOR = ["div.yohtmlc-order-total span.value",
                                         "div.order-header div.a-column.a-span2",
-                                        "div.order-header div.a-col-left .a-span9"]
+                                        "div.order-header div.a-col-left .a-span9",
+                                        # Whole Foods Market in-store (FOPO) order details page
+                                        "#wfm-grand-total-amount"]
+    # The "Purchase Summary" amounts on the Whole Foods Market in-store (FOPO) order details page
+    FIELD_ORDER_WHOLE_FOODS_SUBTOTAL_SELECTOR = "#wfm-subtotal-amount"
+    FIELD_ORDER_WHOLE_FOODS_TAX_SELECTOR = "#wfm-tax-total-amount"
+    # The first "Payment Methods" entry on the Whole Foods Market in-store (FOPO) order details page
+    FIELD_ORDER_WHOLE_FOODS_PAYMENT_METHOD_SELECTOR = "#wfm-0-card-brand"
+    FIELD_ORDER_WHOLE_FOODS_PAYMENT_LAST_4_SELECTOR = "#wfm-0-card-tail"
     FIELD_ORDER_PLACED_DATE_SELECTOR = ["[data-component='orderDate']",
                                         "span.order-date-invoice-item",
                                         "[data-component='briefOrderInfo'] div.a-column",
@@ -162,6 +201,12 @@ class Selectors:
     FIELD_ORDER_ADDRESS_FALLBACK_1_SELECTOR = "div.recipient span.a-declarative"
     FIELD_ORDER_ADDRESS_FALLBACK_2_SELECTOR = "script[id^='shipToData']"
     FIELD_ORDER_GIFT_CARD_INSTANCE_SELECTOR = ".gift-card-instance"
+    # The candidate tags to scan for an "N items in this purchase" summary (e.g. Whole Foods Market and
+    # eGift orders); the count is extracted from the matching tag's text in ``Order._parse_item_count``.
+    # The summary renders in an unclassed ``span`` in the order card's right column, so scope to that
+    # column first and fall back to scanning every ``span`` if the layout differs.
+    FIELD_ORDER_ITEM_COUNT_SELECTOR = ["div.a-fixed-left-grid-col.a-col-right span",
+                                       "span"]
 
     #####################################
     # CSS selectors for Shipment fields

--- a/tests/resources/orders/order-details-fopo-113-4055495-4107437.html
+++ b/tests/resources/orders/order-details-fopo-113-4055495-4107437.html
@@ -1,0 +1,4976 @@
+<!doctype html><html lang="en-us" class="a-no-js" data-19ax5a9jf="dingo"><!-- sp:feature:head-start -->
+<head><script>var aPageStart = (new Date()).getTime();</script><meta charset="utf-8"/>
+<!-- sp:end-feature:head-start -->
+<!-- sp:feature:csm:head-open-part1 -->
+
+<script type='text/javascript'>var ue_t0=ue_t0||+new Date();</script>
+<!-- sp:end-feature:csm:head-open-part1 -->
+<!-- sp:feature:cs-optimization -->
+<meta http-equiv='x-dns-prefetch-control' content='on'>
+<link rel="preconnect" href="https://images-na.ssl-images-amazon.com" crossorigin>
+<link rel="preconnect" href="https://m.media-amazon.com" crossorigin>
+<!-- sp:end-feature:cs-optimization -->
+<!-- sp:feature:csm:head-open-part2 -->
+<script type='text/javascript'>
+window.ue_ihb = (window.ue_ihb || window.ueinit || 0) + 1;
+if (window.ue_ihb === 1) {
+
+var ue_csm = window,
+    ue_hob = +new Date();
+(function(d){var e=d.ue=d.ue||{},f=Date.now||function(){return+new Date};e.d=function(b){return f()-(b?0:d.ue_t0)};e.stub=function(b,a){if(!b[a]){var c=[];b[a]=function(){c.push([c.slice.call(arguments),e.d(),d.ue_id])};b[a].replay=function(b){for(var a;a=c.shift();)b(a[0],a[1],a[2])};b[a].isStub=1}};e.exec=function(b,a){return function(){try{return b.apply(this,arguments)}catch(c){ueLogError(c,{attribution:a||"undefined",logLevel:"WARN"})}}}})(ue_csm);
+
+
+    var ue_err_chan = 'jserr-rw';
+(function(d,e){function h(f,b){if(!(a.ec>a.mxe)&&f){a.ter.push(f);b=b||{};var c=f.logLevel||b.logLevel;c&&c!==k&&c!==m&&c!==n&&c!==p||a.ec++;c&&c!=k||a.ecf++;b.pageURL=""+(e.location?e.location.href:"");b.logLevel=c;b.attribution=f.attribution||b.attribution;a.erl.push({ex:f,info:b})}}function l(a,b,c,e,g){d.ueLogError({m:a,f:b,l:c,c:""+e,err:g,fromOnError:1,args:arguments},g?{attribution:g.attribution,logLevel:g.logLevel}:void 0);return!1}var k="FATAL",m="ERROR",n="WARN",p="DOWNGRADED",a={ec:0,ecf:0,
+pec:0,ts:0,erl:[],ter:[],buffer:[],mxe:50,startTimer:function(){a.ts++;setInterval(function(){d.ue&&a.pec<a.ec&&d.uex("at");a.pec=a.ec},1E4)}};l.skipTrace=1;h.skipTrace=1;h.isStub=1;d.ueLogError=h;d.ue_err=a;e.onerror=l})(ue_csm,window);
+
+
+var ue_id = 'RBWFGARJB4TBW5KMJP91',
+    ue_url = '/rd/uedata',
+    ue_drfp = true,
+    ue_navtiming = 1,
+    ue_mid = 'ATVPDKIKX0DER',
+    ue_sid = '147-7999693-6862434',
+    ue_sn = 'www.amazon.com',
+    ue_furl = 'fls-na.amazon.com',
+    ue_surl = 'https://unagi.amazon.com/1/events/com.amazon.csm.nexusclient.prod',
+    ue_int = 0,
+    ue_fcsn = 1,
+    ue_urt = 3,
+    ue_rpl_ns = 'cel-rpl',
+    ue_ddq = 1,
+    ue_fpf = '//fls-na.amazon.com/1/batch/1/OP/ATVPDKIKX0DER:147-7999693-6862434:RBWFGARJB4TBW5KMJP91$uedata=s:',
+    ue_sbuimp = 1,
+    ue_ibft = 0,
+    ue_lpsi = 6000,
+    ue_lob = '1',
+    ue_act = '-1',
+    ue_dsbl_cel = 1,
+    ue_awsscrid = 1,
+
+    ue_swi = 1;
+var ue_viz=function(){(function(b,f,d){function g(){return(!(p in d)||0<d[p])&&(!(q in d)||0<d[q])}function h(c){if(b.ue.viz.length<w&&!r){var a=c.type;c=c.originalEvent;/^focus./.test(a)&&c&&(c.toElement||c.fromElement||c.relatedTarget)||(a=g()?f[s]||("blur"==a||"focusout"==a?t:u):t,b.ue.viz.push(a+":"+(+new Date-b.ue.t0)),a==u&&(b.ue.isl&&x("at"),r=1))}}for(var r=0,x=b.uex,a,k,l,s,v=["","webkit","o","ms","moz"],e=0,m=1,u="visible",t="hidden",p="innerWidth",q="innerHeight",w=20,n=0;n<v.length&&!e;n++)if(a=
+v[n],k=(a?a+"H":"h")+"idden",e="boolean"==typeof f[k])l=a+"visibilitychange",s=(a?a+"V":"v")+"isibilityState";h({});e&&f.addEventListener(l,h,0);m=g()?1:0;d.addEventListener("resize",function(){var a=g()?1:0;m!==a&&(m=a,h({}))},{passive:!0});b.ue&&e&&(b.ue.pageViz={event:l,propHid:k})})(ue_csm,ue_csm.document,ue_csm.window)};window.ue_viz=ue_viz;
+
+(function(d,k,R){function I(a){return a&&a.replace&&a.replace(/^\s+|\s+$/g,"")}function w(a){return"undefined"===typeof a}function M(a){return"function"===typeof a}function G(a,b){for(var c in b)b[x](c)&&(a[c]=b[c])}function N(a){try{var b=R.cookie.match(RegExp("(^| )"+a+"=([^;]+)"));if(b)return b[2].trim()}catch(c){}}function S(l,b,c){var s=(E||{}).type;if("device"!==c||2!==s&&1!==s){if(l){d.ue_id=a.id=a.rid=l;if("device"===c||"pre-fetch"===c)a.oid=I(l);p&&(p=p.replace(/((.*?:){2})(\w+)/,function(a,
+b){return b+l}));J&&(e("id",J,l),J=0)}b&&(p&&(p=p.replace(/(.*?:)(\w|-)+/,function(a,c){return c+b})),d.ue_sid=b);c&&a.tag("page-source:"+c);d.ue_fpf=p}}function T(){var a={};return function(b){b&&(a[b]=1);b=[];for(var c in a)a[x](c)&&b.push(c);return b}}function F(d,b,c,s){s=s||+new K;var f,k;if(b||w(c)){if(d)for(k in f=b?e("t",b)||e("t",b,{}):a.t,f[d]=s,c)c[x](k)&&e(k,b,c[k]);return s}}function e(d,b,c){var e=b&&b!=a.id?a.sc[b]:a;e||(e=a.sc[b]={});"id"===d&&c&&(U=1);return e[d]=c||e[d]}function V(d,
+b,c,e,k){c="on"+c;var f=b[c];M(f)?d&&(a.h[d]=f):f=function(){};b[c]=function(a){k?(e(a),f(a)):(f(a),e(a))};b[c]&&(b[c].isUeh=1)}function W(l,b,c,s){function z(b,c,g){b=[b];var f=0,s={},m,h;u.latency={};c?(b.push("m=1"),s[c]=1):s=a.sc;for(h in s)if(s[x](h)){var z=e("wb",h),n=e("t",h)||{},v=e("t0",h)||a.t0,r,q;if(c||2==z){r=z?f++:"";b.push("sc"+r+"="+h);var p=A,t=A;2==z&&k.csa?(t=(p=d.ue_awsscrid?k.csa("Content",{element:{type:"scope",slotId:h,csmRequestId:""+g}}):k.csa("Content",{element:{type:"scope",
+slotId:h}}))&&M(p))&&+v&&p("mark","t0",+v):p=t=A;for(q in n)w(n[q])||null===n[q]||(b.push(q+r+"="+(n[q]-v)),t&&p("mark",X[q]||q,+n[q]));b.push("t"+r+"="+n[l]);u.latency["t"+r]=n[l];if(e("ctb",h)||e("wb",h))m=1}}!D&&m&&b.push("ctb=1");return b.join("&")}function v(b,c,g,e,l){if(!(!b||d.ue_swsfp&&e)){var f=d.ue_err;d.ue_url&&!d.ue_drfp&&!e&&!l&&b&&0<b.length&&(e=new Image,a.iel.push(e),e.src=b,a.count&&a.count("postbackImageSize",b.length));p?(l=k.encodeURIComponent)&&b&&(e=new Image,b=""+d.ue_fpf+
+l(b)+":"+(+new K-d.ue_t0),a.iel.push(e),e.src=b):a.log&&(a.log(b,"uedata",{n:1}),a.ielf.push(b));f&&!f.ts&&f.startTimer();a.b&&(f=a.b,a.b="",v(f,c,g,1))}}function r(b){var c=E?E.type:A,d=2==c||a.isBFonMshop,c=c&&!d,e=a.bfini;if(!U||a.isBFCache)e&&1<e&&(b+="&bfform=1",c||(a.isBFT=e-1)),d&&(b+="&bfnt=1",a.isBFT=a.isBFT||1),a.ssw&&a.isBFT&&(a.isBFonMshop&&(a.isNRBF=0),w(a.isNRBF)&&(d=a.ssw(a.oid),d.e||w(d.val)||(a.isNRBF=1<d.val?0:1)),w(a.isNRBF)||(b+="&nrbf="+a.isNRBF)),a.isBFT&&!a.isNRBF&&(b+="&bft="+
+a.isBFT);return b}if(!a.paused&&(b||w(c))){for(var m in c)c[x](m)&&e(m,b,c[m]);a.isBFonMshop||F("pc",b,c);m="ld"===l&&b&&e("wb",b);var B=!d.ue_swsfp||!m,n=e("id",b)||a.id;m||n===a.oid||(J=b,ga(n,(e("t",b)||{}).tc||+e("t0",b),+e("t0",b),e("pty",b),e("spty",b)));var C=e("id",b)||a.id,q=e("id2",b)||d.ue_id2,g=a.url+"?"+l+"&v="+a.v+"&id="+C,D=e("ctb",b)||e("wb",b),u={eventName:l,version:a.v,id:C,sessionId:d.ue_sid||"",obfuscatedMarketplaceId:d.ue_mid||""},t;D&&(g+="&ctb="+D);q&&(g+="&id2="+q);1<d.ueinit&&
+(g+="&ic="+d.ueinit);if(!("ld"!=l&&"ul"!=l||b&&b!=C)){if("ld"==l){try{k[O]&&k[O].isUeh&&(k[O]=null)}catch(N){}if(k.chrome)for(q=0;q<P.length;q++)Y(L,P[q]);(q=R.ue_backdetect)&&q.ue_back&&q.ue_back.value++;d._uess&&(t=d._uess());a.isl=1}B&&a._bf&&(g+="&bf="+a._bf());d.ue_navtiming&&f&&(e("ctb",C,"1"),a.isBFonMshop||F("tc",A,A,Q));B&&H&&!a.isBFonMshop&&!Z&&(f&&G(a.t,{na_:f.navigationStart,ul_:f.unloadEventStart,_ul:f.unloadEventEnd,rd_:f.redirectStart,_rd:f.redirectEnd,fe_:f.fetchStart,lk_:f.domainLookupStart,
+_lk:f.domainLookupEnd,co_:f.connectStart,_co:f.connectEnd,sc_:f.secureConnectionStart,rq_:f.requestStart,rs_:f.responseStart,_rs:f.responseEnd,dl_:f.domLoading,di_:f.domInteractive,de_:f.domContentLoadedEventStart,_de:f.domContentLoadedEventEnd,_dc:f.domComplete,ld_:f.loadEventStart,_ld:f.loadEventEnd,ntd:(M(H.now)&&!w(Q)?new K(Q+H.now())-new K:0)+a.t0}),E&&G(a.t,{ty:E.type+a.t0,rc:E.redirectCount+a.t0}),Z=1);a.isBFonMshop||G(a.t,{hob:d.ue_hob,hoe:d.ue_hoe});a.ifr&&(g+="&ifr=1",u.ifr=!0)}F(l,b,c,
+s);var y,h;m||b&&b!==C||ha(b);c=d.ue_mbl;B&&c&&c.cnt&&!m&&(g+=c.cnt());m?e("wb",b,2):"ld"==l&&(a.lid=I(C));for(y in a.sc)if(1==e("wb",y))break;if(m){if(a.s)return;g=z(g,null,n)}else c=z(g,null,n),c!=g&&(c=r(c),a.b=c),t&&(g+=t),g=z(g,b||a.id,n);g=r(g);if(a.b||m)for(y in a.sc)2==e("wb",y)&&delete a.sc[y];y=0;B&&a._rt&&(g+="&rt="+a._rt());t=k.csa;if(!m&&t)for(h in n=e("t",b)||{},c=t("PageTiming"),n)n[x](h)&&c("mark",X[h]||h,n[h]);m||(a.s=0,(h=d.ue_err)&&0<h.ec&&h.pec<h.ec&&(h.pec=h.ec,g+="&ec="+h.ec+
+"&ecf="+h.ecf),y=e("ctb",b),"ld"!==l||b||a.markers?a.markers&&a.isl&&!m&&b&&G(a.markers,e("t",b)):(a.markers={},G(a.markers,e("t",b))),e("t",b,{}));B&&a.tag&&a.tag().length&&(g+="&csmtags="+a.tag().join("|"),u.csmtags=a.tag(),a.tag=T());h=a.viz||[];n=h.length;B&&n&&(h=h.splice(0,n),g+="&viz="+h.join("|"),u.viz=h);w(d.ue_pty)||(g+="&pty="+d.ue_pty+"&spty="+d.ue_spty+"&pti="+d.ue_pti,u.pty=d.ue_pty,u.spty=d.ue_spty,u.pti=d.ue_pti);a.tabid&&(g+="&tid="+a.tabid);a.aftb&&(g+="&aftb=1");!B||!a._ui||b&&
+b!=C||(g+=a._ui());g+="&lob="+(d.ue_lob||"0");a.a=g;v(g,l,y,m,b&&"string"===typeof b&&-1!==b.indexOf("csa:"));m||(u.lob=d.ue_lob||"0",u.browserData=g,(b=t&&t("UEData"))&&b("log",u))}}function ha(a){var b=k.ue_csm_markers||{},c;for(c in b)b[x](c)&&F(c,a,A,b[c])}function D(a,b,c){c=c||k;if(c[$])c[$](a,b,!1);else if(c[aa])c[aa]("on"+a,b)}function Y(a,b,c){c=c||k;if(c[ba])c[ba](a,b,!1);else if(c[ca])c[ca]("on"+a,b)}function da(){function a(){d.onUl()}function b(a){return function(){c[a]||(c[a]=1,W(a))}}
+var c={},e,f;d.onLd=b("ld");d.onLdEnd=b("ld");d.onUl=b("ul");e={stop:b("os")};k.chrome?(D(L,a),P.push(a)):e[L]=d.onUl;for(f in e)e[x](f)&&V(0,k,f,e[f]);d.ue_viz&&ue_viz();D("load",d.onLd);F("ue")}function ga(e,b,c,f,p){var v=d.ue_mbl,r=k.csa,m=r&&r("SPA"),r=r&&r("PageTiming");v&&v.ajax&&v.ajax(b,c);m&&r&&(e={requestId:e,transitionType:"soft"},"string"===typeof f&&(e.pageType=f,d.ue_pty=f),"string"===typeof p&&(e.subPageType=p,d.ue_spty=p),m("newPage",e),r("mark","transitionStart",b));a.tag("ajax-transition")}
+d.ueinit=(d.ueinit||0)+1;var a=d.ue=d.ue||{};a.t0=k.aPageStart||d.ue_t0;a.id=d.ue_id;a.url=d.ue_url;a.rid=d.ue_id;a.a="";a.b="";a.h={};a.s=1;a.t={};a.sc={};a.iel=[];a.ielf=[];a.viz=[];a.v="0.348446.0";a.paused=!1;var x="hasOwnProperty",L="beforeunload",O="on"+L,$="addEventListener",ba="removeEventListener",aa="attachEvent",ca="detachEvent",X={cf:"criticalFeature",af:"aboveTheFold",fn:"functional",fp:"firstPaint",fcp:"firstContentfulPaint",bb:"bodyBegin",be:"bodyEnd",ld:"loaded"},K=k.Date,H=k.performance||
+k.webkitPerformance,f=(H||{}).timing,E=(H||{}).navigation,Q=(f||{}).navigationStart,p=d.ue_fpf,U=0,Z=0,P=[],J=0,A;a.oid=I(a.id);a.lid=I(a.id);a._t0=a.t0;a.tag=T();a.ifr=k.top!==k.self||k.frameElement?1:0;a.markers=null;a.attach=D;a.detach=Y;if("000-0000000-8675309"===d.ue_sid){var ea=N("cdn-rid"),fa=N("session-id");ea&&fa&&S(ea,fa,"cdn")}d.uei=da;d.ueh=V;d.ues=e;d.uet=F;d.uex=W;a.reset=S;a.pause=function(d){a.paused=d};da()})(ue_csm,ue_csm.window,ue_csm.document);
+
+
+ue.stub(ue,"event");ue.stub(ue,"onSushiUnload");ue.stub(ue,"onSushiFlush");
+
+ue.stub(ue,"log");ue.stub(ue,"onunload");ue.stub(ue,"onflush");
+(function(b){var a=b.ue;a.cv={};a.cv.scopes={};a.cv.buffer=[];a.count=function(b,d,c){var e=a.cv;a.d();c&&c.scope&&(e=a.cv.scopes[c.scope]=a.cv.scopes[c.scope]||{});if(void 0===d)return e[b];e[b]=d;a.cv.buffer.push({c:b,v:d})};a.count("baselineCounter2",1);a&&a.event&&(a.event({requestId:b.ue_id||"rid",server:b.ue_sn||"sn",obfuscatedMarketplaceId:b.ue_mid||"mid"},"csm","csm.CSMBaselineEvent.4"),a.count("nexusBaselineCounter",1,{bf:1}))})(ue_csm);
+
+
+(function(g,h,l){if("function"===typeof h.addEventListener&&"function"===typeof l.querySelectorAll){var e,r=["mouseenter","mouseleave"],t="click dblclick mousedown mouseover mouseout touchstart keydown keypress MSPointerDown pointerdown focusin".split(" ").concat(r),n=!1,p=[];var u=function(a){for(var b=[];a;)b.push(a),a=a.parentNode;return b};var q=function(a,b){var d=-1,c;for(c=0;c<b.length;c++)if(b[c]===a){d=c;break}return d};var v=function(a,b){a=q(a,b);0<=a&&b.splice(a,1)};var x=function(a){a=
+u(a);for(var b,d,c=0;c<a.length;c++)if(d=a[c],(b=d.nodeName)&&b!==l.nodeName){b=b.toLowerCase();if(d.id)return b+"#"+d.id+(f?">"+f:"");(d=d.getAttribute("class"))&&(b=b+"."+d.split(" ").join("."));var f=b+(f?">"+f:"")}return f};var y=function(a){return a.replace(/[^\w.:\-]/g,function(a){return"#"===a?"::":">"===a?":-":"_"})};var w=function(a,b){if(g.ue&&g.ue.count&&g.ueLogError){a=x(a);var d=y(a);var c="degraded"===b?"A UX degrading element has entered the viewport: "+a:"A "+b+" was not handled on element: "+
+a;g.ueLogError({m:c,fromOnError:1},{logLevel:"ERROR",attribution:a,message:c});b=["TNR","TNR:"+b,"TNR:"+d,"TNR:"+b+":"+d];for(e=0;e<b.length;e++)g.ue.count(b[e],(g.ue.count(b[e])||0)+1)}};var z=function(a){a=a.getBoundingClientRect();return a.top<a.bottom&&a.left<a.right&&0<=a.bottom&&a.top<=h.innerHeight&&0<=a.right&&a.left<=h.innerWidth};var m=function(){n||(n=!0,setTimeout(function(){[].forEach.call(l.querySelectorAll("[data-ux-degraded]"),function(a){z(a)?0>q(a,p)&&(p.push(a),w(a,"degraded")):
+v(a,p)});n=!1},250))};h.addEventListener("scroll",m);h.addEventListener("resize",m);m=function(a){var b=!1,d=0>q(a,r);l.addEventListener(a,function(c){if(!b){b=!0;var f=[],e=d?u(c.target):[c.target],g,h;for(g=0;g<e.length;g++){var k=e[g];k.getAttribute&&("mouseover"===a&&k===c.target&&((h=k.getAttribute("data-ux-jq-mouseenter"))||""===h)&&f.push(k),((h=k.getAttribute("data-ux-"+a))||""===h)&&f.push(k))}f.length?(c.ack=c.acknowledge=function(a){a=a||c.currentTarget;v(a,f)},setTimeout(function(){var c;
+for(c=0;c<f.length;c++)w(f[c],a);b=!1},250)):b=!1}},!0)};for(e=0;e<t.length;e++)m(t[e])}})(ue_csm,window,document);
+
+
+var ue_hoe = +new Date();
+}
+window.ueinit = window.ue_ihb;
+</script>
+
+<!-- 10cmoclgjq1adc49a2sdua95 -->
+<script>window.ue && ue.count && ue.count('CSMLibrarySize', 12848)</script>
+<!-- sp:end-feature:csm:head-open-part2 -->
+<!-- sp:feature:aui-assets -->
+<link rel="stylesheet" href="https://m.media-amazon.com/images/I/21uDPuQuYwL._RC|51SvmD+jTBL.css_.css?AUIClients/AmazonUI" />
+<link rel="stylesheet" href="https://m.media-amazon.com/images/I/11WsGYSItxL._RC|01DE6WSvLKL.css,41ixaNR85ML.css,31LMk2aP6xL.css,21JMC7OC91L.css,01xH+fhFIJL.css,0168Xo81wHL.css,413Vvv3GONL.css,1170nDgl0uL.css,01Rw4F+QU6L.css,11NeGmEx+fL.css,01LmAy9LJTL.css,01IdKcBuAdL.css,01iHqjS7YfL.css,01eVBHHaY+L.css,21D3IemrALL.css,11pDJV08stL.css,51yqRfvysvL.css,01HWrzt-WgL.css,01XPHJk60-L.css,11aX6hlPzjL.css,01GAxF7K5tL.css,01ZM-s8Z3xL.css,21gEzBqpmtL.css,11FeoxrgiyL.css,21TxBPhrLyL.css,01rSTIgNJIL.css,21Dt9D2TuML.css,31GD5I7tbCL.css,01i092IYHUL.css,01oaPOLX+-L.css,31Qk3MvcMIL.css,11PDZ29p-PL.css,11kbPm9N5xL.css,215WpAjwzoL.css,11sUwulETuL.css,114aTS6SjML.css,01xFKTPySiL.css,21GcfcmbahL.css,21OD8FuBraL.css,11XozyxiH7L.css,21n1oEPZnHL.css,11HVvPbE6JL.css,119Cktja74L.css,11PMguLK6gL.css,01890+Vwk8L.css,11TZSntL0oL.css,01qiwJ7qDfL.css,21AS3Iv3HQL.css,016mfgi+D2L.css,01VinDhK+DL.css,31un+UKeIeL.css,21msrr4h2yL.css,013-xYw+SRL.css_.css?AUIClients/AmazonUI#us.not-trident.1353409-T2" />
+<script>
+(function(b,a,c,d){if((b=b.AmazonUIPageJS||b.P)&&b.when&&b.register){c=[];for(a=a.currentScript;a;a=a.parentElement)a.id&&c.push(a.id);return b.log("A copy of P has already been loaded on this page.","FATAL",c.join(" "))}})(window,document,Date);(function(a,b,c,d){"use strict";a._pSetI=function(){return null}})(window,document,Date);(function(c,e,I,B){"use strict";c._pd=function(){var a,u;return function(C,f,h,k,b,D,v,E,F){function w(d){try{return d()}catch(J){return!1}}function l(){if(m){var d={w:c.innerWidth||b.clientWidth,h:c.innerHeight||b.clientHeight};5<Math.abs(d.w-q.w)||50<d.h-q.h?(q=d,n=4,(d=a.mobile||a.tablet?450<d.w&&d.w>d.h:1250<=d.w)?k(b,"a-ws"):b.className=v(b,"a-ws")):0<n&&(n--,x=setTimeout(l,16))}}function G(d){(m=d===B?!m:!!d)&&l()}function H(){return m}if(!u){u=!0;var r=function(){var d=["O","ms","Moz","Webkit"],
+c=e.createElement("div");return{testGradients:function(){return!0},test:function(a){var b=a.charAt(0).toUpperCase()+a.substr(1);a=(d.join(b+" ")+b+" "+a).split(" ");for(b=a.length;b--;)if(""===c.style[a[b]])return!0;return!1},testTransform3d:function(){return!0}}}(),y=b.className,z=/(^| )a-mobile( |$)/.test(y),A=/(^| )a-tablet( |$)/.test(y);a={audio:function(){return!!e.createElement("audio").canPlayType},video:function(){return!!e.createElement("video").canPlayType},canvas:function(){return!!e.createElement("canvas").getContext},
+svg:function(){return!!e.createElementNS&&!!e.createElementNS("http://www.w3.org/2000/svg","svg").createSVGRect},offline:function(){return navigator.hasOwnProperty&&navigator.hasOwnProperty("onLine")&&navigator.onLine},dragDrop:function(){return"draggable"in e.createElement("span")},geolocation:function(){return!!navigator.geolocation},history:function(){return!(!c.history||!c.history.pushState)},webworker:function(){return!!c.Worker},autofocus:function(){return"autofocus"in e.createElement("input")},
+inputPlaceholder:function(){return"placeholder"in e.createElement("input")},textareaPlaceholder:function(){return"placeholder"in e.createElement("textarea")},localStorage:function(){return"localStorage"in c&&null!==c.localStorage},orientation:function(){return"orientation"in c},touch:function(){return"ontouchend"in e},gradients:function(){return r.testGradients()},hires:function(){var a=c.devicePixelRatio&&1.5<=c.devicePixelRatio||c.matchMedia&&c.matchMedia("(min-resolution:144dpi)").matches;E("hiRes"+
+(z?"Mobile":A?"Tablet":"Desktop"),a?1:0);return a},transform3d:function(){return r.testTransform3d()},touchScrolling:function(){return f(/Windowshop|android|OS ([5-9]|[1-9][0-9]+)(_[0-9]{1,2})+ like Mac OS X|SOFTWARE=([5-9]|[1-9][0-9]+)(.[0-9]{1,2})+.*DEVICE=iPhone|Chrome|Silk|Firefox|Trident.+?; Touch/i)},ios:function(){return f(/OS [1-9][0-9]*(_[0-9]*)+ like Mac OS X/i)&&!f(/trident|Edge/i)},android:function(){return f(/android.([1-9]|[L-Z])/i)&&!f(/trident|Edge/i)},mobile:function(){return z},
+tablet:function(){return A},rtl:function(){return"rtl"===b.dir}};for(var g in a)a.hasOwnProperty(g)&&(a[g]=w(a[g]));for(var t="textShadow textStroke boxShadow borderRadius borderImage opacity transform transition".split(" "),p=0;p<t.length;p++)a[t[p]]=w(function(){return r.test(t[p])});var m=!0,x=0,q={w:0,h:0},n=4;l();h(c,"resize",function(){clearTimeout(x);n=4;l()});b.className=v(b,"a-no-js");k(b,"a-js");!f(/OS [1-8](_[0-9]*)+ like Mac OS X/i)||c.navigator.standalone||f(/safari/i)||k(b,"a-ember");
+h=[];for(g in a)a.hasOwnProperty(g)&&a[g]&&h.push("a-"+g.replace(/([A-Z])/g,function(a){return"-"+a.toLowerCase()}));k(b,h.join(" "));b.setAttribute("data-aui-build-date",F);C.register("p-detect",function(){return{capabilities:a,localStorage:a.localStorage&&D,toggleResponsiveGrid:G,responsiveGridEnabled:H}});return a||{}}}}()})(window,document,Date);(function(a,p,q,k){function m(e,b,c,g){a.P.when.apply(a.P,b).register("flow:"+e,function(){var a=g.apply(this,arguments);return c||a})}function l(e){a.P.log(e,"FATAL","AmazonUIPageJS@AUIDefineJS")}function f(a,b,c){Object.defineProperty(a,b,{value:c,writable:!1})}function n(e,b,c){"string"!==typeof e&&a.P.error("Anonymous modules are not supported.");var g=c!==k?c:"function"===typeof b?b:k;g||a.P.error("A callback must be provided");var f,h=[];if(c&&Array.isArray(b)&&(h=b.reduce(function(b,d){if("module"===
+d||"require"===d)a.P.error('"module" or "require" injection is not supported.');else if("exports"===d){d=f={};var c="flow:"+e+"-exports";a.P.declare(c,d);b.push(c)}else 0!==d.lastIndexOf("@amzn/",0)?l("Dependency "+d+" does not begin with '@amzn/'"):b.push("flow:"+d);return b},[]),b.length!==h.length))return;m(e,h,f,g)}"use strict";Object.prototype.hasOwnProperty.call(a,"aui")?l("AUIDefineJS is already present globally"):(f(a,"aui",{}),f(a.aui,"amd_define",n))})(window,document,Date);(function(g,h,C,D){function K(a){l&&l.tag&&l.tag(p(":","aui",a))}function q(a,b){l&&l.count&&l.count("aui:"+a,0===b?0:b||(l.count("aui:"+a)||0)+1)}function L(a){try{return a.test(navigator.userAgent)}catch(b){return!1}}function x(a,b,c){a.addEventListener?a.addEventListener(b,c,!1):a.attachEvent&&a.attachEvent("on"+b,c)}function p(a,b,c,f){b=b&&c?b+a+c:b||c;return f?p(a,b,f):b}function y(a,b,c){try{Object.defineProperty(a,b,{value:c,writable:!1})}catch(f){a[b]=c}return c}function M(a,b){a.className=
+N(a,b)+" "+b}function N(a,b){return(" "+a.className+" ").split(" "+b+" ").join(" ").replace(/^ | $/g,"")}function aa(a,b,c){var f=c=a.length,e=function(){f--||(E.push(b),F||(m?m.set(z):setTimeout(z,0),F=!0))};for(e();c--;)O[a[c]]?e():(u[a[c]]=u[a[c]]||[]).push(e)}function ba(a,b,c,f,e){var d=h.createElement(a?"script":"link");x(d,"error",f);e&&x(d,"load",e);a?(d.type="text/javascript",d.async=!0,c&&/AUIClients|images[/]I/.test(b)&&d.setAttribute("crossorigin","anonymous"),d.src=b):(d.rel="stylesheet",
+d.href=b);h.getElementsByTagName("head")[0].appendChild(d)}function P(a,b){return function(c,f){function e(){ba(b,c,d,function(b){G?q("resource_unload"):d?(d=!1,q("resource_retry"),e()):(q("resource_error"),a.log("Asset failed to load: "+c));b&&b.stopPropagation?b.stopPropagation():g.event&&(g.event.cancelBubble=!0)},f)}if(Q[c])return!1;Q[c]=!0;q("resource_count");var d=!0;return!e()}}function ca(a,b,c){for(var f={name:a,guard:function(c){return b.guardFatal(a,c)},guardTime:function(a){return b.guardTime(a)},
+logError:function(c,d,e){b.logError(c,d,e,a)}},e=[],d=0;d<c.length;d++)A.hasOwnProperty(c[d])&&(e[d]=H.hasOwnProperty(c[d])?H[c[d]](A[c[d]],f):A[c[d]]);return e}function v(a,b,c,f,e){return function(d,k){function n(){var a=null;f?a=k:"function"===typeof k&&(q.start=r(),a=k.apply(g,ca(d,h,l)),q.end=r());if(b){A[d]=a;a=d;for(O[a]=!0;(u[a]||[]).length;)u[a].shift()();delete u[a]}q.done=!0}var h=e||this;"function"===typeof d&&(k=d,d=D);b&&(d=d?d.replace(R,""):"__NONAME__",I.hasOwnProperty(d)&&h.error(p(", reregistered by ",
+p(" by ",d+" already registered",I[d]),h.attribution),d),I[d]=h.attribution);for(var l=[],m=0;m<a.length;m++)l[m]=a[m].replace(R,"");var q=w[d||"anon"+ ++da]={depend:l,registered:r(),namespace:h.namespace};d&&ea.hasOwnProperty(d);c?n():aa(l,h.guardFatal(d,n),d);return{decorate:function(a){H[d]=h.guardFatal(d,a)}}}}function S(a){return function(){var b=Array.prototype.slice.call(arguments);return{execute:v(b,!1,a,!1,this),register:v(b,!0,a,!1,this)}}}function J(a,b){return function(c,f){f||(f=c,c=
+D);var e=this.attribution;return function(){n.push(b||{attribution:e,name:c,logLevel:a});var d=f.apply(this,arguments);n.pop();return d}}}function B(a,b){this.load={js:P(this,!0),css:P(this)};y(this,"namespace",b);y(this,"attribution",a)}function T(){h.body?k.trigger("a-bodyBegin"):setTimeout(T,20)}"use strict";var t=C.now=C.now||function(){return+new C},r=function(a){return a&&a.now?a.now.bind(a):t}(g.performance),fa=r(),ea={},l=g.ue;K();K("aui_build_date:3.26.5-2026-06-03");var U={getItem:function(a){try{return g.localStorage.getItem(a)}catch(b){}},
+setItem:function(a,b){try{return g.localStorage.setItem(a,b)}catch(c){}}},m=g._pSetI(),E=[],ha=[],F=!1,ia=navigator.scheduling&&"function"===typeof navigator.scheduling.isInputPending;var z=function(){for(var a=m?m.set(z):setTimeout(z,0),b=t();ha.length||E.length;)if(E.shift()(),m&&ia){if(150<t()-b&&!navigator.scheduling.isInputPending()||50<t()-b&&navigator.scheduling.isInputPending())return}else if(50<t()-b)return;m?m.clear(a):clearTimeout(a);F=!1};var O={},u={},Q={},G=!1;x(g,"beforeunload",function(){G=
+!0;setTimeout(function(){G=!1},1E4)});var R=/^prv:/,I={},A={},H={},w={},da=0,ja=String.fromCharCode(92),n=[],V=!0,W=g.onerror;g.onerror=function(a,b,c,f,e){e&&"object"===typeof e||(e=Error(a,b,c),e.columnNumber=f,e.stack=b||c||f?p(ja,e.message,"at "+p(":",b,c,f)):D);var d=n.pop()||{};e.attribution=p(":",e.attribution||d.attribution,d.name);e.logLevel=d.logLevel;e.attribution&&console&&console.log&&console.log([e.logLevel||"ERROR",a,"thrown by",e.attribution].join(" "));n=[];W&&(d=[].slice.call(arguments),
+d[4]=e,W.apply(g,d))};B.prototype={logError:function(a,b,c,f){b={message:b,logLevel:c||"ERROR",attribution:p(":",this.attribution,f)};if(g.ueLogError)return g.ueLogError(a||b,a?b:null),!0;console&&console.error&&(console.log(b),console.error(a));return!1},error:function(a,b,c,f){a=Error(p(":",f,a,c));a.attribution=p(":",this.attribution,b);throw a;},guardError:J(),guardFatal:J("FATAL"),guardCurrent:function(a){var b=n[n.length-1];return b?J(b.logLevel,b).call(this,a):a},guardTime:function(a){var b=
+n[n.length-1],c=b&&b.name;return c&&c in w?function(){var b=r(),e=a.apply(this,arguments);w[c].async=(w[c].async||0)+r()-b;return e}:a},log:function(a,b,c){return this.logError(null,a,b,c)},declare:v([],!0,!0,!0),register:v([],!0),execute:v([]),AUI_BUILD_DATE:"3.26.5-2026-06-03",when:S(),now:S(!0),trigger:function(a,b,c){var f=t();this.declare(a,{data:b,pageElapsedTime:f-(g.aPageStart||NaN),triggerTime:f});c&&c.instrument&&X.when("prv:a-logTrigger").execute(function(b){b(a)})},handleTriggers:function(){this.log("handleTriggers deprecated")},
+attributeErrors:function(a){return new B(a)},_namespace:function(a,b){return new B(a,b)},setPriority:function(a){V?V=!1:this.log("setPriority only accept the first call.")}};var k=y(g,"AmazonUIPageJS",new B);var X=k._namespace("PageJS","AmazonUI");X.declare("prv:p-debug",w);k.declare("p-recorder-events",[]);k.declare("p-recorder-stop",function(){});y(g,"P",k);T();if(h.addEventListener){var Y;h.addEventListener("DOMContentLoaded",Y=function(){k.trigger("a-domready");h.removeEventListener("DOMContentLoaded",
+Y,!1)},!1)}var Z=h.documentElement,ka=g._pd(k,L,x,M,Z,U,N,q,"3.26.5-2026-06-03");L(/UCBrowser/i)||ka.localStorage&&M(Z,U.getItem("a-font-class"));k.declare("a-event-revised-handling",!1);k.declare("a-fix-event-off",!1);q("pagejs:pkgExecTime",r()-fa)})(window,document,Date);
+(function(d,G,I,J){function r(h){k&&k.tag&&k.tag(g(":","aui",h))}function e(h,d){k&&k.count&&k.count("aui:"+h,0===d?0:d||(k.count("aui:"+h)||0)+1)}function t(d){try{return d.test(navigator.userAgent)}catch(y){return!1}}function l(d){return"function"===typeof d}function w(d,g,e){d.addEventListener?d.addEventListener(g,e,!1):d.attachEvent&&d.attachEvent("on"+g,e)}function g(d,e,l,k){e=e&&l?e+d+l:e||l;return k?g(d,e,k):e}"use strict";var k=d.ue,A=String.fromCharCode(92),B=["webpack://@import/chromium-server/"];
+P.execute("RetailPageServiceWorker",function(){function h(a,b){m.controller&&a?(a={feature:"retail_service_worker_messaging",command:a},b&&(a.data=b),m.controller.postMessage(a)):a&&e("sw:sw_message_no_ctrl",1)}function y(a){var b=a.data;if(b&&"retail_service_worker_messaging"===b.feature&&b.command&&b.data){var c=b.data;a=d.ue;var f=d.ueLogError;switch(b.command){case "log_counter":a&&l(a.count)&&c.name&&a.count(c.name,0===c.value?0:c.value||1);break;case "log_tag":a&&l(a.tag)&&c.tag&&(a.tag(c.tag),
+b=d.uex,a.isl&&l(b)&&b("at"));break;case "log_error":f&&l(f)&&c.message&&f({message:c.message,logLevel:c.level||"ERROR",attribution:c.attribution||"RetailServiceWorker"});break;case "log_weblab_trigger":if(!c.weblab||!c.treatment)break;a&&l(a.trigger)?a.trigger(c.weblab,c.treatment):(e("sw:wt:miss"),e("sw:wt:miss:"+c.weblab+":"+c.treatment));break;default:e("sw:unsupported_message_command",1)}}}function v(a,b){return"sw:"+(b||"")+":"+a+":"}function z(a,b){try{m.register("/service-worker.js").then(function(){e(a+
+"success")}).catch(function(c){C(c,a,b)})}catch(c){C(c,a,b)}}function C(a,b,c){var f;a:{if(a&&"object"===typeof a&&"string"===typeof a.stack)for(f=0;f<B.length;f++)if(-1!==a.stack.indexOf(B[f])){f=!0;break a}f=!1}f?e(b+"error:suppressed"):(P.logError(a,"[AUI SW] Failed to "+c+" service worker: ","ERROR","RetailPageServiceWorker"),e(b+"failure"))}function D(){n.forEach(function(a){r(a)})}function q(a){return a.capabilities.isAmazonApp&&a.capabilities.android}function E(a,b,c){if(b)if(b.mshop&&q(a))a=
+v(c,"mshop_and"),b=b.mshop.action,n.push(a+"supported"),b(a,c);else if(b.browser){a=t(/Chrome/i)&&!t(/Edge/i)&&!t(/OPR/i)&&!a.capabilities.isAmazonApp&&!t(new RegExp(A+"bwv"+A+"b"));var f=b.browser;b=v(c,"browser");a?(a=f.action,n.push(b+"supported"),a(b,c)):n.push(b+"unsupported")}}function F(a,b,c){a&&n.push(v("register",c)+"unsupported");b&&n.push(v("unregister",c)+"unsupported");D()}try{var m=navigator.serviceWorker}catch(a){r("sw:nav_err")}(function(){if(m){var a=function(){h("page_loaded",{rid:d.ue_id,
+mid:d.ue_mid,pty:d.ue_pty,sid:d.ue_sid,spty:d.ue_spty,furl:d.ue_furl})};w(m,"message",y);h("client_messaging_ready");P.when("load").execute(a);w(m,"controllerchange",function(){h("client_messaging_ready");"complete"===G.readyState&&a()})}})();var n=[],p=function(a,b){var c=d.uex,f=d.uet;a=g(":","aui","sw",a);"ld"===b&&l(c)?c("ld",a,{wb:1}):l(f)&&f(b,a,{wb:1})},H=function(a,b,c){function f(a){b&&l(b.failure)&&b.failure(a)}function k(){n=setTimeout(function(){r(g(":","sw:"+h,u.TIMED_OUT));f({ok:!1,
+statusCode:u.TIMED_OUT,done:!1});p(h,"ld")},c||4E3)}var u={NO_CONTROLLER:"no_ctrl",TIMED_OUT:"timed_out",UNSUPPORTED_BROWSER:"unsupported_browser",UNEXPECTED_RESPONSE:"unexpected_response"},h=g(":",a.feature,a.command),n,q=!0;if("MessageChannel"in d&&m&&"controller"in m)if(m.controller){var t=new MessageChannel;t.port1.onmessage=function(c){(c=c.data)&&c.feature===a.feature&&c.command===a.command?(q&&(p(h,"cf"),q=!1),p(h,"af"),clearTimeout(n),c.done||k(),c.ok?b&&l(b.success)&&b.success(c):f(c),c.done&&
+p(h,"ld")):e(g(":","sw:"+h,u.UNEXPECTED_RESPONSE),1)};k();p(h,"bb");m.controller.postMessage(a,[t.port2])}else r(g(":","sw:"+a.feature,u.NO_CONTROLLER)),f({ok:!1,statusCode:u.NO_CONTROLLER,done:!0});else r(g(":","sw:"+a.feature,u.UNSUPPORTED_BROWSER)),f({ok:!1,statusCode:u.UNSUPPORTED_BROWSER,done:!0})};(function(){m?(p("ctrl_changed","bb"),m.addEventListener("controllerchange",function(){r("sw:ctrl_changed");p("ctrl_changed","ld")})):e(g(":","sw:ctrl_changed","sw_unsupp"),1)})();(function(){var a=
+function(){p(b,"ld");var a=d.uex;H({feature:"page_proxy",command:"request_feature_tags"},{success:function(b){b=b.data;Array.isArray(b)&&b.forEach(function(a){"string"===typeof a?r(g(":","sw:ppft",a)):e(g(":","sw:ppft","invalid_tag"),1)});e(g(":","sw:ppft","success"),1);k&&k.isl&&l(a)&&a("at")},failure:function(a){e(g(":","sw:ppft","error:"+(a.statusCode||"ppft_error")),1)}})};if("requestIdleCallback"in d){var b=g(":","ppft","callback_ricb");d.requestIdleCallback(a,{timeout:1E3})}else b=g(":","ppft",
+"callback_timeout"),setTimeout(a,0);p(b,"bb")})();var x={reg:{},unreg:{}};x.reg.mshop={action:z};x.reg.browser={action:z};(function(a){var b=a.reg,c=a.unreg;m&&m.getRegistrations?(P.when("A").execute(function(b){if((a.reg.mshop||a.unreg.mshop)&&"function"===typeof q&&q(b)){var f=a.reg.mshop?"T1":"C",g=d.ue;g&&g.trigger?g.trigger("MSHOP_SW_CLIENT_446196",f):e("sw:mshop:wt:failed")}E(b,c,"unregister")}),w(d,"load",function(){P.when("A").execute(function(a){E(a,b,"register");D()})})):(F(b&&b.browser,
+c&&c.browser,"browser"),P.when("A").execute(function(a){"function"===typeof q&&q(a)&&F(b&&b.mshop,c&&c.mshop,"mshop_and")}))})(x)})})(window,document,Date);
+'use strict';(function(b){function t(a,e,d){function h(a,b,c){var f=Array(e.length);~m&&(f[m]={});~n&&(f[n]=c);for(c=0;c<q.length;c++){var h=q[c],g=a[c];f[h]=g}for(c=0;c<p.length;c++)h=p[c],g=b[c],f[h]=g;a=d.apply(null,f);return~m?f[m]:a}"string"!==typeof a&&b.P.error("C001");var c=-1<a.indexOf("/")&&(-1<a.indexOf("es3")||-1<a.indexOf("evergreen")),r=c&&-1<a.indexOf("@");c&&!r&&(a=a.substring(0,a.lastIndexOf("/")));if(!w[a]){w[a]=!0;d||(d=e,e=[]);a=a.split(":",2);c=a[1]?a[0]:void 0;var g=(a[1]||a[0]).replace(/@capability\//,
+"@c/"),x=-1<g.indexOf("/")?g.split("/")[0]:g,l=c?b.P._namespace(c):b.P;a=!g.lastIndexOf("@c/",0);c=!g.lastIndexOf("@m/",0);for(var q=[],u=[],p=[],v=[],n=-1,m=-1,k=0;k<e.length;k++){var f=e[k];"module"===f&&l.error("C002");"exports"===f?m=k:"require"===f?n=k:f.lastIndexOf("@p/",0)?f.lastIndexOf("@c/",0)&&f.lastIndexOf("@m/",0)?f.lastIndexOf("./",0)?(q.push(k),u.push("mix:"+f)):(f=x+"/"+f.substr(2),p.push(k),v.push(f)):(p.push(k),v.push(f)):(q.push(k),u.push(f.substr(3)))}var y=a||c||r||~n||p.length;
+l.when.apply(l,u).register("mix:"+g,function(){var a=[].slice.call(arguments);return y?{capabilities:v,cardModuleFactory:function(b,c){b=h(a,b,c);b.P=l;return b},require:~n?t:void 0}:h(a,[],function(){})});y&&l.when("mix:@amzn/mix.client-runtime","mix:"+g).execute(function(a,b){a.registerCapabilityModule(g,b)});l.when("mix:"+g).register("xcp:"+g,function(a){return a});var t=function(a,b,c){try{var e=a[0],d=e.lastIndexOf("./",0)?e:x+"/"+e.substr(2),f=d.lastIndexOf("@p/",0)?"mix:"+d:d.substr(3);l.when(f).execute(function(a){try{b(a)}catch(A){c(A)}})}catch(z){c(z)}}}}
+"use strict";var w={};b.mix_d||((b.Promise?P:P.when("3p-promise")).register("@p/promise-is-ready",function(a){b.Promise=b.Promise||a}),(Array.prototype.includes?P:P.when("a-polyfill")).register("@p/polyfill-is-ready",function(){}),b.mix_d=function(a,b,d){P.when("@p/promise-is-ready","@p/polyfill-is-ready").execute("@p/mix-d-deps",function(){t(a,b,d)})},b.xcp_d=b.mix_d,P.when("mix:@amzn/mix.client-runtime").execute(function(a){P.declare("xcp:@xcp/runtime",a)}));b.mixTimeout||(b.mixTimeout=function(a,
+e,d){b.mixCardInitTimeouts||(b.mixCardInitTimeouts={});b.mixCardInitTimeouts[e]&&clearTimeout(b.mixCardInitTimeouts[e]);b.mixCardInitTimeouts[e]=setTimeout(function(){P.log("Client-side initialization timeout","WARN",a)},d)});b.mix_csa_map=b.mix_csa_map||{};b.mix_csa_internal=b.mix_csa_internal||function(a,e,d){return b.mix_csa_map[e]=b.mix_csa_map[e]||b.csa(a,d)};b.mix_csa_internal_key=b.mix_csa_internal_key||function(a,b){for(var d="",e=0;e<b.length;e++){var c=b[e];void 0!==a[c]&&"object"!==typeof a[c]&&
+(d+=c+":"+a[c]+",")}if(!d)throw Error("bad mix-csa key gen.");return d};b.mix_csa_event=b.mix_csa_event||function(a){try{var e=b.mix_csa_internal_key(a,["producerId"])}catch(d){return P.logError(d,"MIX C005","WARN",void 0),function(){}}try{return b.mix_csa_internal("Events",e,a)}catch(d){return P.logError(d,"MIX C004","WARN",e),function(){}}};b.mix_csa=b.mix_csa||function(a,e){try{e=e||"";var d=document.querySelectorAll(a);if(1<d.length)for(var h=0;h<d.length;h++){if(d[h].querySelector(e)){var c=
+d[h];break}}else 1===d.length&&(c=d[0]);if(!c)throw Error(" ");return b.mix_csa_internal("Content",a,{element:c})}catch(r){return P.logError(r,"MIX C004","WARN",a),function(){}}}})(window);
+(window.AmazonUIPageJS ? AmazonUIPageJS : P).when('sp.load.js').execute(function() {
+  (window.AmazonUIPageJS ? AmazonUIPageJS : P).load.js('https://m.media-amazon.com/images/I/61xJcNKKLXL.js?AUIClients/AmazonUIjQuery');
+  (window.AmazonUIPageJS ? AmazonUIPageJS : P).load.js('https://m.media-amazon.com/images/I/11I0WXrZVoL._RC|11Y+5x+kkTL.js,51DFoGfFeXL.js,115zbyk371L.js,11GgN1+C7hL.js,01+z+uIeJ-L.js,01VRMV3FBdL.js,21NadQlXUWL.js,01vRf9id2EL.js,31on-La90vL.js,11a7qqY8xXL.js,11PZSUl3FLL.js,51C4kaFbiAL.js,11FhdH2HZwL.js,11wb9K3sw0L.js,11BrgrMAHUL.js,11GPhx42StL.js,210X-JWUe-L.js,01Svfxfy8OL.js,61lbT4bHNWL.js,01ikBbTAneL.js,31xywoXPfpL.js,01qXJuwGmxL.js,01WlsjNmqIL.js,11F929pmpYL.js,31Zn4S+IOkL.js,01rpauTep4L.js,31rqCOnXDNL.js,011FfPwYqHL.js,21P5VvHf-XL.js,01-E15R8CKL.js,21kN0q4IA-L.js,01VvIkYCafL.js,11vb6P5C5AL.js,01Od3PfWdaL.js_.js?AUIClients/AmazonUI');
+  (window.AmazonUIPageJS ? AmazonUIPageJS : P).load.js('https://m.media-amazon.com/images/I/516npEhK50L.js?AUIClients/CardJsRuntimeBuzzCopyBuild');
+});
+</script>
+<!-- sp:end-feature:aui-assets -->
+<!-- sp:feature:nav-agent-metadata -->
+      <style id="agent-styles">
+      /* CRITICAL FIX: Opacity > 0 for technical clickability. */
+      #nav-search-submit-text-agent, #nav-search-submit-button-agent {
+        opacity: 0.001 !important;
+        pointer-events: auto !important;
+        cursor: default !important;
+        background: transparent !important;
+        border: none !important;
+        outline: none !important;
+        z-index: 9999 !important;
+      }
+
+      #nav-search-submit-button-agent:hover, #nav-search-submit-button-agent:focus {
+        background: transparent !important;
+      }
+
+      /* *** FIX 2: Force PERMANENT transparency on the parent containers. *** */
+      #nav-search, #nav-search-bar-form {
+        background-color: transparent !important;
+        background: transparent !important;
+        border: none !important;
+        box-shadow: none !important;
+      }
+
+      /* *** FIX 3: Keep the focus transparency rule (using :has is safer) *** */
+      #nav-search:has(#twotabsearchtextbox:focus), #nav-search-bar-form:has(#twotabsearchtextbox:focus) {
+        background-color: transparent !important;
+        background: transparent !important;
+        border: none !important;
+        box-shadow: none !important;
+      }
+
+      #nav-search:hover, #nav-search.nav-active, #nav-search-bar-form:hover, #nav-search-bar-form:focus-within {
+        border-color: transparent !important;
+        box-shadow: none !important;
+      }
+      </style>
+      <script id="agent-semantic-map" type="application/agent+json">
+      {
+        "@context": "https://agent.schema.org",
+        "@type": "AgentInterfaceMap",
+        "pageType": "product-listing",
+        "primaryActions": [
+          {
+            "id": "search_agent",
+            "action": "search",
+            "selector": "#nav-search-submit-button-agent",
+            "description": "AI-optimized search submission",
+            "inputSelector": "#twotabsearchtextbox",
+            "priority": "primary",
+            "recommended": true,
+            "visibility": "visually-hidden"
+          }
+        ],
+        "suggestions": {
+          "preferredSearchMode": "agent",
+          "agentButton": "#nav-search-submit-button-agent"
+        }
+      }
+      </script>
+<!-- sp:end-feature:nav-agent-metadata -->
+<!-- sp:feature:nav-inline-css -->
+<!-- NAVYAAN CSS -->
+
+<style type="text/css">
+.nav-sprite-v1 .nav-sprite, .nav-sprite-v1 .nav-icon {
+  background-image: url(https://m.media-amazon.com/images/G/01/gno/sprites/nav-sprite-global-1x-reorg-privacy._CB779528203_.png);
+  background-position: 0 1000px;
+  background-repeat: repeat-x;
+}
+.nav-spinner {
+  background-image: url(https://m.media-amazon.com/images/G/01/javascripts/lib/popover/images/snake._CB485935611_.gif);
+  background-position: center center;
+  background-repeat: no-repeat;
+}
+.nav-timeline-icon, .nav-access-image, .nav-timeline-prime-icon {
+  background-image: url(https://m.media-amazon.com/images/G/01/gno/sprites/timeline_sprite_1x._CB485945973_.png);
+  background-repeat: no-repeat;
+}
+</style>
+<link rel="stylesheet" href="https://m.media-amazon.com/images/I/51waPb-h-9L._RC|71rJTBWm2GL.css,41WcY5PbsbL.css,61p+Jc2B9kL.css,51Z1WqjT15L.css,31wmH1IMCGL.css,01FcI3FsaiL.css,21Hc1s0-E4L.css,31YZpDCYJPL.css,21DwGGPS1eL.css,41vWFCvFunL.css,21CB9R4dxNL.css,111Bp55OByL.css,01Acb9NWohL.css,21KQnzhmfTL.css,41bqNBi+QSL.css,61f0dQ2ffRL.css,01NLp3ZKNoL.css_.css?AUIClients/NavDesktopUberAsset#desktop.us.1173010-T1.1381529-T1.1253326-T1.1236111-T1.1346270-T1" />
+<!-- sp:end-feature:nav-inline-css -->
+<!-- sp:feature:host-assets -->
+
+
+
+
+
+
+
+<link rel="stylesheet" href="https://m.media-amazon.com/images/I/012E12eduRL.css?AUIClients/F3PostOrderWidgetAssets-orderSummary" />
+<link rel="stylesheet" href="https://m.media-amazon.com/images/I/018uy0Bl9DL.css?AUIClients/F3PostOrderWidgetAssets-destinationInfo" />
+<link rel="stylesheet" href="https://m.media-amazon.com/images/I/01KYCwnRHfL.css?AUIClients/F3PostOrderWidgetAssets-progressTracker" />
+<link rel="stylesheet" href="https://m.media-amazon.com/images/I/01em6sCeaoL.css?AUIClients/F3PostOrderWidgetAssets-itemList" />
+<link rel="stylesheet" href="https://m.media-amazon.com/images/I/01cet1YhGyL.css?AUIClients/F3PostOrderWidgetAssets-helpLinks" />
+<link rel="stylesheet" href="https://m.media-amazon.com/images/I/013p00Lkg0L.css?AUIClients/F3PostOrderDetailsPageAssets-orderDetailsPage" />
+<link rel="stylesheet" href="https://m.media-amazon.com/images/I/01P7ieND0lL.css?AUIClients/F3PostOrderDetailsPageAssets-importantMessageBox" />
+
+<script>
+  (window.AmazonUIPageJS ? AmazonUIPageJS : P).load.js('https://m.media-amazon.com/images/I/01xhQ+j47xL.js?AUIClients/F3PostOrderWidgetAssets-orderSummary');
+  (window.AmazonUIPageJS ? AmazonUIPageJS : P).load.js('https://m.media-amazon.com/images/I/110qC0rUboL.js?AUIClients/F3PostOrderWidgetAssets-destinationInfo');
+  (window.AmazonUIPageJS ? AmazonUIPageJS : P).load.js('https://m.media-amazon.com/images/I/31ZlLUACyEL.js?AUIClients/F3PostOrderWidgetAssets-progressTracker');
+  (window.AmazonUIPageJS ? AmazonUIPageJS : P).load.js('https://m.media-amazon.com/images/I/01P9F1lVywL.js?AUIClients/F3PostOrderWidgetAssets-itemList');
+  (window.AmazonUIPageJS ? AmazonUIPageJS : P).load.js('https://m.media-amazon.com/images/I/21zlRCNSqbL.js?AUIClients/F3PostOrderWidgetAssets-helpLinks');
+  (window.AmazonUIPageJS ? AmazonUIPageJS : P).load.js('https://m.media-amazon.com/images/I/11ehJm2AD9L.js?AUIClients/F3PostOrderDetailsPageAssets-orderDetailsPage');
+  (window.AmazonUIPageJS ? AmazonUIPageJS : P).load.js('https://m.media-amazon.com/images/I/310C6325fJL.js?AUIClients/F3PostOrderDetailsPageAssets-importantMessageBox');
+  (window.AmazonUIPageJS ? AmazonUIPageJS : P).load.js('https://m.media-amazon.com/images/I/213RdmhF14L.js?AUIClients/F3PostOrderWidgetAssets-utility');
+  (window.AmazonUIPageJS ? AmazonUIPageJS : P).load.js('https://m.media-amazon.com/images/I/31jdfgcsPAL.js?AUIClients/AmazonUIFormControlsJS');
+</script>
+
+
+
+<title dir="ltr">Order Details</title>
+
+<!--&&&Portal&Delimiter&&&--><!-- sp:end-feature:host-assets -->
+<!-- sp:feature:encrypted-slate-token -->
+<meta name='encrypted-slate-token' content='AnYxYuojbWY2e1B60jSHVmsFWaxIgsbFxLEWjYHVal+vz3YOjAnz36ODmUhnUN5Vf+pTnSwuvioG6moGjsUxSLe0zxej3Jl7m25a0LIGHUOJIyEEjuI00rTbAMyDEkLSJLSLvZubVvfVIBCUEAhry0lzV2qNbb6ZdqMMdE4MDDLrkCm5FZQ9qAqarRHOziN9MyPsxr83gYviXHuLi2cQO3frXu73C8rQYzIwKeqHy60+Wry3yB64vbHCI+ZW+pSYHMBRCGIBaFsoc617emcQQNJDLqiNBTFn0dZDL50YnEVfMA0CKBMw54u06fqEDGdN3V4muceM2KBTxCQP+FdkOROK1iOTcTY='>
+<!-- sp:end-feature:encrypted-slate-token -->
+<!-- sp:feature:bidi-endpoint -->
+<meta name='bidi-endpoint' content='ws.ep-e908141b0.bidi.amazon.dev'>
+<!-- sp:end-feature:bidi-endpoint -->
+<!-- sp:feature:flow-closure-id -->
+<meta name='flow-closure-id' content='1780935494'>
+<!-- sp:end-feature:flow-closure-id -->
+<!-- sp:feature:csm:head-close -->
+<script type='text/javascript'>
+window.ue_ihe = (window.ue_ihe || 0) + 1;
+if (window.ue_ihe === 1) {
+(function(k,l,g){function m(a){c||(c=b[a.type].id,"undefined"===typeof a.clientX?(e=a.pageX,f=a.pageY):(e=a.clientX,f=a.clientY),2!=c||h&&(h!=e||n!=f)?(r(),d.isl&&l.setTimeout(function(){p("at",d.id)},0)):(h=e,n=f,c=0))}function r(){for(var a in b)b.hasOwnProperty(a)&&d.detach(a,m,b[a].parent)}function s(){for(var a in b)b.hasOwnProperty(a)&&d.attach(a,m,b[a].parent)}function t(){var a="";!q&&c&&(q=1,a+="&ui="+c);return a}var d=k.ue,p=k.uex,q=0,c=0,h,n,e,f,b={click:{id:1,parent:g},mousemove:{id:2,
+parent:g},scroll:{id:3,parent:l},keydown:{id:4,parent:g}};d&&p&&(s(),d._ui=t)})(ue_csm,window,document);
+
+
+(function(s,l){function m(b,e,c){c=c||new Date(+new Date+t);c="expires="+c.toUTCString();n.cookie=b+"="+e+";"+c+";path=/"}function p(b){b+="=";for(var e=n.cookie.split(";"),c=0;c<e.length;c++){for(var a=e[c];" "==a.charAt(0);)a=a.substring(1);if(0===a.indexOf(b))return decodeURIComponent(a.substring(b.length,a.length))}return""}function q(b,e,c){if(!e)return b;-1<b.indexOf("{")&&(b="");for(var a=b.split("&"),f,d=!1,h=!1,g=0;g<a.length;g++)f=a[g].split(":"),f[0]==e?(!c||d?a.splice(g,1):(f[1]=c,a[g]=
+f.join(":")),h=d=!0):2>f.length&&(a.splice(g,1),h=!0);h&&(b=a.join("&"));!d&&c&&(0<b.length&&(b+="&"),b+=e+":"+c);return b}var k=s.ue||{},t=3024E7,n=ue_csm.document||l.document,r=null,d;a:{try{d=l.localStorage;break a}catch(u){}d=void 0}k.count&&k.count("csm.cookieSize",document.cookie.length);k.cookie={get:p,set:m,updateCsmHit:function(b,e,c){try{var a;if(!(a=r)){var f;a:{try{if(d&&d.getItem){f=d.getItem("csm-hit");break a}}catch(k){}f=void 0}a=f||p("csm-hit")||"{}"}a=q(a,b,e);r=a=q(a,"t",+new Date);
+try{d&&d.setItem&&d.setItem("csm-hit",a)}catch(h){}m("csm-hit",a,c)}catch(g){"function"==typeof l.ueLogError&&ueLogError(Error("Cookie manager: "+g.message),{logLevel:"WARN"})}}}})(ue_csm,window);
+
+
+(function(l,e){function c(b){b="";var c=a.isBFT?"b":"s",d=""+a.oid,g=""+a.lid,h=d;d!=g&&20==g.length&&(c+="a",h+="-"+g);a.tabid&&(b=a.tabid+"+");b+=c+"-"+h;b!=f&&100>b.length&&(f=b,a.cookie?a.cookie.updateCsmHit(m,b+("|"+ +new Date)):e.cookie="csm-hit="+b+("|"+ +new Date)+n+"; path=/")}function p(){f=0}function d(b){!0===e[a.pageViz.propHid]?f=0:!1===e[a.pageViz.propHid]&&c({type:"visible"})}var n="; expires="+(new Date(+new Date+6048E5)).toGMTString(),m="tb",f,a=l.ue||{},k=a.pageViz&&a.pageViz.event&&
+a.pageViz.propHid;a.attach&&(a.attach("click",c),a.attach("keyup",c),k||(a.attach("focus",c),a.attach("blur",p)),k&&(a.attach(a.pageViz.event,d,e),d({})));a.aftb=1})(ue_csm,ue_csm.document);
+
+
+ue_csm.ue.stub(ue,"impression");
+
+
+ue.stub(ue,"trigger");
+
+
+if(window.ue&&uet) { uet('bb'); }
+
+}
+</script>
+<script>window.ue && ue.count && ue.count('CSMLibrarySize', 2728)</script>
+<!-- sp:end-feature:csm:head-close -->
+<!-- sp:feature:head-close -->
+<script>
+window.P && P.register('bb');
+if (typeof ues === 'function') {
+  ues('t0', 'portal-bb', new Date());
+  ues('ctb', 'portal-bb', 1);
+}
+</script>
+</head><!-- sp:end-feature:head-close -->
+<!-- sp:feature:start-body -->
+<body class="a-m-us a-aui_72554-c a-aui_template_weblab_cache_333406-c"><div id="a-page"><script type="a-state" data-a-state="{&quot;key&quot;:&quot;a-wlab-states&quot;}">{"AUI_72554":"C","AUI_TEMPLATE_WEBLAB_CACHE_333406":"C"}</script><script>typeof uex === 'function' && uex('ld', 'portal-bb', {wb: 1})</script><!-- sp:end-feature:start-body -->
+<!-- sp:feature:csm:body-open -->
+
+
+<script>
+!function(){function n(n,t){var r=i(n);return t&&(r=r("instance",t)),r}var r=[],c=0,i=function(t){return function(){var n=c++;return r.push([t,[].slice.call(arguments,0),n,{time:Date.now()}]),i(n)}};n._s=r,this.csa=n}();;
+csa('Config', {});
+if (window.csa) {
+    csa("Config", {
+        'Application': 'Retail:Prod:www.amazon.com',
+        'Events.Namespace': 'csa',
+        'ObfuscatedMarketplaceId': 'ATVPDKIKX0DER',
+        'Events.SushiEndpoint': 'https://unagi.amazon.com/1/events/com.amazon.csm.csa.prod',
+        'Events.SushiCsaVIP': 'unagi.amazon.com',
+        'Events.SushiCsaSourceGroup': 'com.amazon.csm.csa.prod',
+        'Events.SushiCsaCustomSourceGroup': 'com.amazon.csm.customsg.prod',
+        'Events.SushiEndpointPattern': 'https://%s/1/events/%s',
+        'CacheDetection.RequestID': "RBWFGARJB4TBW5KMJP91",
+        'CacheDetection.Callback': window.ue && ue.reset,
+        'Transport.nonBatchSchema': "csa.UEData.4",
+        'LCP.elementDedup': 1,
+        'lob': '1'
+    });
+
+    csa("Events")("setEntity", {
+        page: {requestId: "RBWFGARJB4TBW5KMJP91", meaningful: "interactive"},
+        session: {id: "147-7999693-6862434"}
+    });
+}
+!function(e){var i,r,o="splice",u=e.csa,f={},c={},a=e.csa._s,l=0,s=0,g=-1,h={},d={},p={},n=Object.keys,v=function(){};function t(n,t){return u(n,t)}function w(n,t){var e=c[n]||{};k(e,t),c[n]=e,s++,D(I,0)}function b(n,t,e){var r=!0;return t=U(t),e&&e.buffered&&(r=(p[n]||[]).every(function(n){return!1!==t(n)})),r?(h[n]||(h[n]=[]),h[n].push(t),function(){!function(n,t){var e=h[n];e&&e[o](e.indexOf(t),1)}(n,t)}):v}function m(n,t){if(t=U(t),n in d)return t(d[n]),v;return b(n,function(n){return t(n),!1})}function y(n,t){if(u("Errors")("logError",n),f.DEBUG)throw t||n}function E(){return[S(),S(),S(),S()].join("-")}function S(){return Math.abs(4294967295*Math.random()|0).toString(36)}function U(n,t){return function(){try{return n.apply(this,arguments)}catch(n){y(n.message||n,n)}}}function D(n,t){return e.setTimeout(U(n),t)}function I(){for(var n=0;n<a.length;){var t=a[n],e=t[0]in c;if(!e&&!r)return void(l=a.length);e?(a[o](l=n,1),O(t)):n++}g=s}function O(n){var t=c[n[0]],e=n[1],r=e[0];if(!t||!t[r])return y("Undefined function: "+t+"/"+r);i=n[3],c[n[2]]=t[r].apply(t,e.slice(1))||{},i=0}function C(){r=1,I()}function k(t,e){n(e).forEach(function(n){t[n]=e[n]})}m("$beforeunload",C),w("Config",{instance:function(n){k(f,n)}}),u.plugin=U(function(n){n(t)}),t.config=f,t.register=w,t.on=b,t.once=m,t.blank=v,t.emit=function(n,t,e){for(var r=h[n]||[],i=0;i<r.length;)!1===r[i](t)?r[o](i,1):i++;d[n]=t||{},e&&e.buffered&&(p[n]||(p[n]=[]),100<=p[n].length&&p[n].shift(),p[n].push(t||{}))},t.UUID=E,t.generateNewRequestId=function(){return E().toUpperCase().replace(/-/g,"").slice(0,20)},t.time=function(n){var t=i?new Date(i.time):new Date;return"ISO"===n?t.toISOString():t.getTime()},t.error=y,t.warn=function(n,t){if(u("Errors")("logWarn",n),f.DEBUG)throw t||n},t.exec=U,t.timeout=D,t.interval=function(n,t){return e.setInterval(U(n),t)},(t.global=e).csa._s.push=function(n){n[0]in c&&(!a.length||r)?(O(n),a.length&&g!==s&&I()):a[o](l++,0,n)},I(),f["StubCalls.Cleanup.Onload"]&&m("$load",C),D(function(){D(C,f.SkipMissingPluginsTimeout||5e3)},1)}("undefined"!=typeof window?window:global);csa.plugin(function(o){var f="addEventListener",e="requestAnimationFrame",t=o.exec,r=o.global,u=o.on;o.raf=function(n){if(r[e])return r[e](t(n))},o.on=function(n,e,t,r){if(n&&"function"==typeof n[f]){var i=o.exec(t);return n[f](e,i,r),function(){n.removeEventListener(e,i,r)}}return"string"==typeof n?u(n,e,t,r):o.blank}});csa.plugin(function(o){var t,n,r={},e="localStorage",c="sessionStorage",a="local",i="session",u=o.exec;function s(e,t){var n;try{r[t]=!!(n=o.global[e]),n=n||{}}catch(e){r[t]=!(n={})}return n}function f(){t=t||s(e,a),n=n||s(c,i)}function l(e){return e&&e[i]?n:t}o.store=u(function(e,t,n){f();var o=l(n);return e?t?void(o[e]=t):o[e]:Object.keys(o)}),o.storageSupport=u(function(){return f(),r}),o.deleteStored=u(function(e,t){f();var n=l(t);if("function"==typeof e)for(var o in n)n.hasOwnProperty(o)&&e(o,n[o])&&delete n[o];else delete n[e]})});csa.plugin(function(n){n.types={ovl:function(n){var r=[];if(n)for(var i in n)n.hasOwnProperty(i)&&r.push(n[i]);return r}}});csa.plugin(function(a){var e=a.config,t=a.global,r=t.location||{},n=r.host,o=t.document||{},l=e.Application||"Other"+(n?":"+n:""),s="UEData",i=e["KillSwitch."+s],c=e["Transport.AnonymizeRequests"]||!1,f=e.RedactPath||!1,p="csa.UEData.4",u="csa",g=a("Transport");i||a.register(s,{log:function(e){if(function(e){return!e||"object"==typeof e&&0===Object.keys(e).length}(e))a.warn("Received empty or null uedata input");else{var t=function(t){var n={schemaId:p,timestamp:a.time("ISO"),producerId:u,messageId:a.UUID(),application:l,url:f?r.protocol+"//"+r.hostname:c?r.href.split("?")[0]:r.href,referrer:f?"":c?o.referrer.split("?")[0]:o.referrer};if(["eventName","lob","ifr","id","csmtags","viz","sessionId","obfuscatedMarketplaceId"].forEach(function(e){null!=t[e]&&(n[e]=t[e])}),["pty","spty","pti"].forEach(function(e){null!=t[e]&&(n.pageInfo=n.pageInfo||{},n.pageInfo[e]=t[e])}),t.latency&&t.latency.t&&(n.t=t.latency.t+""),null!=t.browserData){var e=t.browserData.indexOf("?");-1!=e&&(n.browserData=t.browserData.substring(1+e))}return n.clientRequestId=a.generateNewRequestId(),n}(e);!function(e){return e.pageInfo&&null!=e.pageInfo.pty&&null!=e.pageInfo.spty&&null!=e.pageInfo.pti&&(e.viz&&0<e.viz.length||e.csmtags&&0<e.csmtags.length)}(t)?g("log",t):g("log",t,{forceSend:!0})}}})});csa.plugin(function(a){var e=a.config,n="Errors",c="fcsmln",s=e["KillSwitch."+n];function r(n){return function(e){a("Metrics",{producerId:"csa",dimensions:{message:e}})("recordMetric",n,1)}}function t(r){var t,o,l=a("Events",{producerId:r.producerId,lob:e.lob||"0"}),i=["name","type","csm","adb"],u={url:"pageURL",file:"f",line:"l",column:"c"};this.log=function(e){if(!s&&!function(e){if(!e)return!0;for(var n in e)return!1;return!0}(e)){var n=r.logOptions||{ent:{page:["pageType","subPageType","requestId"]}};l("log",function(n){return t=a.UUID(),o={messageId:t,schemaId:r.schemaId||"<ns>.Error.6",errorMessage:n.m||null,attribution:n.attribution||null,logLevel:"FATAL",url:null,file:null,line:null,column:null,stack:n.s||[],context:n.cinfo||{},metadata:{}},n.logLevel&&(o.logLevel=""+n.logLevel),i.forEach(function(e){n[e]&&(o.metadata[e]=n[e])}),c in n&&(o.metadata[c]=n[c]+""),"INFO"===n.logLevel||Object.keys(u).forEach(function(e){"number"!=typeof n[u[e]]&&"string"!=typeof n[u[e]]||(o[e]=""+n[u[e]])}),o}(e),n)}}}a.register(n,{instance:function(e){return new t(e||{})},logError:r("jsError"),logWarn:r("jsWarn")})});csa.plugin(function(o){var r,e,n,t,a,i="function",u="willDisappear",c="$app.",f="$document.",p="focus",s="blur",d="active",l="resign",$=o.global,m=o.exec,b=o.config,h=b["Transport.AnonymizeRequests"]||!1,g=b.RedactPath||!1,v=o("Events"),y=$.location,P=$.document||{},w=$.P||{},k=(($.performance||{}).navigation||{}).type,E=o.on,T=o.emit,I=P.hidden,A={};y&&P&&(E($,"beforeunload",S),E($,"pagehide",S),E(P,"visibilitychange",j(f,function(){return P.visibilityState||"unknown"})),E(P,p,j(f+p)),E(P,s,j(f+s)),w.when&&w.when("mash").execute(function(e){e&&(E(e,"appPause",j(c+"pause")),E(e,"appResume",j(c+"resume")),j(c+"deviceready")(),$.cordova&&$.cordova.platformId&&j(c+cordova.platformId)(),E(P,d,j(c+d)),E(P,l,j(c+l)))}),e=$.app||{},n=m(function(){T(c+"willDisappear"),S()}),a=typeof(t=e[u])==i,e[u]=m(function(){n(),a&&t()}),$.app||($.app=e),"complete"===P.readyState?R():E($,"load",R),I?x():U(),o.on("$app.blur",x),o.on("$app.focus",U),o.on("$document.blur",x),o.on("$document.focus",U),o.on("$document.hidden",x),o.on("$document.visible",U),o.register("SPA",{newPage:D}),D({transitionType:{0:"hard",1:"refresh",2:"back-button"}[k]||"unknown"}));function D(n,e){var t=!!r,a=(e=e||{}).keepPageAttributes;t&&(T("$beforePageTransition"),T("$pageTransition")),t&&!a&&v("removeEntity","page"),r=o.UUID(),a?A.id=r:A={schemaId:"<ns>.PageEntity.2",id:r,url:g?y.protocol+"//"+y.hostname:h?y.href.split("?")[0]:y.href,server:y.hostname,path:g?"":y.pathname,referrer:g?"":h?P.referrer.split("?")[0]:P.referrer,title:P.title},Object.keys(n||{}).forEach(function(e){A[e]=n[e]}),v("setEntity",{page:A}),T("$pageChange",A,{buffered:1}),t&&T("$afterPageTransition")}function R(){T("$load"),T("$ready"),T("$afterload")}function S(){T("$ready"),T("$beforeunload"),T("$unload"),T("$afterunload")}function x(){I||(T("$visible",!1,{buffered:1}),I=!0)}function U(){I&&(T("$visible",!0,{buffered:1}),I=!1)}function j(n,t){return m(function(){var e=typeof t==i?n+t():n;T(e)})}});csa.plugin(function(f){var e="Events",n="UNKNOWN",s="id",o="all",l="sushiSourceGroup",i="copyBaseMetadata",r="copyEntities",c="messageId",a="timestamp",d="producerId",u="application",p="obfuscatedMarketplaceId",g="entities",y="page",h="requestId",v="pageType",b="subPageType",O="schemaId",m="version",I="attributes",E="<ns>",S="lob",k=f.config["Events.SushiCsaSourceGroup"],A="session",T=f.config,t=f.global,U=t.Object.keys,j=(t.location||{}).host,w=T["KillSwitch.PageEntity"],x=T[e+".Namespace"]||"csa_other",N=x+".",q=T.Application||"Other"+(j?":"+j:""),D=T["Transport.AnonymizeRequests"]||!1,K=f("Transport"),M={},P=function(e,t){Object.keys(e).forEach(t)};function _(n,i,r){P(i,function(e){var t=r===o||(r||{})[e];e in n||(n[e]={version:1,id:i[e][s]||f.UUID()}),G(n[e],i[e],t)})}function G(t,n,i){P(n,function(e){!function(e,t,n){return"string"!=typeof t&&e!==m?f.error("Attribute is not of type string: "+e):!0===n||1===n||(e===s||!!~(n||[]).indexOf(e))}(e,n[e],i)||(t[e]=n[e])})}function z(r,e,o){P(e,function(t){var e=r[t];if(!(e[O]&&~e[O].indexOf("PageEntity")&&w)&&e[O]){var n={},i={};n[s]=e[s],n[d]=e[d]||o[d],n[O]=e[O],n[m]=e[m]++,n[I]=i,B(n,o),G(i,e,1),C(i),t===y&&(n.__backfill=function(e){!function(e,t,n,i){if(e&&e[O]&&e[O]!==n&&!e[O].indexOf(N)){var r=e[g];if(r&&r[i]&&r[i][s]===t[s]){var o=r[i],c=U(o);c.push(h),c.push(v),c.push(b),G(o,t,c)}}}(e,i,n[O],t)}),K("log",n)}})}function B(e,t){e[a]=function(e){return"number"==typeof e&&(e=new Date(e).toISOString()),e||f.time("ISO")}(e[a]),e[c]=e[c]||f.UUID(),e[u]=q,e[p]=T.ObfuscatedMarketplaceId||n,O in e&&(e[O]=e[O].replace(E,x)),t&&t[S]&&(e[S]=t[S])}function C(e){delete e[m],delete e[O],delete e[d]}function R(t){var c={},s=!!t[l]&&t[l]!==k,a=!!t[i],u=!!t[r];this.log=function(i,e){var n={},r=(e||{}).ent;if(!i)return f.error("The event cannot be undefined");var o=i[g];if(s)a&&B(i,t),u&&(_(n,M,r),_(n,c,r));else{if("string"!=typeof i[O])return f.error("A valid schema id is required for the event");B(i,t),_(n,M,r),_(n,c,r)}i[d]=t[d],s?(o||u&&0<Object.keys(n).length)&&(i[g]={},o&&P(o,function(t){var n=r&&r[t];i[g][t]={},P(o[t],function(e){(!n||!0===n||Array.isArray(n)&&~n.indexOf(e))&&(i[g][t][e]=o[t][e])})}),u&&0<Object.keys(n).length&&P(n,function(t){i[g][t]||(i[g][t]={}),P(n[t],function(e){e in i[g][t]||(i[g][t][e]=n[t][e])}),C(i[g][t])})):s||(_(n,o||{},r),P(n,function(e){C(n[e])}),i[g]=n),e&&e[S]&&(i[S]=e[S]),(e=e||{})[l]||(e[l]=t[l]||k),K("log",i,e)},this.setEntity=function(e){D&&delete e[A],_(c,e,o),z(c,e,t)}}!T["KillSwitch."+e]&&U&&f.register(e,{setEntity:function(e){D&&delete e[A],f.emit("$entities.set",e,{buffered:1}),_(M,e,o),z(M,e,{producerId:"csa",lob:T[S]||"0"})},removeEntity:function(e){delete M[e]},instance:function(e){return new R(e)}})});csa.plugin(function(p){var a,h="Transport",l="post",f="preflight",c="csa.cajun.",i="store",u="deleteStored",s="sendBeacon",n="__merge",t="__backfill",e=".FlushInterval",g="sushiSourceGroup",v=p.config["Events.SushiCsaSourceGroup"],y="function",d=0,m=p.config[h+".BufferSize"]||2e3,E=p.config[h+".RetryDelay"]||1500,S=p.config[h+".AnonymizeRequests"]||!1,b=p.config[h+".nonBatchSchema"]||"",k={},G=0,I=[],R=p.global,o=R.document,w=p.timeout,A=p.emit,B=R.Object.keys,r=p.config[h+e]||5e3,O=r,j=p.config[h+e+".BackoffFactor"]||1,D=p.config[h+e+".BackoffLimit"]||3e4,T=0,U=0,$=0;function _(o,r){if(864e5<p.time()-+new Date(o.timestamp))return p.warn("Event is too old: "+o);if((r=r||{}).forceSend&&b&&b===o.schemaId)I.forEach(function(e){if(e.accepts(o,r)){var n=e.post?e:null;n&&C(n,[o],r[g]||v)}});else if(G<m){typeof o[t]==y&&(U||$||B(k).forEach(function(e){o[t](k[e].event)}),delete o[t]);var e=o.messageId||p.UUID();e in k||(k[e]={event:o,options:r},G++),typeof o[n]==y&&(r[g]||v)===(((k[e]||{}).options||{})[g]||v)&&o[n](k[e].event),!T&&d&&(T=w(q,function(){var e=O;return O=Math.min(e*j,D),e}()))}}function q(){var r={};B(k).forEach(function(e){var n=k[e],o=n.options&&n.options[g]||v;r[o]||(r[o]=[]),r[o].push(n.event)}),B(r).forEach(function(e){!function(o,r){I.forEach(function(n){var e=r.filter(function(e){return n.accepts(e,{sushiSourceGroup:o})});0<e.length&&(n.chunks?n.chunks(e,o):[e]).forEach(function(e){n[l]&&C(n,e,o)})})}(e,r[e])}),k={},T=0,U+=1,A("$transport.flushed")}function C(n,o,r){function t(){p[u](c+e)}var e=p.UUID();p[i](c+e,JSON.stringify({events:o,sourceGroup:r})),[function(e,n,o,r){var t=R.navigator||{},c=R.cordova||{};if(S)return 0;if(!t[s]||!e[l])return 0;e[f]&&c&&"ios"===c.platformId&&!a&&((new Image).src=e[f]().url,a=1);var i=e[l](n,o);if(!i.type&&t[s](i.url,i.body))return r(),1},function(e,n,o,r){var t=e[l](n,o),c=t.url,i=t.body,a=t.type,f=new XMLHttpRequest,u=0;function s(e,n,o){f.open("POST",e),f.withCredentials=!S,o&&f.setRequestHeader("Content-Type",o),f.send(n)}return f.onload=function(){f.status<299?r():p.config[h+".XHRRetries"]&&u<3&&w(function(){s(c,i,a)},++u*E)},s(c,i,a),1}].some(function(e){try{return e(n,o,r,t)}catch(e){}})}B&&(p.once("$afterload",function(){$=d=1,function(t){(p[i]()||[]).forEach(function(e){if(!e.indexOf(c))try{var n=p[i](e);p[u](e);var o=JSON.parse(n);if(o&&"object"==typeof o&&!Array.isArray(o))try{if(o.events&&o.sourceGroup){var r=o.sourceGroup;o.events.forEach(function(e){t(e,{sushiSourceGroup:r})})}}catch(e){p.error("Error processing backup object format: "+e.message)}else if(Array.isArray(o))try{o.forEach(t)}catch(e){p.error("Error processing array format backup: "+e.message)}}catch(e){p.error(e)}})}(_),p.on(o,"visibilitychange",q,!1),q()}),p.once("$afterunload",function(){d=1,q()}),p.on("$afterPageTransition",function(){G=0,O=r}),p.register(h,{log:_,register:function(e){I.push(e)}}))});csa.plugin(function(n){var u=n.config["Events.SushiEndpoint"],t=n.config["Events.SushiCsaSourceGroup"];n("Transport")("register",{accepts:function(n,r){return!(!n||!r)&&(n.schemaId&&(!r.sushiSourceGroup||r.sushiSourceGroup===t))},post:function(n){var r=n.map(function(n){return{data:n}});return{url:u,body:JSON.stringify({events:r})}},preflight:function(){var n,r=/\/\/(.*?)\//.exec(u);return r&&r[1]&&(n="https://"+r[1]+"/ping"),{url:n}},chunks:function(n){for(var r=[];500<n.length;)r.push(n.splice(0,500));return r.push(n),r}})});csa.plugin(function(u){var e=u.config["Events.SushiEndpoint"],t=u.config["Events.SushiCsaSourceGroup"],s=u.config["Events.SushiCsaVIP"],i=u.config["Events.SushiEndpointPattern"];u("Transport")("register",{accepts:function(n,r){return!(!n||!r)&&(!!r.sushiSourceGroup&&r.sushiSourceGroup!==t)},post:function(n,r){var t=n.map(function(n){return{data:n}});return{url:function(n){var r=e;n&&(r=function(n){var r=Array.prototype.slice.call(arguments,1),t=(n.match(/%s/g)||[]).length;r.length<t&&u.warn("Warning: More placeholders ("+t+") than arguments ("+r.length+")");var e=0;return n.replace(/%s/g,function(){return e<r.length?r[e++]:""})}(i,s,n));return r}(r),body:JSON.stringify({events:t})}},preflight:function(){var n,r=/\/\/(.*?)\//.exec(e);return r&&r[1]&&(n="https://"+r[1]+"/ping"),{url:n}},chunks:function(n){for(var r=[];500<n.length;)r.push(n.splice(0,500));return r.push(n),r}})});csa.plugin(function(n){var t,a,o,r,e=n.config,i="PageViews",d=e[i+".ImpressionMinimumTime"]||1e3,s="hidden",c="innerHeight",l="innerWidth",g="renderedTo",f=g+"Viewed",m=g+"Meaningful",u=g+"Impressed",p=1,h=2,v=3,w=4,P=5,y="loaded",I=7,b=8,T=n.global,S=n.on,E=n("Events",{producerId:"csa",lob:e.lob||"0"}),K=T.document,V={},$={},M=P,R=e["KillSwitch."+i],H=e["KillSwitch.PageRender"],W=e["KillSwitch.PageImpressed"];function j(e){if(!V[I]){if(V[e]=n.time(),e!==v&&e!==y||(t=t||V[e]),t&&M===w){if(a=a||V[e],!R)(i={})[m]=t-o,i[f]=a-o,k("PageView.5",i);r=r||n.timeout(x,d)}var i;if(e!==P&&e!==p&&e!==h||(clearTimeout(r),r=0),e!==p&&e!==h||H||k("PageRender.4",{transitionType:e===p?"hard":"soft"}),e===I&&!W)(i={})[m]=t-o,i[f]=a-o,i[u]=V[e]-o,k("PageImpressed.3",i)}}function k(e,i){$[e]||(i.schemaId="<ns>."+e,E("log",i,{ent:"all"}),$[e]=1)}function q(){0===T[c]&&0===T[l]?(M=b,n("Events")("setEntity",{page:{viewport:"hidden-iframe"}})):M=K[s]?P:w,j(M)}function x(){j(I),r=0}function z(){var e=o?h:p;V={},$={},a=t=0,o=n.time(),j(e),q()}function A(){var e=K.readyState;"interactive"===e&&j(v),"complete"===e&&j(y)}K&&void 0!==K[s]?(z(),S(K,"visibilitychange",q,!1),S(K,"readystatechange",A,!1),S("$afterPageTransition",z),S("$timing:loaded",A),n.once("$load",A)):n.warn("Page visibility not supported")});csa.plugin(function(c){var s=c.config["Interactions.ParentChainLength"]||35,n="click",r="touches",f="timeStamp",o="length",u="pageX",g="pageY",p="pageXOffset",h="pageYOffset",l=250,m=5,v=200,d=.5,t={capture:!0,passive:!0},X=c.config["KillSwitch.ContentInteractions"],Y=c.global,x=c.emit,e=c.on,y=Y.Math.abs,a=(Y.document||{}).documentElement||{},N={x:0,y:0,t:0,sX:0,sY:0},b={x:0,y:0,t:0,sX:0,sY:0};function I(t){if(t.id)return"//*[@id='"+t.id+"']";var n=function(t){var n,e=1;for(n=t.previousSibling;n;n=n.previousSibling)n.nodeName===t.nodeName&&(e+=1);return e}(t),e=t.nodeName;return 1!==n&&(e+="["+n+"]"),t.parentNode&&(e=I(t.parentNode)+"/"+e),e}function C(t,n,e){if(!X){var a=c("Content",{target:e}),i={schemaId:"<ns>.ContentInteraction.2",interaction:t,interactionData:n,messageId:c.UUID()};if(e){var r=I(e);r&&(i.attribution=r);var o=function(t){for(var n=t,e=n.tagName,a=!1,i=t?t.href:null,r=0;r<s;r++){if(!n||!n.parentElement){a=!0;break}e=(n=n.parentElement).tagName+"/"+e,i=i||n.href}return a||(e=".../"+e),{pc:e,hr:i}}(e);o.pc&&(i.interactionData.parentChain=o.pc),o.hr&&(i.interactionData.href=o.hr)}a("log",i),x("$content.interaction",{e:i,w:a})}}function i(t){C(n,{interactionX:""+t.pageX,interactionY:""+t.pageY},t.target)}function D(t){if(t&&t[r]&&1===t[r][o]){var n=t[r][0];b=N={e:t.target,x:n[u],y:n[g],t:t[f],sX:Y[p],sY:Y[h]}}}function S(t){if(t&&t[r]&&1===t[r][o]&&N&&b){var n=t[r][0],e=t[f],a=e-b.t,i={e:t.target,x:n[u],y:n[g],t:e,sX:Y[p],sY:Y[h]};b=i,v<=a&&(N=i)}}function w(t){if(t){var n=y(N.x-b.x),e=y(N.y-b.y),a=y(N.sX-b.sX),i=y(N.sY-b.sY),r=t[f]-N.t;if(l<1e3*n/r&&m<n||l<1e3*e/r&&m<e){var o=e<n;o&&a&&n*d<=a||!o&&i&&e*d<=i||C((o?"horizontal":"vertical")+"-swipe",{interactionX:""+N.x,interactionY:""+N.y,endX:""+b.x,endY:""+b.y},N.e)}}}e(a,n,i,t),e(a,"touchstart",D,t),e(a,"touchmove",S,t),e(a,"touchend",w,t)});csa.plugin(function(a){var c,l,s,e,t="MutationObserver",f="observe",n="disconnect",m="_csa_flt",d="_csa_llt",v="_csa_mr",h="_csa_mi",p="lastChild",_="lastElementChild",b="length",g={childList:!0,subtree:!0},I=10,L=25,i=1e3,y=10,C=4,E={"#text":1,"#comment":1,SCRIPT:1,STYLE:1,NOSCRIPT:1,LINK:1,META:1},r=a.global,u=r.document,S=u.body||u.documentElement,T=Date.now,o=[],x=[],M=0,N=1,k=[],w=[],B=0;T&&r[t]&&(M=0,l=new r[t](O),a.once("$ready",A),N&&(R(),e=a.interval(P,i)),a.register("SpeedIndexBuffers",{getBuffers:D,registerListener:function(e){c=e},replayModuleIsLive:function(e){a.timeout(A,0),e&&e(D)}}));function O(e){o.push({t:T(),m:e}),c&&c()}function P(){var e=T();(!s||i<e-s)&&R()}function R(){for(var e=S,t=T(),n=[],i=[],r=0,u=0,o=0;e&&r<y;)e[m]?++u:(e[m]=t,n.push(e),o=1),i[b]<C&&i.push(e),e[h]=B,e[d]=t,e=e[_]||e[p],r+=1;o&&(u<w[b]&&function(e){for(var t=e,n=w[b];t<n;t++){var i=w[t];if(i){if(i[v])break;if(i[h]<B){if(i[v]=1,!E[i.nodeName||""]){var r=i,u=l;a.raf(function(){u&&r&&u[f](r,g),u=r=null})}break}}}}(u),w=i,k.push({t:t,m:n}),++B,c&&c()),N&&a.timeout(R,o?I:L),s=t}function A(){N&&(N=0,e&&r.clearInterval(e),e=null,R(),l[f](S,g))}function D(e){e&&(A(),x[b]||x.push({t:T(),x:0,y:0}),e(M,k,o,x),l&&l[n]())}});
+csa.plugin(function(b){var a=b.global,c=a.uet,e=a.uex,f=a.ue,a=a.Object,g=0,h={largestContentfulPaint:"lcp",visuallyLoaded50:"vl50",visuallyLoaded90:"vl90",visuallyLoaded100:"vl100"};b&&c&&e&&a.keys&&f&&(b.once("$ditched.beforemitigation",function(){g=1}),a.keys(h).forEach(function(a){b.on("$timing:"+a,function(b){var d=h[a];if(f.isl||g){var k="csa:"+d;c(d,k,void 0,b);e("at",k)}else c(d,void 0,void 0,b)})}))});
+
+
+window.rx = { 'rid':'RBWFGARJB4TBW5KMJP91', 'sid':'147-7999693-6862434', 'c':{  'rxp':'/rd/uedata',  'ml_dl':false }};
+</script>
+<script>window.ue && ue.count && ue.count('CSMLibrarySize', 20578)</script>
+<!-- sp:end-feature:csm:body-open -->
+<!-- sp:feature:nav-inline-js -->
+<!-- NAVYAAN JS -->
+
+<script type="text/javascript">!function(n){function e(n,e){return{m:n,a:function(n){return[].slice.call(n)}(e)}}document.createElement("header");var r=function(n){function u(n,r,u){n[u]=function(){a._replay.push(r.concat(e(u,arguments)))}}var a={};return a._sourceName=n,a._replay=[],a.getNow=function(n,e){return e},a.when=function(){var n=[e("when",arguments)],r={};return u(r,n,"run"),u(r,n,"declare"),u(r,n,"publish"),u(r,n,"build"),r.depends=n,r.iff=function(){var r=n.concat([e("iff",arguments)]),a={};return u(a,r,"run"),u(a,r,"declare"),u(a,r,"publish"),u(a,r,"build"),a},r},u(a,[],"declare"),u(a,[],"build"),u(a,[],"publish"),u(a,[],"importEvent"),r._shims.push(a),a};r._shims=[],n.$Nav||(n.$Nav=r("rcx-nav")),n.$Nav.make||(n.$Nav.make=r)}(window)</script><script type="text/javascript">
+$Nav.importEvent('navbarJS-beaconbelt');
+$Nav.declare('img.sprite', {
+  'png32': 'https://m.media-amazon.com/images/G/01/gno/sprites/nav-sprite-global-1x-reorg-privacy._CB779528203_.png',
+  'png32-2x': 'https://m.media-amazon.com/images/G/01/gno/sprites/nav-sprite-global-2x-reorg-privacy._CB779528203_.png'
+});
+$Nav.declare('img.timeline', {
+  'timeline-icon-2x': 'https://m.media-amazon.com/images/G/01/gno/sprites/timeline_sprite_2x._CB443581191_.png'
+});
+window._navbarSpriteUrl = 'https://m.media-amazon.com/images/G/01/gno/sprites/nav-sprite-global-1x-reorg-privacy._CB779528203_.png';
+$Nav.declare('img.pixel', 'https://m.media-amazon.com/images/G/01/x-locale/common/transparent-pixel._CB485935036_.gif');
+</script>
+
+<img src="https://m.media-amazon.com/images/G/01/gno/sprites/nav-sprite-global-1x-reorg-privacy._CB779528203_.png" style="display:none" alt=""/>
+<script type="text/javascript">var nav_t_after_preload_sprite = + new Date();</script>
+<script>
+(window.AmazonUIPageJS ? AmazonUIPageJS : P).when('navCF').execute(function() {
+  (window.AmazonUIPageJS ? AmazonUIPageJS : P).load.js('https://m.media-amazon.com/images/I/51rG04VN8cL._RC|71AeMNGOB4L.js,41InaEL-ZPL.js,01QvReFeJyL.js,01kC46b9vjL.js,81XkUkLWahL.js,01m0EuyLqIL.js,41jBieyCvYL.js,01wXnKULArL.js,01+pnQJuQ0L.js,21gBwAAfnjL.js,51D+BomCJLL.js,21Vid0E-nAL.js,31yCF4ftzxL.js,11lw6J7z8iL.js,31COIUU385L.js,01VYGE8lGhL.js_.js?AUIClients/NavDesktopUberAsset#desktop.language-en.us.1324036-T1.803398-T1.1200978-T1.1381529-T1.1354730-T1.1371733-T2.948355-T2.1253326-T1.1295082-T1.1401014-T1.1340845-T1.1346270-T1');
+});
+</script>
+<!-- sp:end-feature:nav-inline-js -->
+<!-- sp:feature:nav-skeleton -->
+<!-- sp:end-feature:nav-skeleton -->
+<!-- sp:feature:navbar -->
+
+<!--Pilu -->
+
+
+  <!-- NAVYAAN -->
+
+
+
+
+
+
+
+
+
+
+
+<!-- navmet initial definition -->
+
+
+
+<script type='text/javascript'>
+    if(window.navmet===undefined) {
+      window.navmet=[];
+      if (window.performance && window.performance.timing && window.ue_t0) {
+        var t = window.performance.timing;
+        var now = + new Date();
+        window.navmet.basic = {
+          'networkLatency': (t.responseStart - t.fetchStart),
+          'navFirstPaint': (now - t.responseStart),
+          'NavStart': (now - window.ue_t0)
+        };
+        window.navmet.push({key:"NavFirstPaintStart",end:+new Date(),begin:window.ue_t0});
+      }
+    }
+    if (window.ue_t0) {
+      window.navmet.push({key:"NavMainStart",end:+new Date(),begin:window.ue_t0});
+    }
+</script>
+
+    <script type="text/javascript">
+        const BROWSER_MARGIN = '12px';
+
+        
+        const DOCKED_PANEL_WIDTH = '320px';
+        
+
+        let state = sessionStorage.getItem('rufus:panel:dockedState');
+
+        
+        if (!state) {
+            try {
+                state = localStorage.getItem('rufus:panel:dockedState');
+                if (state) {
+                    sessionStorage.setItem('rufus:panel:dockedState', state);
+                }
+            } catch (e) {
+                // localStorage unavailable (e.g. private browsing)
+            }
+        }
+        
+    
+        if (state === 'docked-left' || state === 'docked-right') {
+            const body = document.body;
+            body.classList.add(`rufus-${state}`);
+            
+            body.style.paddingTop = BROWSER_MARGIN;
+            body.style[state === 'docked-left' ? 'paddingLeft' : 'paddingRight'] = DOCKED_PANEL_WIDTH;
+            body.style[state === 'docked-left' ? 'paddingRight' : 'paddingLeft'] = BROWSER_MARGIN;
+            body.offsetHeight;
+            document.body.style.setProperty('--rufus-docked-panel-width', DOCKED_PANEL_WIDTH);
+            window.dispatchEvent(new Event('resize'));
+        }
+    </script>
+
+
+
+
+
+<script type='text/javascript'>window.navmet.tmp=+new Date();</script>
+  <script type='text/javascript'>
+    // Nav start should be logged at this place only if request is NOT progressively loaded.
+    // For progressive loading case this metric is logged as part of skeleton.
+    // Presence of skeleton signals that request is progressively loaded.
+    if(!document.getElementById("navbar-skeleton")) {
+      window.uet && uet('ns');
+    }
+    window._navbar = (function (o) {
+      o.componentLoaded = o.loading = function(){};
+      o.browsepromos = {};
+      o.issPromos = [];
+      return o;
+    }(window._navbar || {}));
+    window._navbar.declareOnLoad = function () { window.$Nav && $Nav.declare('page.load'); };
+    if (window.addEventListener) {
+      window.addEventListener("load", window._navbar.declareOnLoad, false);
+    } else if (window.attachEvent) {
+      window.attachEvent("onload", window._navbar.declareOnLoad);
+    } else if (window.$Nav) {
+      $Nav.when('page.domReady').run("OnloadFallbackSetup", function () {
+        window._navbar.declareOnLoad();
+      });
+    }
+    window.$Nav && $Nav.declare('config.lightningDeals', {"activeItems":[],"marketplaceID":"ATVPDKIKX0DER","customerID":"AEXAMPLE00000"});
+  </script>
+
+    <style mark="aboveNavInjectionCSS" type="text/css">
+       #nav-flyout-ewc .nav-flyout-buffer-left { display: none; } #nav-flyout-ewc .nav-flyout-buffer-right { display: none; } div#navSwmHoliday.nav-focus {border: none;margin: 0;}
+    </style>
+    <script mark="aboveNavInjectionJS" type="text/javascript">
+      try {
+        if(window.navmet===undefined)window.navmet=[]; if(window.$Nav) { $Nav.when('$', 'config', 'flyout.accountList', 'SignInRedirect', 'dataPanel').run('accountListRedirectFix', function ($, config, flyout, SignInRedirect, dataPanel) { if (!config.accountList) { return; } flyout.getPanel().onData(function (data) { if (SignInRedirect) { var $anchors = $('[data-nav-role=signin]', flyout.elem()); $.each($anchors, function(i, anchorEl) {SignInRedirect.setRedirectUrl($(anchorEl), null, null);});}});}); $Nav.when('$').run('defineIsArray', function(jQuery) { if(jQuery.isArray===undefined) { jQuery.isArray=function(param) { if(param.length===undefined) { return false; } return true; }; } }); $Nav.declare('config.cartFlyoutDisabled', 'true'); $Nav.when('$','$F','config','logEvent','panels','phoneHome','dataPanel','flyouts.renderPromo','flyouts.sloppyTrigger','flyouts.accessibility','util.mouseOut','util.onKey','debug.param').build('flyouts.buildSubPanels',function($,$F,config,logEvent,panels,phoneHome,dataPanel,renderPromo,createSloppyTrigger,a11yHandler,mouseOutUtility,onKey,debugParam){var flyoutDebug=debugParam('navFlyoutClick');return function(flyout,event){var linkKeys=[];$('.nav-item',flyout.elem()).each(function(){var $item=$(this);linkKeys.push({link:$item,panelKey:$item.attr('data-nav-panelkey')});});if(linkKeys.length===0){return;} var visible=false;var $parent=$('<div class=\'nav-subcats\'></div>').appendTo(flyout.elem());var panelGroup=flyout.getName()+'SubCats';var hideTimeout=null;var sloppyTrigger=createSloppyTrigger($parent);var showParent=function(){if(hideTimeout){clearTimeout(hideTimeout);hideTimeout=null;} if(visible){return;} var height=$('#nav-flyout-shopAll').height(); $parent.css({'height': height});$parent.animate({width:'show'},{duration:200,complete:function(){$parent.css({overflow:'visible'});}});visible=true;};var hideParentNow=function(){$parent.stop().css({overflow:'hidden',display:'none',width:'auto',height:'auto'});panels.hideAll({group:panelGroup});visible=false;if(hideTimeout){clearTimeout(hideTimeout);hideTimeout=null;}};var hideParent=function(){if(!visible){return;} if(hideTimeout){clearTimeout(hideTimeout);hideTimeout=null;} hideTimeout=setTimeout(hideParentNow,10);};flyout.onHide(function(){sloppyTrigger.disable();hideParentNow();this.elem().hide();});var addPanel=function($link,panelKey){var panel=dataPanel({className:'nav-subcat',dataKey:panelKey,groups:[panelGroup],spinner:false,visible:false});if(!flyoutDebug){var mouseout=mouseOutUtility();mouseout.add(flyout.elem());mouseout.action(function(){panel.hide();});mouseout.enable();} var a11y=a11yHandler({link:$link,onEscape:function(){panel.hide();$link.focus();}});var logPanelInteraction=function(promoID,wlTriggers){var logNow=$F.once().on(function(){var panelEvent=$.extend({},event,{id:promoID});if(config.browsePromos&&!!config.browsePromos[promoID]){panelEvent.bp=1;} logEvent(panelEvent);phoneHome.trigger(wlTriggers);});if(panel.isVisible()&&panel.hasInteracted()){logNow();}else{panel.onInteract(logNow);}};panel.onData(function(data){renderPromo(data.promoID,panel.elem());logPanelInteraction(data.promoID,data.wlTriggers);});panel.onShow(function(){var columnCount=$('.nav-column',panel.elem()).length;panel.elem().addClass('nav-colcount-'+columnCount);showParent();var $subCatLinks=$('.nav-subcat-links > a',panel.elem());var length=$subCatLinks.length;if(length>0){var firstElementLeftPos=$subCatLinks.eq(0).offset().left;for(var i=1;i<length;i++){if(firstElementLeftPos===$subCatLinks.eq(i).offset().left){$subCatLinks.eq(i).addClass('nav_linestart');}} if($('span.nav-title.nav-item',panel.elem()).length===0){var catTitle=$.trim($link.html());catTitle=catTitle.replace(/ref=sa_menu_top/g,'ref=sa_menu');var $subPanelTitle=$('<span class=\'nav-title nav-item\'>'+ catTitle+'</span>');panel.elem().prepend($subPanelTitle);}} $link.addClass('nav-active');});panel.onHide(function(){$link.removeClass('nav-active');hideParent();a11y.disable();sloppyTrigger.disable();});panel.onShow(function(){a11y.elems($('a, area',panel.elem()));});sloppyTrigger.register($link,panel);if(flyoutDebug){$link.click(function(){if(panel.isVisible()){panel.hide();}else{panel.show();}});} var panelKeyHandler=onKey($link,function(){if(this.isEnter()||this.isSpace()){panel.show();}},'keydown',false);$link.focus(function(){panelKeyHandler.bind();}).blur(function(){panelKeyHandler.unbind();});panel.elem().appendTo($parent);};var hideParentAndResetTrigger=function(){hideParent();sloppyTrigger.disable();};for(var i=0;i<linkKeys.length;i++){var item=linkKeys[i];if(item.panelKey){addPanel(item.link,item.panelKey);}else{item.link.mouseover(hideParentAndResetTrigger);}}};});};
+      } catch ( err ) {
+        if ( window.$Nav ) {
+          window.$Nav.when('metrics', 'logUeError').run(function(metrics, log) {
+            metrics.increment('NavJS:AboveNavInjection:error');
+            log(err.toString(), {
+              'attribution': 'rcx-nav',
+              'logLevel': 'FATAL'
+            });
+          });
+        }
+      }
+    </script>
+
+  <noscript>
+    <style type="text/css"><!--
+      #navbar #nav-shop .nav-a:hover {
+        color: #ff9900;
+        text-decoration: underline;
+      }
+      #navbar #nav-search .nav-search-facade,
+      #navbar #nav-tools .nav-icon,
+      #navbar #nav-shop .nav-icon,
+      #navbar #nav-subnav .nav-hasArrow .nav-arrow {
+        display: none;
+      }
+      #navbar #nav-search .nav-search-submit,
+      #navbar #nav-search .nav-search-scope {
+        display: block;
+      }
+      #nav-search .nav-search-scope {
+        padding: 0 5px;
+      }
+      #navbar #nav-search .nav-search-dropdown {
+        position: relative;
+        top: 5px;
+        height: 23px;
+        font-size: 14px;
+        opacity: 1;
+        filter: alpha(opacity = 100);
+      }
+    --></style>
+ </noscript>
+<script type='text/javascript'>window.navmet.push({key:'PreNav',end:+new Date(),begin:window.navmet.tmp});</script>
+
+<a id='nav-top'></a>
+
+
+
+
+
+  
+<nav
+  id="shortcut-menu"
+  class="nav-assistant"
+  aria-label="Shortcuts menu"
+  tabindex="-1"
+  role="navigation" 
+  
+  data-skip-link-target-text="Main content start"
+  data-hashed-id="a37652a4e2fad37e7ff492694add6f9ac92a8d892c6a6f11926e7eafc1ef2ea0"
+data-raw-id="AEXAMPLE00000"
+>
+  <h2 id="nav-assistant-links-heading" class="nav-assistant-heading nav-assistant-headers-font">Skip to</h2>
+  <ul aria-labelledby="nav-assistant-links-heading" class="nav-assistant-links-container">
+    <li class="nav-assistant-list-item ">
+      <a
+        href="#skippedLink"
+        id="nav-assist-skip-to-main-content"
+        aria-label="main content"
+        aria-describedby="nav-assist-shortcut-help"
+        tabindex="0"
+        data-target="#skippedLink"
+        data-scrolltarget=""
+        data-behavior="navigate"
+        
+        
+        data-nav-assist-menu-item-index="0"
+        class="nav-assistant-link nav-assistant-menu-item nav-assistant-link-item a-color-base a-color-link "
+      >
+        Main content
+      </a>
+    </li>
+  </ul>
+  <hr class="nav-assistant-separator" aria-hidden="true" />
+  <h2 id="nav-assist-shortcuts-heading" class="nav-assistant-heading nav-assistant-headers-font font-color aok-hidden">
+      Keyboard shortcuts
+  </h2>
+  <ul class="keyboard-shortcuts-list-container aok-hidden" id="nav-assist-shortcuts-container" aria-labelledby="nav-assist-shortcuts-heading">
+    <li class="nav-assistant-list-item">
+      <a
+        href="javascript:void(0)"
+        id="nav-assist-search"
+        role="link"
+        tabindex="-1"
+        class="nav-assistant-menu-item nav-assistant-link-item nav-assistant-keyboard-shortcut-item keyboard-shortcut-menu-container a-color-base a-color-link "
+        data-nav-assist-menu-item-index="1"
+        data-behavior="navigate"
+        
+        data-actuators="[{&quot;eventCode&quot;:&quot;Slash&quot;,&quot;eventKey&quot;:&quot;÷&quot;,&quot;isShiftRequired&quot;:false},{&quot;eventCode&quot;:&quot;Digit7&quot;,&quot;eventKey&quot;:&quot;\\&quot;,&quot;isShiftRequired&quot;:true},{&quot;eventCode&quot;:&quot;Period&quot;,&quot;eventKey&quot;:&quot;\\&quot;,&quot;isShiftRequired&quot;:true},{&quot;eventCode&quot;:&quot;Slash&quot;,&quot;eventKey&quot;:&quot;/&quot;,&quot;isShiftRequired&quot;:false},{&quot;eventCode&quot;:&quot;Digit7&quot;,&quot;eventKey&quot;:&quot;/&quot;,&quot;isShiftRequired&quot;:true},{&quot;eventCode&quot;:&quot;Period&quot;,&quot;eventKey&quot;:&quot;/&quot;,&quot;isShiftRequired&quot;:true},{&quot;eventKey&quot;:&quot;/&quot;,&quot;isShiftRequired&quot;:false}]"
+        data-target="#twotabsearchtextbox"
+        data-modal-ignore=""
+        aria-label="Search, alt, forward slash"
+        aria-describedby="nav-assist-shortcut-help"
+      >
+        <div class="keyboard-shortcut-container" aria-hidden="true">
+          <span class="shortcut-name nav-assistant-card-font">Search</span>
+          <div class="shortcut-keys-container" dir="ltr">
+              <span class="shortcut-key nav-assistant-card-font font-color">alt</span>
+              <span class="plus-sign-color">+</span>
+              <span class="shortcut-key nav-assistant-card-font font-color">/</span>
+              
+          </div>
+        </div>
+      </a>
+    </li>
+    <li class="nav-assistant-list-item">
+      <a
+        href="javascript:void(0)"
+        id="nav-assist-cart"
+        role="link"
+        tabindex="-1"
+        class="nav-assistant-menu-item nav-assistant-link-item nav-assistant-keyboard-shortcut-item keyboard-shortcut-menu-container a-color-base a-color-link "
+        data-nav-assist-menu-item-index="2"
+        data-behavior="navigate"
+        
+        data-actuators="[{&quot;eventKey&quot;:&quot;Ç&quot;,&quot;eventCode&quot;:&quot;KeyC&quot;,&quot;isShiftRequired&quot;:true},{&quot;eventKey&quot;:&quot;¢&quot;,&quot;eventCode&quot;:&quot;KeyC&quot;,&quot;isShiftRequired&quot;:true},{&quot;eventKey&quot;:&quot;C&quot;,&quot;isShiftRequired&quot;:true}]"
+        data-target="/gp/cart/view.html/?ref_&#x3D;nav_assist"
+        data-modal-ignore=""
+        aria-label="Cart, shift, alt, c"
+        aria-describedby="nav-assist-shortcut-help"
+      >
+        <div class="keyboard-shortcut-container" aria-hidden="true">
+          <span class="shortcut-name nav-assistant-card-font">Cart</span>
+          <div class="shortcut-keys-container" dir="ltr">
+              <span class="shortcut-key nav-assistant-card-font font-color">shift</span>
+              <span class="plus-sign-color">+</span>
+              <span class="shortcut-key nav-assistant-card-font font-color">alt</span>
+              <span class="plus-sign-color">+</span>
+              <span class="shortcut-key nav-assistant-card-font font-color">C</span>
+              
+          </div>
+        </div>
+      </a>
+    </li>
+    <li class="nav-assistant-list-item">
+      <a
+        href="javascript:void(0)"
+        id="nav-assist-home"
+        role="link"
+        tabindex="-1"
+        class="nav-assistant-menu-item nav-assistant-link-item nav-assistant-keyboard-shortcut-item keyboard-shortcut-menu-container a-color-base a-color-link "
+        data-nav-assist-menu-item-index="3"
+        data-behavior="navigate"
+        
+        data-actuators="[{&quot;eventKey&quot;:&quot;Ó&quot;,&quot;eventCode&quot;:&quot;KeyH&quot;,&quot;isShiftRequired&quot;:true},{&quot;eventKey&quot;:&quot;Î&quot;,&quot;eventCode&quot;:&quot;KeyH&quot;,&quot;isShiftRequired&quot;:true},{&quot;eventKey&quot;:&quot;˘&quot;,&quot;eventCode&quot;:&quot;KeyH&quot;,&quot;isShiftRequired&quot;:true},{&quot;eventKey&quot;:&quot;H&quot;,&quot;isShiftRequired&quot;:true}]"
+        data-target="/?ref_&#x3D;nav_assist"
+        data-modal-ignore=""
+        aria-label="Home, shift, alt, h"
+        aria-describedby="nav-assist-shortcut-help"
+      >
+        <div class="keyboard-shortcut-container" aria-hidden="true">
+          <span class="shortcut-name nav-assistant-card-font">Home</span>
+          <div class="shortcut-keys-container" dir="ltr">
+              <span class="shortcut-key nav-assistant-card-font font-color">shift</span>
+              <span class="plus-sign-color">+</span>
+              <span class="shortcut-key nav-assistant-card-font font-color">alt</span>
+              <span class="plus-sign-color">+</span>
+              <span class="shortcut-key nav-assistant-card-font font-color">H</span>
+              
+          </div>
+        </div>
+      </a>
+    </li>
+    <li class="nav-assistant-list-item">
+      <a
+        href="javascript:void(0)"
+        id="nav-assist-your-orders"
+        role="link"
+        tabindex="-1"
+        class="nav-assistant-menu-item nav-assistant-link-item nav-assistant-keyboard-shortcut-item keyboard-shortcut-menu-container a-color-base a-color-link "
+        data-nav-assist-menu-item-index="4"
+        data-behavior="navigate"
+        
+        data-actuators="[{&quot;eventKey&quot;:&quot;Ø&quot;,&quot;eventCode&quot;:&quot;KeyO&quot;,&quot;isShiftRequired&quot;:true},{&quot;eventKey&quot;:&quot;Œ&quot;,&quot;eventCode&quot;:&quot;KeyO&quot;,&quot;isShiftRequired&quot;:true},{&quot;eventKey&quot;:&quot;O&quot;,&quot;isShiftRequired&quot;:true}]"
+        data-target="/gp/css/order-history/?ref_&#x3D;nav_assist"
+        data-modal-ignore=""
+        aria-label="Your orders, shift, alt, o"
+        aria-describedby="nav-assist-shortcut-help"
+      >
+        <div class="keyboard-shortcut-container" aria-hidden="true">
+          <span class="shortcut-name nav-assistant-card-font">Orders</span>
+          <div class="shortcut-keys-container" dir="ltr">
+              <span class="shortcut-key nav-assistant-card-font font-color">shift</span>
+              <span class="plus-sign-color">+</span>
+              <span class="shortcut-key nav-assistant-card-font font-color">alt</span>
+              <span class="plus-sign-color">+</span>
+              <span class="shortcut-key nav-assistant-card-font font-color">O</span>
+              
+          </div>
+        </div>
+      </a>
+    </li>
+    <li class="nav-assistant-list-item">
+      <button
+        id="nav-assist-show-shortcuts"
+        role="button"
+        tabindex="-1"
+        class="nav-assistant-menu-item nav-assistant-link-item nav-assistant-keyboard-shortcut-item keyboard-shortcut-menu-container a-color-base a-color-link nav-assistant-link-button"
+        data-nav-assist-menu-item-index="5"
+        data-behavior="show-hide"
+        
+        data-actuators="[{&quot;eventKey&quot;:&quot;¸&quot;,&quot;eventCode&quot;:&quot;KeyZ&quot;,&quot;isShiftRequired&quot;:true},{&quot;eventKey&quot;:&quot;ˇ&quot;,&quot;eventCode&quot;:&quot;KeyY&quot;,&quot;isShiftRequired&quot;:true},{&quot;eventKey&quot;:&quot;Å&quot;,&quot;eventCode&quot;:&quot;KeyW&quot;,&quot;isShiftRequired&quot;:true},{&quot;eventKey&quot;:&quot;⁄&quot;,&quot;eventCode&quot;:&quot;KeyZ&quot;,&quot;isShiftRequired&quot;:true},{&quot;eventKey&quot;:&quot;Z&quot;,&quot;eventCode&quot;:&quot;KeyZ&quot;,&quot;isShiftRequired&quot;:true},{&quot;eventKey&quot;:&quot;Z&quot;,&quot;eventCode&quot;:&quot;KeyY&quot;,&quot;isShiftRequired&quot;:true},{&quot;eventKey&quot;:&quot;Z&quot;,&quot;eventCode&quot;:&quot;KeyW&quot;,&quot;isShiftRequired&quot;:true},{&quot;eventKey&quot;:&quot;Z&quot;,&quot;isShiftRequired&quot;:true}]"
+        data-target="a[data-nav-assist-menu-item-index&#x3D;&quot;0&quot;]"
+        data-modal-ignore=""
+        aria-label="Show/hide shortcuts, shift, alt, z"
+        aria-describedby="nav-assist-shortcut-help"
+      >
+        <div class="keyboard-shortcut-container" aria-hidden="true">
+          <span class="shortcut-name nav-assistant-card-font">Show/Hide shortcuts</span>
+          <div class="shortcut-keys-container" dir="ltr">
+              <span class="shortcut-key nav-assistant-card-font font-color">shift</span>
+              <span class="plus-sign-color">+</span>
+              <span class="shortcut-key nav-assistant-card-font font-color">alt</span>
+              <span class="plus-sign-color">+</span>
+              <span class="shortcut-key nav-assistant-card-font font-color">Z</span>
+              
+          </div>
+        </div>
+      </button>
+    </li>
+  </ul>
+  <div
+    id="nav-assist-shortcut-help"
+    class="aok-hidden"
+  >
+    <div class="shortcut-help-container">
+      <div class="shortcut-help-item-container">
+        <div class="icon-container"><i class="a-icon a-icon-info a-icon-mini shortcut-help-icon"></i></div>
+        <div class="help-text-container">
+          <span class="shortcut-help-text font-color">To move between items, use your keyboard&#x27;s up or down arrows.</span>
+        </div>
+      </div>
+    </div>
+  </div>
+</nav>
+
+
+
+
+
+<script type='text/javascript'>window.navmet.main=+new Date();</script>
+
+
+<style type="text/css">
+#navbar-main #navbar #nav-belt { background: #131921; } #navbar-main #navbar #nav-main { background: #232f3e; } #navbar-main #navbar .nav-a-2 .nav-line-1, .nav-a-2 .nav-line-2, #nav-search-label { color: #fff; } #navbar-main #navbar #nav-cart-count, #nav-ewc-cart-count { color: #f08804; top: 7px; } #navbar-main #navbar #nav-search { .nav-search-scope { background-color: #e6e6e6; border-left: 1px solid #e6e6e6; border-top: 1px solid #e6e6e6; border-bottom: 1px solid #e6e6e6; } .nav-search-scope:hover, .nav-search-scope:focus, .nav-search-scope.nav-focus { background-color: #d4d4d4; border-left-color: #d4d4d4; border-top-color: #d4d4d4; border-bottom-color: #d4d4d4; } .nav-searchbar.nav-active, .nav-searchbar.nav-focus { box-shadow: 0 0 0 2px #ff9900, 0 0 0 3px rgba(255, 153, 0, 0.5); z-index: 1; } .nav-searchbar.nav-active .nav-search-scope, .nav-searchbar.nav-focus .nav-search-scope, .nav-searchbar.nav-active .nav-search-field, .nav-searchbar.nav-focus .nav-search-field { border-top: 1px solid #febd69; border-bottom: 1px solid #febd69; } .nav-searchbar.nav-active .nav-search-scope, .nav-searchbar.nav-focus .nav-search-scope { border-left: 1px solid #febd69; } .nav-search-submit { background-color: #febd69; } .nav-search-submit:hover, .nav-search-submit:focus, .nav-search-submit.nav-focus { background-color: #f3a847; } } #navbar-main #navbar .nav-icon.nav-arrow { border-top-color: #a7acb2; } #navbar-main #navbar .nav-icon-flipped.nav-arrow { border-bottom-color: #a7acb2; } #navbar-main #navbar #nav-flyout-ewc .nav-flyout-head { background-color: #232f3e; } #navbar-main #navbar #nav-logo-borderfade .nav-fade-mask { background-color: #232f3e; width: 195px; }
+</style>
+<header id="navbar-main" class = "nav-opt-sprite nav-flex nav-locale-us nav-lang-en nav-ssl nav-rec nav-progressive-attribute">
+
+   
+  <div id='navbar' cel_widget_id='Navigation-desktop-navbar'
+  role='navigation' class="nav-sprite-v1 celwidget nav-bluebeacon nav-a11y-t1 bold-focus-hover layout2 nav-flex layout3 layout3-alt nav-packard-glow hamburger nav-progressive-attribute" aria-label="Primary">
+    <div id='nav-belt'>
+      <div class='nav-left'>
+        <script type='text/javascript'>window.navmet.tmp=+new Date();</script>
+  <div id="nav-logo" class="nav-prime-1 nav-progressive-attribute">
+    <a href="/ref=nav_logo" id="nav-logo-sprites" class="nav-logo-link nav-progressive-attribute" aria-label="Amazon Prime" lang="en" >
+      <span class="nav-sprite nav-logo-base"></span>
+      <span id="logo-ext" class="nav-sprite nav-logo-ext nav-progressive-content"></span>
+      <span class="nav-logo-locale">.us</span>
+    </a>
+ <div id="nav-tagline" class="nav-progressive-content">
+  <a href="/ref=nav_logo_prime" tabindex="-1"  class="nav-sprite nav-logo-tagline">
+    
+  </a>
+</div>
+  </div>
+<script type='text/javascript'>window.navmet.push({key:'Logo',end:+new Date(),begin:window.navmet.tmp});</script>
+        
+<div id="nav-global-location-slot" data-csa-c-type="widget" data-csa-c-slot-id="GLOW-desktop-nav" data-csa-c-content-id="nav-glow">
+    <span id="nav-global-location-data-modal-action" class="a-declarative nav-progressive-attribute" data-a-modal='{&quot;width&quot;:375, &quot;closeButton&quot;:&quot;true&quot;,&quot;popoverLabel&quot;:&quot;Choose your location&quot;, &quot;ajaxHeaders&quot;:{&quot;anti-csrftoken-a2z&quot;:&quot;hBQG86VbMKkkJfYJCciivzOdVxDunhjAmRGEWqMDsO3eAAAAAGooK3EAAAAB&quot;}, &quot;name&quot;:&quot;glow-modal&quot;, &quot;url&quot;:&quot;/portal-migration/hz/glow/get-rendered-address-selections?deviceType&#x3D;desktop&amp;pageType&#x3D;F3OmnichannelPostOrder&amp;storeContext&#x3D;NoStoreName&amp;actionSource&#x3D;desktop-modal&quot;, &quot;footer&quot;:&quot;&lt;span class&#x3D;\&quot;a-declarative\&quot; data-action&#x3D;\&quot;a-popover-close\&quot; data-a-popover-close&#x3D;\&quot;{}\&quot;&gt;&lt;span class&#x3D;\&quot;a-button a-button-primary\&quot;&gt;&lt;span class&#x3D;\&quot;a-button-inner\&quot;&gt;&lt;button name&#x3D;\&quot;glowDoneButton\&quot; class&#x3D;\&quot;a-button-text\&quot; type&#x3D;\&quot;button\&quot;&gt;Done&lt;/button&gt;&lt;/span&gt;&lt;/span&gt;&lt;/span&gt;&quot;,&quot;header&quot;:&quot;Choose your location&quot;}' data-action="a-modal">
+        <a id="nav-global-location-popover-link" role="button" tabindex="0" class="nav-a nav-a-2 a-popover-trigger a-declarative nav-progressive-attribute" href="">
+            <div class="nav-sprite nav-progressive-attribute" id="nav-packard-glow-loc-icon"></div>
+            <div id="glow-ingress-block">
+                <span class="nav-line-1 nav-progressive-content" id="glow-ingress-line1">
+                   Deliver to Customer
+                </span>
+                <span class="nav-line-2 nav-progressive-content" id="glow-ingress-line2">
+                   Sharon 06069&zwnj;
+                </span>
+            </div>
+        </a>
+        </span>
+        <input data-addnewaddress="add-new" id="unifiedLocation1ClickAddress" name="dropdown-selection" type="hidden" value="jllksojumoknr" class="nav-progressive-attribute" />
+        <input data-addnewaddress="add-new" id="ubbShipTo" name="dropdown-selection-ubb" type="hidden" value="jllksojumoknr" class="nav-progressive-attribute"/>
+        <input id="glowValidationToken" name="glow-validation-token" type="hidden" value="hBQG86VbMKkkJfYJCciivzOdVxDunhjAmRGEWqMDsO3eAAAAAGooK3EAAAAB" class="nav-progressive-attribute"/>
+        <input id="glowDestinationType" name="glow-destination-type" type="hidden" value="ACCOUNT_ADDRESS" class="nav-progressive-attribute"/>
+</div>
+
+<div id="nav-global-location-toaster-script-container" class="nav-progressive-content">
+</div>
+
+      </div>
+          <div class='nav-fill' id='nav-fill-search'>
+            <script type='text/javascript'>window.navmet.tmp=+new Date();</script>
+<div id="nav-search">
+  <div id="nav-bar-left"></div> 
+  <form
+    id="nav-search-bar-form"
+    accept-charset="utf-8"
+    action="/s/ref=nb_sb_noss"
+    class="nav-searchbar nav-progressive-attribute"
+    method="GET"
+    name="site-search"
+    role="search"
+  >
+
+    <div class="nav-left">
+      <div id="nav-search-dropdown-card">
+        
+  <div class="nav-search-scope nav-sprite">
+    <div class="nav-search-facade" data-value="search-alias=aps">
+      <span id="nav-search-label-id" class="nav-search-label nav-progressive-content">All</span>
+      <i class="nav-icon"></i>
+    </div>
+    <label id="searchDropdownDescription" for="searchDropdownBox" class="nav-progressive-attribute" style="display:none">Select the department you want to search in</label>
+    <select
+      aria-describedby="searchDropdownDescription"
+      class="nav-search-dropdown searchSelect nav-progressive-attrubute nav-progressive-search-dropdown"
+      data-nav-digest="RQWv7AxGrkDxs/LIJhOsSvOwQ0k="
+      data-nav-selected="0"
+      id="searchDropdownBox"
+      name="url"
+      style="display: block;"
+      tabindex="0"
+      title="Search in"
+    >
+        <option selected="selected" value="search-alias=aps">All Departments</option>
+        <option value="search-alias=alexa-skills">Alexa Skills</option>
+        <option value="search-alias=vehicles">Amazon Autos</option>
+        <option value="search-alias=amazon-devices">Amazon Devices</option>
+        <option value="search-alias=amazon-global-store">Amazon Global Store</option>
+        <option value="search-alias=bazaar">Amazon Haul</option>
+        <option value="search-alias=amazon-one-medical">Amazon One Medical</option>
+        <option value="search-alias=amazon-pharmacy">Amazon Pharmacy</option>
+        <option value="search-alias=warehouse-deals">Amazon Resale</option>
+        <option value="search-alias=appliances">Appliances</option>
+        <option value="search-alias=mobile-apps">Apps & Games</option>
+        <option value="search-alias=arts-crafts">Arts, Crafts & Sewing</option>
+        <option value="search-alias=audible">Audible Books & Originals</option>
+        <option value="search-alias=automotive">Automotive Parts & Accessories</option>
+        <option value="search-alias=baby-products">Baby</option>
+        <option value="search-alias=beauty">Beauty & Personal Care</option>
+        <option value="search-alias=stripbooks">Books</option>
+        <option value="search-alias=popular">CDs & Vinyl</option>
+        <option value="search-alias=mobile">Cell Phones & Accessories</option>
+        <option value="search-alias=fashion">Clothing, Shoes & Jewelry</option>
+        <option value="search-alias=fashion-womens">Women's Clothing, Shoes & Jewelry</option>
+        <option value="search-alias=fashion-mens">Men's Clothing, Shoes & Jewelry</option>
+        <option value="search-alias=fashion-girls">Girl's Clothing, Shoes & Jewelry</option>
+        <option value="search-alias=fashion-boys">Boy's Clothing, Shoes & Jewelry</option>
+        <option value="search-alias=fashion-baby">Baby Clothing, Shoes & Jewelry</option>
+        <option value="search-alias=collectibles">Collectibles & Fine Art</option>
+        <option value="search-alias=computers">Computers</option>
+        <option value="search-alias=financial">Credit and Payment Cards</option>
+        <option value="search-alias=digital-music">Digital Music</option>
+        <option value="search-alias=electronics">Electronics</option>
+        <option value="search-alias=lawngarden">Garden & Outdoor</option>
+        <option value="search-alias=gift-cards">Gift Cards</option>
+        <option value="search-alias=grocery">Grocery & Gourmet Food</option>
+        <option value="search-alias=handmade">Handmade</option>
+        <option value="search-alias=hpc">Health, Household & Baby Care</option>
+        <option value="search-alias=local-services">Home & Business Services</option>
+        <option value="search-alias=garden">Home & Kitchen</option>
+        <option value="search-alias=industrial">Industrial & Scientific</option>
+        <option value="search-alias=prime-exclusive">Just for Prime</option>
+        <option value="search-alias=digital-text">Kindle Store</option>
+        <option value="search-alias=fashion-luggage">Luggage & Travel Gear</option>
+        <option value="search-alias=luxury">Luxury Stores</option>
+        <option value="search-alias=magazines">Magazine Subscriptions</option>
+        <option value="search-alias=movies-tv">Movies & TV</option>
+        <option value="search-alias=mi">Musical Instruments</option>
+        <option value="search-alias=office-products">Office Products</option>
+        <option value="search-alias=pets">Pet Supplies</option>
+        <option value="search-alias=luxury-beauty">Premium Beauty</option>
+        <option value="search-alias=instant-video">Prime Video</option>
+        <option value="search-alias=smart-home">Smart Home</option>
+        <option value="search-alias=software">Software</option>
+        <option value="search-alias=sporting">Sports & Outdoors</option>
+        <option value="search-alias=specialty-aps-sns">Subscribe & Save</option>
+        <option value="search-alias=subscribe-with-amazon">Subscription Boxes</option>
+        <option value="search-alias=tools">Tools & Home Improvement</option>
+        <option value="search-alias=toys-and-games">Toys & Games</option>
+        <option value="search-alias=under-ten-dollars">Under $10</option>
+        <option value="search-alias=videogames">Video Games</option>
+        <option value="search-alias=vons">Vons</option>
+        <option value="search-alias=wholefoods">Whole Foods Market</option>
+    </select>
+  </div>
+
+      </div>
+    </div>
+    <div class="nav-fill">
+      <div class="nav-search-field ">
+          <label for="twotabsearchtextbox" style="display: none;">Search Amazon</label>
+          <input
+            type="text"
+            id="twotabsearchtextbox"
+            value=""
+            name="field-keywords"
+            autocomplete="off"
+            placeholder="Search Amazon"
+            class="nav-input nav-progressive-attribute"
+            dir="auto"
+            tabindex="0"
+            aria-label="Search Amazon"
+            role="searchbox"
+            aria-autocomplete="list"
+            aria-controls="sac-autocomplete-results-container"
+            aria-expanded="false"
+            aria-haspopup="grid"
+            spellcheck="false"
+            data-agent-button-proxy="nav-search-submit-button-agent"
+            data-agent-field="search-query"
+            form="nav-search-bar-form"
+            data-agent-patched="true"
+          >
+      </div>
+      <div id="nav-iss-attach"></div>
+    </div>
+    <div class="nav-right">
+      <div class="nav-search-submit nav-sprite">
+        <span id="nav-search-submit-text" class="nav-search-submit-text nav-sprite nav-progressive-attribute" aria-label="Go">
+          <input id="nav-search-submit-button" type="submit" class="nav-input nav-progressive-attribute" value="Go" tabindex="0">
+        </span>
+      </div>
+        <span id="nav-search-submit-text-agent" 
+              aria-hidden="true"
+              role="presentation">
+          <input id="nav-search-submit-button-agent" 
+                  type="submit" 
+                  value="Agent Search" 
+                  tabindex="-1"
+                  data-agent-action="primary-search" 
+                  data-search-mode="agent" 
+                  data-agent-priority="primary" 
+                  data-agent-recommended="true" 
+                  data-target-audience="ai-agent" 
+                  data-provides="structured-results" 
+                  data-optimization="high">
+        </span>
+    </div>
+  </form>
+</div>
+<script type='text/javascript'>window.navmet.push({key:'Search',end:+new Date(),begin:window.navmet.tmp});</script>
+          </div>
+      <div class='nav-right'>
+          <script type='text/javascript'>window.navmet.tmp=+new Date();</script>
+          <div id='nav-tools' class="layoutToolbarPadding">
+              
+              
+              
+              
+  <div class="nav-div" id="icp-nav-flyout">
+  <a href="/customer-preferences/edit?ie=UTF8&preferencesReturnUrl=%2F&ref_=topnav_lang" class="nav-a nav-a-2 icp-link-style-2" aria-label="Choose a language for shopping in Amazon United States. The current selection is English (EN).
+">
+    <span class="icp-nav-link-inner">
+      <span class="nav-line-1">
+      </span>
+      <span class="nav-line-2">
+         <span class="icp-nav-flag icp-nav-flag-us icp-nav-flag-lop" role="img" aria-label="United States"></span>
+          <div>EN</div>
+      </span>
+    </span>
+  </a>
+  <button class="nav-flyout-button nav-icon nav-arrow" aria-label="Expand to Change Language or Country" tabindex=0></button>
+</div>
+
+              
+  <div class="nav-div" id="nav-link-accountList">
+  <a href="https://www.amazon.com/gp/css/homepage.html?ref_=nav_youraccount_btn" class="nav-a nav-a-2 nav-truncate   nav-progressive-attribute" data-nav-ref="nav_youraccount_btn"  data-nav-role="signin" data-ux-jq-mouseenter="true" tabindex="0" data-csa-c-type="link" data-csa-c-slot-id="nav-link-accountList" data-csa-c-content-id="nav_youraccount_btn"  aria-controls="nav-flyout-accountList" >
+  <div class="nav-line-1-container"><span id="nav-link-accountList-nav-line-1" class="nav-line-1 nav-progressive-content">Hello, Customer</span></div>
+  <span class="nav-line-2 ">Account & Lists
+  </span>
+  </a>
+  <button class="nav-flyout-button nav-icon nav-arrow" aria-label="Expand Account and Lists" tabindex=0></button>
+  </div>
+
+              
+<a href="/gp/css/order-history?ref_=nav_orders_first" class="nav-a nav-a-2   nav-progressive-attribute" id="nav-orders" tabindex="0">
+  <span class="nav-line-1">Returns</span>
+  <span class="nav-line-2">& Orders<span class="nav-icon nav-arrow"></span></span>
+</a>
+
+              
+              
+  <a href="/gp/cart/view.html?ref_=nav_cart" aria-label="1 item in cart" class="nav-a nav-a-2 nav-progressive-attribute" id="nav-cart">
+    <div id="nav-cart-count-container">
+      <span id="nav-cart-count" aria-hidden="true" class="nav-cart-count nav-cart-1 nav-progressive-attribute nav-progressive-content">1</span>
+      <span class="nav-cart-icon nav-sprite"></span>
+    </div>
+    <div id="nav-cart-text-container" class=" nav-progressive-attribute">
+      <span aria-hidden="true" class="nav-line-1">
+        
+      </span>
+      <span aria-hidden="true" class="nav-line-2">
+        Cart
+        <span class="nav-icon nav-arrow"></span>
+      </span>
+    </div>
+  </a>
+
+          </div>
+          <script type='text/javascript'>window.navmet.push({key:'Tools',end:+new Date(),begin:window.navmet.tmp});</script>
+
+      </div>
+    </div>
+    <div id='nav-belt-search' class='nav-fill'></div>
+    <div id='nav-main' class='nav-sprite'>
+      <div class='nav-left'>
+        <script type='text/javascript'>window.navmet.tmp=+new Date();</script>
+  <a href="/gp/site-directory?ref_=nav_em_js_disabled" id="nav-hamburger-menu" role="button" aria-label="Open All Categories Menu" aria-expanded="false" data-csa-c-type="widget" data-csa-c-slot-id="HamburgerMenuDesktop"
+  data-csa-c-interaction-events="click" >
+    <i class="hm-icon nav-sprite"></i>
+    <span class="hm-icon-label">All</span>
+  </a>
+  
+<script type="text/javascript">
+  var hmenu = document.getElementById("nav-hamburger-menu");
+  hmenu.setAttribute("href", "javascript: void(0)");
+  window.navHamburgerMetricLogger = function() {
+    if (window.ue && window.ue.count) {
+      var metricName = "Nav:Hmenu:IconClickActionPending";
+      window.ue.count(metricName, (ue.count(metricName) || 0) + 1);
+    }
+    window.$Nav && $Nav.declare("navHMenuIconClicked",!0);
+    window.$Nav && $Nav.declare("navHMenuIconClickedNotReadyTimeStamp", Date.now());
+  };
+  hmenu.addEventListener("click", window.navHamburgerMetricLogger);
+  window.$Nav && $Nav.declare('hamburgerMenuIconAvailableOnLoad', false);
+</script>  
+<script type='text/javascript'>window.navmet.push({key:'HamburgerMenuIcon',end:+new Date(),begin:window.navmet.tmp});</script>
+        
+            <button class='nav-rufus-disco' id='nav-rufus-disco' data-state='closed' role='button' aria-label='Open Alexa panel' data-csa-c-type='button' data-csa-c-slot-id='rufus-dsk-disco-slot' data-csa-c-content-id='rufus-dsk-disco-content'><div id='nav-rufus-disco-avatar' class='nav-rufus-disco-avatar'></div><div id='nav-rufus-disco-text' class='nav-rufus-disco-text'>for shopping</div></button><div id='nav-flyout-rufus' class='rufus-panel-container' data-state='closed' style='background-color:#FBFBFB'><div id='rufus-panel-resize-handle-unified' class='rufus-panel-resize-handle-unified'></div><div id='rufus-panel-tooltip' class='rufus-panel-tooltip'><div class='rufus-panel-tooltip-content'>Drag to reposition this window <button class='rufus-panel-tooltip-close' type='button' aria-label='close'>×</button></div><div class='rufus-panel-tooltip-caret'></div></div><div id='rufus-panel-header-container' class='rufus-panel-header-container'><div id='rufus-panel-header-grabber-row' class='rufus-panel-header-grabber-row'><div id='rufus-panel-header-grabber' class='rufus-panel-header-grabber' aria-label='drag to resize'></div></div><div id='rufus-panel-header-content-row' class='rufus-panel-header-content-row rufus-dockable'><div id='rufus-panel-header-left-section' class='rufus-panel-header-left-section'><div id='rufus-panel-header-logo' class='rufus-panel-header-logo'><div id='rufus-panel-header-title' class='rufus-panel-header-title-logo-update' style='background-image:url(https://m.media-amazon.com/images/G/01/Rufus_Desktop/Alexa_For_Shopping_Header.svg)' role='img' aria-label='Alexa For Shopping Logo'></div></div><button class='rufus-panel-header-minimize aok-hidden' role='button' aria-label='minimize' id='rufus-panel-header-minimize' data-csa-c-type='button' data-csa-c-slot-id='rufus-dsk-panel-header-minimize-slot' data-csa-c-content-id='rufus-dsk-panel-header-minimize-content'></button></div><div id='rufus-panel-header-center-section' class='rufus-panel-header-center-section'><div id='rufus-panel-header-overflow' class='rufus-panel-header-overflow'></div></div><div id='rufus-panel-header-right-section' class='rufus-panel-header-right-section'><button class='rufus-panel-header-overflow-button' role='button' aria-label='Alexa overflow menu' aria-expanded='false' id='rufus-panel-header-overflow-button' data-csa-c-type='button' data-csa-c-slot-id='rufus-dsk-panel-header-overflow-button-slot' data-csa-c-content-id='rufus-dsk-panel-header-overflow-button-content'></button><div class='rufus-overflow-menu-container' id='rufus-overflow-menu-container' data-state='closed'></div><button class='rufus-panel-header-dock-undock-button' role='button' aria-label='' id='rufus-panel-header-dock-undock-button' data-csa-c-type='button' data-csa-c-slot-id='rufus-dsk-panel-header-dock-undock-button-slot' data-csa-c-content-id='rufus-dsk-panel-header-dock-undock-button-content'></button> <button class='rufus-panel-header-close' role='button' aria-label='close' id='rufus-panel-header-close' data-csa-c-type='button' data-csa-c-slot-id='rufus-dsk-panel-header-close-slot' data-csa-c-content-id='rufus-dsk-panel-header-close-content'></button></div></div></div><div id='nav-rufus-content' class='nav-rufus-content rufus-dockable' style='background-color:#FBFBFB'></div><input type='hidden' id='rufus-view-context' name='rufus-view-context' value='{"pageType":"F3OmnichannelPostOrder"}'></div><script type='text/javascript'>;(function () {
+        function isValidNumber(input) {
+    // if the input is string, Number(input) will become NaN but the type will be number
+    // so we need to check if the value if NaN after its type is changed to number
+    return typeof Number(input) === "number" && !isNaN(Number(input));
+}
+        const featureScope = {"renderRufusPanel":"renderRufusPanel","startRufusStream":"startRufusStream","startRufusInitialLoading":"startRufusInitialLoading"};
+        function logError(error) {
+    const extendedWindow = window;
+    if (extendedWindow.ueLogError) {
+        const errorLogAdditionalInfo = {
+            attribution: "AmazonNavigationRufusCard",
+            logLevel: "ERROR",
+            message: error.message
+        };
+        extendedWindow.ueLogError(error, errorLogAdditionalInfo);
+    }
+}
+        function logCount(metricName) {
+    const extendedWindow = window;
+    if (extendedWindow.ue && extendedWindow.ue.count) {
+        var current = extendedWindow.ue.count(metricName) || 0;
+        extendedWindow.ue.count(metricName, current + 1);
+    }
+}
+        function logLatency(scope, isStart) {
+    // ts-ignore needed since 'uet' and 'uex' defined in javascript
+    // @ts-ignore
+    if (typeof uet == "function" && isStart) {
+        // @ts-ignore
+        uet("bb", scope, { wb: 1 });
+    }
+    // @ts-ignore
+    if (typeof uex == "function" && typeof uet == "function" && !isStart) {
+        // @ts-ignore
+        uet("be", scope, { wb: 1 });
+        // @ts-ignore
+        uex("ld", scope, { wb: 1 });
+    }
+}
+        function renderErrorUI(errorMessage) {
+    const rufusContent = document.querySelector(".nav-rufus-content");
+    const errorDiv = document.createElement("div");
+    errorDiv.classList.add("rufus-panel-error-message");
+    errorDiv.innerHTML = errorMessage;
+    rufusContent.appendChild(errorDiv);
+}
+        function fetchRufusTriggerMarker(rufusTriggerMarkerMappingString, pageType) {
+    if (!pageType || !rufusTriggerMarkerMappingString) {
+        return;
+    }
+    let rufusPageTriggerMarkerMapping;
+    try {
+        rufusPageTriggerMarkerMapping = JSON.parse(rufusTriggerMarkerMappingString);
+    }
+    catch (error) {
+        const errorMessage = "Error parsing rufusTriggerMarkerMappingString: " +
+            rufusTriggerMarkerMappingString +
+            ". " +
+            error;
+        logError(new Error(errorMessage));
+        return undefined;
+    }
+    return rufusPageTriggerMarkerMapping === null || rufusPageTriggerMarkerMapping === void 0 ? void 0 : rufusPageTriggerMarkerMapping[pageType];
+}
+        function updateCurrentRufusContent(innerHTMLContent, isCacheContent, noScrollTreatment) {
+    const rufusContent = document.querySelector(".nav-rufus-content");
+    const tempDiv = document.createElement("div");
+    tempDiv.innerHTML = innerHTMLContent;
+    // Query for the first element matching the selector "link[rel='stylesheet']"
+    const stylesheet = tempDiv.querySelector("link[rel='stylesheet']");
+    if (stylesheet) {
+        const linkElement = document.createElement("link");
+        linkElement.rel = "stylesheet";
+        linkElement.href = stylesheet.href;
+        // Set up the onload event handler for the <link> element
+        linkElement.onload = function () {
+            // make sure no duplicate rufus container view will be appended
+            if (!rufusContent.querySelector(".rufus-container")) {
+                // remove all script tags and the first occurrence of the link tag.
+                rufusContent.innerHTML += innerHTMLContent
+                    .replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, "")
+                    .replace(/<link[^>]*>/i, "");
+                const rufusConversationContainer = rufusContent.querySelector("#rufus-conversation-container");
+                if (rufusConversationContainer) {
+                    // Determine the scroll position to restore.
+                    // Default is scroll-to-bottom. When restoring from cache with the
+                    // RUFUS_DESKTOP_AFO_NO_SCROLL_1414612 weblab active (T1), attempt to
+                    // restore the exact position the user was at before navigation.
+                    // The thick client saves this value to sessionStorage under "rufus:panel:scrollTop".
+                    // The key will be stored only for the AFO click case, other page navigation
+                    // scenarios will continue to scroll to the bottom.
+                    // Note: the definitive fix for glitch-free restoration is to handle this
+                    // in the thick client as well.
+                    let targetScrollTop = rufusConversationContainer.scrollHeight;
+                    if (isCacheContent && noScrollTreatment === "T1") {
+                        try {
+                            const CL_SCROLL_POSITION_CACHE_KEY = "rufus:panel:scrollTop";
+                            const savedScrollTop = sessionStorage.getItem(CL_SCROLL_POSITION_CACHE_KEY);
+                            if (savedScrollTop !== null) {
+                                targetScrollTop = parseFloat(savedScrollTop);
+                                logCount("rufus-scroll-restore-position-hit");
+                            }
+                            else {
+                                // No saved position — targetScrollTop stays as scrollHeight (scroll-to-bottom).
+                                logCount("rufus-scroll-restore-position-miss");
+                            }
+                        }
+                        catch (error) {
+                            // sessionStorage may be unavailable (e.g. private browsing restrictions);
+                            // fall back gracefully to scroll-to-bottom.
+                            logCount("rufus-scroll-restore-session-storage-error");
+                        }
+                    }
+                    rufusConversationContainer.scrollTop = targetScrollTop;
+                }
+            }
+            else {
+                // when panel is rendered with cached content, we still need to update CSRF token from /render response to avoid
+                // 403 issue when a tab is kept open more than 24 hours and streaming happened in this tab
+                const csrfContentMetadata = rufusContent.querySelector('meta[name="anti-csrftoken-a2z"]');
+                const newCSRFContentMetadata = tempDiv.querySelector('meta[name="anti-csrftoken-a2z"]');
+                const newCSRFToken = newCSRFContentMetadata === null || newCSRFContentMetadata === void 0 ? void 0 : newCSRFContentMetadata.getAttribute("content");
+                newCSRFToken &&
+                    (csrfContentMetadata === null || csrfContentMetadata === void 0 ? void 0 : csrfContentMetadata.setAttribute("content", newCSRFToken));
+                // Swap refreshable weblab treatment map from new /render response
+                // so the thick client can read fresh treatments from the DOM
+                const refreshableWeblabInput = rufusContent.querySelector('input[name="refreshableClientWeblabTreatmentMap"]');
+                const newRefreshableWeblabInput = tempDiv.querySelector('input[name="refreshableClientWeblabTreatmentMap"]');
+                if (refreshableWeblabInput && newRefreshableWeblabInput) {
+                    refreshableWeblabInput.value = newRefreshableWeblabInput.value;
+                }
+            }
+            // Extract script content from responseText and execute it with script element
+            const tmpElement = document.createElement("div");
+            tmpElement.innerHTML = innerHTMLContent;
+            const scripts = tmpElement.querySelectorAll("script");
+            scripts.forEach(function (script) {
+                var clonedScript = document.createElement("script");
+                if (script.src) {
+                    clonedScript.src = script.src;
+                }
+                // page state will store the data into <script />.
+                // We should also clone the script type and attribute for using page state
+                if (script.type) {
+                    clonedScript.type = script.type;
+                }
+                const pageStateAttriute = script.getAttribute("data-a-state");
+                if (pageStateAttriute != null) {
+                    clonedScript.setAttribute("data-a-state", pageStateAttriute);
+                }
+                clonedScript.text = script.text;
+                document.body.appendChild(clonedScript);
+                logLatency(featureScope.renderRufusPanel, false);
+            });
+            tmpElement.remove();
+        };
+        rufusContent.appendChild(linkElement);
+        return true;
+    }
+    else {
+        const innerHTMLContentType = isCacheContent ? "cache" : "backend response";
+        const errorMessage = "stylesheet not found in innerHTML, while loading " +
+            innerHTMLContentType;
+        logError(new Error(errorMessage));
+        return false;
+    }
+}
+        function checkAllKeysHaveValue(config, keys) {
+    for (let i = 0; i < Object.keys(keys).length; i++) {
+        const key = Object.keys(keys)[i];
+        const value = config[key];
+        if (value === undefined || value === null || value === "") {
+            return false; // Return false if any value is undefined, null, or an empty string
+        }
+    }
+    return true; // Return true if all values are defined and non-empty
+}
+        function observeVisibility(targetDiv, callback) {
+    function handleVisibilityChange(entries, observer) {
+        for (let i = 0; i < entries.length; i++) {
+            const entry = entries[i];
+            const isVisible = window.getComputedStyle(entry.target).visibility !== "hidden";
+            if (entry.isIntersecting && isVisible) {
+                callback();
+                // Disconnect the observer after the function is triggered once
+                observer.disconnect();
+            }
+        }
+    }
+    const observer = new IntersectionObserver(handleVisibilityChange, {
+        root: null,
+        rootMargin: "0px",
+        threshold: 1
+    });
+    observer.observe(targetDiv);
+}
+        function renderRufusContent(hasCacheContent, errorMessageTextToRender) {
+    logLatency(featureScope.renderRufusPanel, true);
+    let retries = 0;
+    const maxRetries = 1;
+    function sendRequest() {
+        const extendedWindow = window;
+        var url = "/rufus/cl/render?ref=nl_cl_dsk_rend";
+        var xhr = new XMLHttpRequest();
+        xhr.open("GET", url, true);
+        xhr.onload = function () {
+            if (xhr.status >= 200 && xhr.status < 300) {
+                let content = xhr.responseText;
+                updateCurrentRufusContent(content, false);
+                logCount("rufusRenderSuccess");
+                extendedWindow.P &&
+                    extendedWindow.P.declare("rufus-container-fetched", {
+                        container: content
+                    });
+            }
+            else if (xhr.status === 504 && retries < maxRetries) {
+                retries++;
+                logCount("rufusRenderRetryOnTimeout:" + retries);
+                sendRequest();
+            }
+            else {
+                renderErrorUI(errorMessageTextToRender);
+                logCount("rufusRenderServerError:" + getStatusBucket(xhr.status));
+            }
+        };
+        xhr.onerror = function () {
+            if (retries < maxRetries) {
+                retries++;
+                logCount("rufusRenderRetryOnNetworkError:" + retries);
+                sendRequest();
+            }
+            else {
+                renderErrorUI(errorMessageTextToRender);
+                logCount("rufusRenderNetworkError");
+            }
+        };
+        xhr.send();
+    }
+    sendRequest();
+    return true;
+}
+        function wrapFunctionWithSchedulerAndExecutor(func, timeout) {
+    let hasExecuted = false;
+    let timeoutId;
+    // Function to execute and mark as executed
+    function execute() {
+        if (!hasExecuted) {
+            hasExecuted = true;
+            func();
+        }
+    }
+    // schedule timeout to execute function
+    function schedule() {
+        timeoutId = setTimeout(execute, timeout);
+    }
+    // force executing function before timeout if needed
+    function forceExecute() {
+        timeoutId && clearTimeout(timeoutId);
+        execute();
+    }
+    // Return schedule and forceExecute function to execute in different scenarios
+    return {
+        schedule: schedule,
+        forceExecute: forceExecute
+    };
+}
+        function getDockingSide(dockedSidePanelTreatment) {
+    const treatment = dockedSidePanelTreatment || "C";
+    if (treatment === "T1") {
+        return "docked-left";
+    }
+    else if (treatment === "T2") {
+        return "docked-right";
+    }
+    return "none";
+}
+        (function rufusJavascript(params) {
+    var _a;
+    const FTUX_RUX_ELIGIBLE_SOURCES = new Set([
+        "NileIngressOnsiteMarketing",
+        "NileIngressLink"
+    ]);
+    function isFtuxRuxEligibleSource(qis) {
+        return !!qis && FTUX_RUX_ELIGIBLE_SOURCES.has(qis);
+    }
+    // Session storage key for docked panel width (set by DockedPanelResizeHandler)
+    const DOCKED_PANEL_WIDTH_KEY = "rufus:dockedPanelWidth";
+    // Panel width constraints
+    const DEFAULT_DOCKED_PANEL_WIDTH = 320;
+    const MAX_DOCKED_PANEL_WIDTH = 420;
+    /**
+     * Calculates the default docked panel width based on the current screen size.
+     * This ensures the panel always opens at the appropriate width for the viewport,
+     * "forgetting" any previous user-resized width.
+     *
+     * Screen size breakpoints:
+     * - Small (≤1439px):           320px
+     * - Medium (≥1440px):          420px
+     */
+    function getDefaultDockedPanelWidth() {
+        const screenWidth = window.innerWidth;
+        if (screenWidth >= 1440) {
+            return MAX_DOCKED_PANEL_WIDTH; // 420px
+        }
+        return DEFAULT_DOCKED_PANEL_WIDTH; // 320px - Default
+    }
+    // Get the docked panel width for page load / navigation:
+    // - When adjustable width weblab is enabled (T1): use stored width if available (for navigation continuity),
+    //   otherwise fall back to dynamic default based on screen size
+    // - Otherwise: use static minimum width (320px)
+    function getDockedPanelWidth() {
+        if (params.dockedPanelAdjustableWidthTreatment === "T1") {
+            try {
+                const storedWidth = sessionStorage.getItem(DOCKED_PANEL_WIDTH_KEY);
+                if (storedWidth) {
+                    const widthValue = parseInt(storedWidth, 10);
+                    if (!isNaN(widthValue) &&
+                        widthValue >= DEFAULT_DOCKED_PANEL_WIDTH &&
+                        widthValue <= MAX_DOCKED_PANEL_WIDTH) {
+                        return widthValue;
+                    }
+                }
+            }
+            catch (error) {
+                // Session storage may not be available, use default
+            }
+            // No stored width → use dynamic default based on screen size
+            return getDefaultDockedPanelWidth();
+        }
+        return DEFAULT_DOCKED_PANEL_WIDTH;
+    }
+    let rufusPanelConfig;
+    const extendedWindow = window;
+    extendedWindow.isB2B = params.isB2B;
+    const rufusFlyoutDiv = document.getElementById("nav-flyout-rufus");
+    rufusFlyoutDiv &&
+        observeVisibility(rufusFlyoutDiv, function () {
+            if (extendedWindow.P && typeof extendedWindow.P.declare === "function") {
+                extendedWindow.P.declare("rufus-panel-first-visible", new Date().getTime());
+            }
+        });
+    const rufusPanelConfigString = params.rufusPanelConfigString;
+    const rufusViewContext = params.rufusViewContext;
+    const isCacheEnabled = params.isCacheEnabled;
+    const uniqueId = params.uniqueId;
+    const renderRequestForAllPageTypesEnabled = params.renderRequestForAllPageTypesEnabled;
+    const rufusErrorMessageText = params.rufusErrorMessageText;
+    const latencyRegressionMitigationStrategy = params.latencyRegressionMitigationStrategy;
+    const rufusNavOnlyHoldoutTreatment = params.rufusNavOnlyHoldoutTreatment;
+    const rufusTriggerMarkerMappingString = params.rufusTriggerMarkerMappingString;
+    const rufusTriggerMarkerFallbackTimeoutString = params.rufusTriggerMarkerFallbackTimeoutString;
+    const movableCLEnabled = params.movableCLEnabled;
+    const dockedSidePanelTreatment = params.dockedSidePanelTreatment;
+    const statePersistenceTreatment = params.statePersistenceTreatment;
+    const dockedPanelAdjustableWidthTreatment = params.dockedPanelAdjustableWidthTreatment;
+    const blueHeronGatingTreatment = params.blueHeronGatingTreatment;
+    const movableCLPersistenceTreatment = params.movableCLPersistenceTreatment;
+    const deprecateMovableCLEnabled = params.deprecateMovableCLEnabled;
+    const noScrollTreatment = params.noScrollTreatment;
+    // Add Alexa+ rebranding body class when Blue Heron weblab is T1
+    if (blueHeronGatingTreatment === "T1") {
+        document.body.classList.add("rufus-cl-alexa-plus");
+    }
+    // Default panel positioning values
+    const DEFAULT_PANEL_LEFT = 0;
+    const DEFAULT_PANEL_BOTTOM = 0;
+    const DOCKED_PANEL_WIDTH = getDockedPanelWidth();
+    const EWC_CART_WIDTH = 100;
+    const BROWSER_MARGIN = 12;
+    const TOTAL_WIDTH_TAKEN_IN_PAGE = DOCKED_PANEL_WIDTH + BROWSER_MARGIN;
+    const AUTO_UNDOCKING_SIZE = 1000 + TOTAL_WIDTH_TAKEN_IN_PAGE;
+    const DUAL_PANEL_SELECTOR = ".nav-ewc-persistent-hover #nav-flyout-ewc";
+    // Check if adjustable width feature is enabled
+    const isAdjustableWidthEnabled = () => dockedPanelAdjustableWidthTreatment === "T1";
+    // Should auto-undock for small screens unless adjustable width is enabled
+    // or movable CL deprecation weblab is enabled (auto-undock removed entirely).
+    const shouldAutoUndock = () => window.innerWidth < AUTO_UNDOCKING_SIZE &&
+        !isAdjustableWidthEnabled() &&
+        !deprecateMovableCLEnabled;
+    // Dock icon constants
+    const DOCK_LEFT_ICON = "url('data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%2215%22%20height%3D%2214%22%20viewBox%3D%220%200%2015%2014%22%20fill%3D%22none%22%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%3E%3Cpath%20d%3D%22M4.53012%2010.5672L4.53012%2010.6412C4.53012%2011.7458%205.42555%2012.6412%206.53012%2012.6412L9.08708%2012.6412%22%20stroke%3D%22%23565959%22%20stroke-width%3D%221.5%22%20stroke-linecap%3D%22round%22/%3E%3Cpath%20d%3D%22M8.78328%2012.6412L11.3402%2012.6412C12.4448%2012.6412%2013.3402%2011.7458%2013.3402%2010.6412L13.3402%208.19678%22%20stroke%3D%22%23565959%22%20stroke-width%3D%221.5%22%20stroke-linecap%3D%22round%22/%3E%3Cpath%20d%3D%22M13.3402%208.4931L13.3402%206.04865C13.3402%204.94408%2012.4448%204.04865%2011.3402%204.04865L10.3782%204.04865%22%20stroke%3D%22%23565959%22%20stroke-width%3D%221.5%22%20stroke-linecap%3D%22round%22/%3E%3Cpath%20d%3D%22M0.75%205.00316L0.75%207.56012C0.75%208.66469%201.64543%209.56012%202.75%209.56012L5.19445%209.56012%22%20stroke%3D%22%23565959%22%20stroke-width%3D%221.5%22%20stroke-linecap%3D%22round%22/%3E%3Cpath%20d%3D%22M5.19443%209.56012L7.63889%209.56012C8.74345%209.56012%209.63889%208.66469%209.63889%207.56012L9.63889%205.00316%22%20stroke%3D%22%23565959%22%20stroke-width%3D%221.5%22%20stroke-linecap%3D%22round%22/%3E%3Cpath%20d%3D%22M5.19445%200.75H2.75C1.64543%200.75%200.75%201.64543%200.75%202.75V5.30696%22%20stroke%3D%22%23565959%22%20stroke-width%3D%221.5%22%20stroke-linecap%3D%22round%22/%3E%3Cpath%20d%3D%22M9.63889%205.30696L9.63889%202.75C9.63889%201.64543%208.74346%200.75%207.63889%200.75L5.19443%200.75%22%20stroke%3D%22%23565959%22%20stroke-width%3D%221.5%22%20stroke-linecap%3D%22round%22/%3E%3Cpath%20d%3D%22M3.29893%203.30185L7.47142%207.52393%22%20stroke%3D%22%23565959%22%20stroke-linecap%3D%22round%22/%3E%3Cpath%20d%3D%22M6.03329%202.85727L2.84341%202.85727L2.84341%205.96838%22%20stroke%3D%22%23565959%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22/%3E%3C/svg%3E')";
+    const DOCK_RIGHT_ICON = "url('data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%2214%22%20height%3D%2214%22%20viewBox%3D%220%200%2014%2014%22%20fill%3D%22none%22%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%3E%3Cpath%20d%3D%22M2.82408%203.93988H2.75C1.64543%203.93988%200.75%204.83531%200.75%205.93988V8.49684%22%20stroke%3D%22%23565959%22%20stroke-width%3D%221.5%22%20stroke-linecap%3D%22round%22/%3E%3Cpath%20d%3D%22M0.75%208.19304L0.75%2010.75C0.75%2011.8546%201.64543%2012.75%202.75%2012.75L5.19445%2012.75%22%20stroke%3D%22%23565959%22%20stroke-width%3D%221.5%22%20stroke-linecap%3D%22round%22/%3E%3Cpath%20d%3D%22M4.89814%2012.75L7.34259%2012.75C8.44716%2012.75%209.34259%2011.8546%209.34259%2010.75L9.34259%209.78797%22%20stroke%3D%22%23565959%22%20stroke-width%3D%221.5%22%20stroke-linecap%3D%22round%22/%3E%3Cpath%20d%3D%22M3.86111%205.00316L3.86111%207.56012C3.86111%208.66469%204.75654%209.56012%205.86111%209.56012L8.30557%209.56012%22%20stroke%3D%22%23565959%22%20stroke-width%3D%221.5%22%20stroke-linecap%3D%22round%22/%3E%3Cpath%20d%3D%22M8.30555%209.56012L10.75%209.56012C11.8546%209.56012%2012.75%208.66469%2012.75%207.56012L12.75%205.00316%22%20stroke%3D%22%23565959%22%20stroke-width%3D%221.5%22%20stroke-linecap%3D%22round%22/%3E%3Cpath%20d%3D%22M8.30557%200.75H5.86111C4.75655%200.75%203.86111%201.64543%203.86111%202.75V5.30696%22%20stroke%3D%22%23565959%22%20stroke-width%3D%221.5%22%20stroke-linecap%3D%22round%22/%3E%3Cpath%20d%3D%22M12.75%205.30696L12.75%202.75C12.75%201.64543%2011.8546%200.75%2010.75%200.75L8.30555%200.75%22%20stroke%3D%22%23565959%22%20stroke-width%3D%221.5%22%20stroke-linecap%3D%22round%22/%3E%3Cpath%20d%3D%22M10.1573%203.33211L5.9352%207.50459%22%20stroke%3D%22%23565959%22%20stroke-linecap%3D%22round%22/%3E%3Cpath%20d%3D%22M10.6019%206.06646L10.6019%202.87659L7.49075%202.87659%22%20stroke%3D%22%23565959%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22/%3E%3C/svg%3E')";
+    // Determine docking side
+    const dockingSide = getDockingSide(dockedSidePanelTreatment);
+    const isIpad = navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1;
+    const rufusButton = document.getElementById("nav-rufus-disco");
+    if (isIpad) {
+        rufusButton && rufusButton.remove();
+        rufusFlyoutDiv && rufusFlyoutDiv.remove();
+        logCount("Nav:Rufus:IngressButtonRemoved");
+        return;
+    }
+    const rufusPanelCacheKey = "rufus:panel";
+    const rufusPanelCacheString = sessionStorage.getItem(rufusPanelCacheKey);
+    let rufusPanelCache = undefined;
+    try {
+        rufusPanelCache =
+            rufusPanelCacheString && JSON.parse(rufusPanelCacheString);
+    }
+    catch (error) {
+        const errorMessage = "Error parsing rufusPanelCacheString: " +
+            rufusPanelCacheString +
+            ". " +
+            error;
+        logError(new Error(errorMessage));
+    }
+    const cachedUniqueId = rufusPanelCache &&
+        rufusPanelCache.metadata &&
+        rufusPanelCache.metadata.uniqueId;
+    let cacheContent;
+    let cachedState;
+    //ToDo: Remove someId condition when uniqueId on panelAssets is merged.
+    if (isCacheEnabled &&
+        (cachedUniqueId === "someId" || cachedUniqueId === uniqueId)) {
+        cacheContent = rufusPanelCache === null || rufusPanelCache === void 0 ? void 0 : rufusPanelCache.content;
+        cachedState = rufusPanelCache === null || rufusPanelCache === void 0 ? void 0 : rufusPanelCache.state;
+    }
+    else {
+        logCount("rufus-content-cache-uniqueId-mismatch");
+        // Preserve panel UI state (open/closed, position, size) when there's an actual
+        // identity mismatch (e.g. profile switch) — both IDs exist but differ.
+        // Don't preserve state when uniqueId is missing from cache (corrupted/old cache).
+        // Gated behind blueHeronGatingTreatment and movableCLPersistenceTreatment weblabs.
+        if (blueHeronGatingTreatment === "T1" &&
+            movableCLPersistenceTreatment === "T1" &&
+            isCacheEnabled &&
+            cachedUniqueId &&
+            rufusPanelCache &&
+            rufusPanelCache.state) {
+            cachedState = rufusPanelCache.state;
+        }
+    }
+    // add default errorMessage for the panel to avoid something wrong happens in linkTree.
+    const defaultErrorMessageText = "Something went wrong. Try again later.";
+    const errorMessageTextToRender = rufusErrorMessageText
+        ? rufusErrorMessageText
+        : defaultErrorMessageText;
+    // add default style values for the panel to avoid something wrong happens in linkTree.
+    const fallbackRufusPanelConfig = {
+        panelHeightRatio: "0.5",
+        panelWidth: "320px",
+        minimizedPanelWidth: "200px",
+        peekViewPanelWidth: "320px"
+    };
+    const panelConfigKeys = Object.keys(fallbackRufusPanelConfig);
+    // If rufusPanelConfigString is only `{}`, it can also be parsed, we should avoid get empty values
+    if (typeof rufusPanelConfigString === "string" &&
+        rufusPanelConfigString !== "{}") {
+        try {
+            rufusPanelConfig = checkAllKeysHaveValue(JSON.parse(rufusPanelConfigString), panelConfigKeys)
+                ? JSON.parse(rufusPanelConfigString)
+                : fallbackRufusPanelConfig;
+        }
+        catch (error) {
+            rufusPanelConfig = fallbackRufusPanelConfig;
+            const errorMessage = "Error parsing rufusPanelConfig: " +
+                rufusPanelConfigString +
+                ". " +
+                error;
+            logError(new Error(errorMessage));
+        }
+        rufusPanelConfig.panelHeightRatio = isValidNumber(rufusPanelConfig.panelHeightRatio)
+            ? rufusPanelConfig.panelHeightRatio
+            : 0.5;
+    }
+    else {
+        rufusPanelConfig = fallbackRufusPanelConfig;
+        const errorMessage = "rufusPanelConfig is empty or is not string: " + rufusPanelConfigString;
+        logError(new Error(errorMessage));
+    }
+    const navbar = document.getElementById("navbar-main");
+    const rufusPanelMinimizeButton = document.getElementById("rufus-panel-header-minimize");
+    const rufusPanelCloseButton = document.getElementById("rufus-panel-header-close");
+    const rufusPanelDockButton = document.getElementById("rufus-panel-header-dock-undock-button");
+    const rufusContent = document.querySelector(".nav-rufus-content");
+    const rufusViewContextDiv = document.getElementById("rufus-view-context");
+    if (!navbar ||
+        !rufusFlyoutDiv ||
+        !rufusButton ||
+        !rufusPanelCloseButton ||
+        !rufusPanelMinimizeButton ||
+        !rufusViewContextDiv) {
+        return;
+    }
+    function setElementProperty(element, propertyName, propertyValue) {
+        element.style.setProperty(propertyName, propertyValue);
+    }
+    function setUndockButtonIconForTreatment(state) {
+        if (!rufusPanelDockButton || dockingSide === "none") {
+            return;
+        }
+        // Set appropriate icon based on state and treatment
+        if (state === "expanded") {
+            const icon = dockingSide === "docked-left" ? DOCK_LEFT_ICON : DOCK_RIGHT_ICON;
+            rufusPanelDockButton.style.background = `${icon} no-repeat center transparent`;
+        }
+        else {
+            rufusPanelDockButton.style.backgroundImage = "";
+        }
+    }
+    function checkIfStateIsDocked(state) {
+        return state === "docked-left" || state === "docked-right";
+    }
+    function isRufusPanelDocking(currentState, newState) {
+        return (!checkIfStateIsDocked(currentState) && checkIfStateIsDocked(newState));
+    }
+    function handleRufusElementState(newState, previousState) {
+        rufusFlyoutDiv.setAttribute("data-state", newState);
+        rufusButton.setAttribute("data-state", newState);
+        if (dockingSide !== "none") {
+            handleBodyPadding(newState, previousState);
+        }
+    }
+    /**
+     * Handles body padding and classes for docked panel states
+     */
+    function handleBodyPadding(newState, previousState) {
+        // Only add transition classes when actually transitioning between different states
+        // (not when restoring state on page load where previousState is undefined,
+        // or when currentState === newState)
+        const isTransitioning = previousState !== undefined && previousState !== newState;
+        const isOpening = isTransitioning && checkIfStateIsDocked(newState);
+        const isClosing = isTransitioning && checkIfStateIsDocked(previousState);
+        const transitionClass = isOpening
+            ? "rufus-docked-opening-transition"
+            : isClosing
+                ? "rufus-docked-closing-transition"
+                : "";
+        document.body.style.transition = "";
+        transitionClass && document.body.classList.add(transitionClass);
+        if (newState === "closed" || newState === "expanded") {
+            const hadDockingClasses = document.body.classList.contains("rufus-docked-left") ||
+                document.body.classList.contains("rufus-docked-right");
+            document.body.classList.remove("rufus-docked-left", "rufus-docked-right");
+            // Remove adjustable width class when leaving docked state
+            document.body.classList.remove("rufus-docked-adjustable");
+            document.body.style.removeProperty("--rufus-docked-panel-width");
+            document.body.style.removeProperty("--total-rufus-panel-full-width");
+            document.body.style.removeProperty("--total-rufus-panel-half-width");
+            document.body.style.paddingLeft = "";
+            document.body.style.paddingRight = "";
+            document.body.style.paddingTop = "";
+            // Only trigger layout recalculation if the panel was actually docked before (i.e. not if we move between closed and expanded)
+            if (hadDockingClasses) {
+                triggerLayoutRecalculation();
+            }
+        }
+        else if (newState === "docked-left" || newState === "docked-right") {
+            document.body.classList.add(`rufus-${newState}`);
+            // Add adjustable width class and set dynamic panel width when entering docked state.
+            // DOCKED_PANEL_WIDTH already has the correct width from getDockedPanelWidth(),
+            // which reads from session storage (set by thick client's DockedPanelResizeHandler)
+            // or falls back to the screen-size-based default.
+            if (params.dockedPanelAdjustableWidthTreatment === "T1") {
+                document.body.classList.add("rufus-docked-adjustable");
+                document.body.style.setProperty("--rufus-docked-panel-width", `${DOCKED_PANEL_WIDTH}px`);
+                // Persist the width to session storage so on next page navigation,
+                // getDockedPanelWidth() reads it back immediately and avoids a flicker
+                // from 320px → dynamic default.
+                try {
+                    sessionStorage.setItem(DOCKED_PANEL_WIDTH_KEY, String(DOCKED_PANEL_WIDTH));
+                }
+                catch (e) {
+                    // Session storage may not be available
+                }
+            }
+            document.body.style.setProperty("--total-rufus-panel-full-width", `${TOTAL_WIDTH_TAKEN_IN_PAGE}px`);
+            document.body.style.setProperty("--total-rufus-panel-half-width", `${TOTAL_WIDTH_TAKEN_IN_PAGE / 2}px`);
+            const hasDualPanel = document.querySelector(DUAL_PANEL_SELECTOR) !== null;
+            let rightPadding = hasDualPanel ? EWC_CART_WIDTH : 0;
+            if (newState === "docked-left") {
+                document.body.style.paddingLeft = `${DOCKED_PANEL_WIDTH}px`;
+                rightPadding += BROWSER_MARGIN;
+            }
+            else if (newState === "docked-right") {
+                document.body.style.paddingLeft = `${BROWSER_MARGIN}px`;
+                rightPadding += DOCKED_PANEL_WIDTH;
+            }
+            document.body.style.paddingRight = `${rightPadding}px`;
+            document.body.style.paddingTop = `${BROWSER_MARGIN}px`;
+            triggerLayoutRecalculation();
+        }
+    }
+    /**
+     * Forces layout recalculation and notifies components of layout changes.
+     * Required when docking changes body padding to ensure proper positioning.
+     */
+    function triggerLayoutRecalculation() {
+        document.body.offsetHeight;
+        window.dispatchEvent(new CustomEvent("resize", {
+            detail: {
+                rufusAction: true
+            }
+        }));
+        if (extendedWindow.P && typeof extendedWindow.P.when === "function") {
+            extendedWindow.P.when("A").execute("rufus-force-aui-resize", function (A) {
+                A.trigger("resize", window, { width: 1, height: 1 });
+            });
+        }
+    }
+    let closeAnimationRunning = false;
+    const RESIZE_INTERVAL_MS = 10;
+    const CLEANUP_DELAY_MS = 500;
+    let resizeInterval;
+    let cleanupScheduled = false;
+    const animation_expanded_to_closed = "rufus-panel-expanded-to-closed";
+    const animation_closed_to_expanded = "rufus-panel-closed-to-expanded";
+    const animation_minimized_to_expanded = "rufus-panel-minimized-to-expanded";
+    const animation_expanded_to_minimized = "rufus-panel-expanded-to-minimized";
+    const animation_expanded_to_closed_movable = "rufus-panel-expanded-to-closed-movable";
+    const animation_closed_to_expanded_movable = "rufus-panel-closed-to-expanded-movable";
+    const animation_expanded_to_closed_movable_right_ingress = "rufus-panel-expanded-to-closed-movable-right-ingress";
+    const animation_closed_to_expanded_movable_right_ingress = "rufus-panel-closed-to-expanded-movable-right-ingress";
+    const animation_minimized_to_expanded_movable = "rufus-panel-minimized-to-expanded-movable";
+    const animation_expanded_to_minimized_movable = "rufus-panel-expanded-to-minimized-movable";
+    const animation_docked_left_to_closed = "rufus-panel-docked-left-to-closed";
+    const animation_closed_to_docked_left = "rufus-panel-closed-to-docked-left";
+    const animation_docked_right_to_closed = "rufus-panel-docked-right-to-closed";
+    const animation_closed_to_docked_right = "rufus-panel-closed-to-docked-right";
+    const animation_docked_left_to_expanded = "rufus-panel-docked-left-to-expanded";
+    const animation_expanded_to_docked_left = "rufus-panel-expanded-to-docked-left";
+    const animation_docked_right_to_expanded = "rufus-panel-docked-right-to-expanded";
+    const animation_expanded_to_docked_right = "rufus-panel-expanded-to-docked-right";
+    // Shared docked transitions (same for both regular and movable)
+    const dockedTransitions = new Map([
+        ["docked-left_closed", animation_docked_left_to_closed],
+        ["docked-right_closed", animation_docked_right_to_closed],
+        ["closed_docked-left", animation_closed_to_docked_left],
+        ["closed_docked-right", animation_closed_to_docked_right],
+        ["docked-left_expanded", animation_docked_left_to_expanded],
+        ["docked-right_expanded", animation_docked_right_to_expanded],
+        ["expanded_docked-left", animation_expanded_to_docked_left],
+        ["expanded_docked-right", animation_expanded_to_docked_right]
+    ]);
+    // Base transitions (non-movable)
+    const baseTransitions = new Map([
+        ["expanded_minimized", animation_expanded_to_minimized],
+        ["expanded_closed", animation_expanded_to_closed],
+        ["minimized_expanded", animation_minimized_to_expanded],
+        ["minimized_closed", animation_expanded_to_closed],
+        ["closed_expanded", animation_closed_to_expanded]
+    ]);
+    // Movable-specific transitions
+    const movableTransitions = new Map([
+        ["expanded_minimized", animation_expanded_to_minimized_movable],
+        ["expanded_closed", animation_expanded_to_closed_movable],
+        ["minimized_expanded", animation_minimized_to_expanded_movable],
+        ["minimized_closed", animation_expanded_to_closed],
+        ["closed_expanded", animation_closed_to_expanded_movable],
+        [
+            "expanded_closed_right_ingress",
+            animation_expanded_to_closed_movable_right_ingress
+        ],
+        [
+            "closed_expanded_right_ingress",
+            animation_closed_to_expanded_movable_right_ingress
+        ]
+    ]);
+    // Combine them
+    const animationMap = new Map([...baseTransitions, ...dockedTransitions]);
+    const animationMapMovableCL = new Map([
+        ...movableTransitions,
+        ...dockedTransitions
+    ]);
+    // Extract nileRequestId from cached panel state (matches thick client's ConversationOrchestrator init)
+    const getCachedNileRequestId = () => {
+        var _a, _b;
+        try {
+            const cacheString = sessionStorage.getItem(rufusPanelCacheKey);
+            if (!cacheString)
+                return "";
+            const cache = JSON.parse(cacheString);
+            return ((_b = (_a = cache === null || cache === void 0 ? void 0 : cache.state) === null || _a === void 0 ? void 0 : _a.requestContext) === null || _b === void 0 ? void 0 : _b.requestId) || "";
+        }
+        catch (_c) {
+            return "";
+        }
+    };
+    /**
+     * Emits a Nexus event via window.ue.event() using the same payload schema
+     * as the thick client's recordEventNexusMetric(). This ensures PANEL_RESIZE
+     * events are logged for state transitions that occur before the thick client
+     * loads, closing the data gap where these transitions were previously untracked.
+     *
+     * If ue.event is not yet available (CSM library hasn't loaded), the fully-built
+     * metric object is queued and flushed once ue.event becomes available. Timestamps
+     * are captured at call time so they remain accurate regardless of flush delay.
+     */
+    const pendingNexusEvents = [];
+    let nexusFlushIntervalId = null;
+    const MAX_FLUSH_ATTEMPTS = 30; // give up after ~30 s
+    let nexusFlushAttempts = 0;
+    function buildNexusMetric(eventName, eventDetail) {
+        const sessionId = (() => {
+            try {
+                const match = document.cookie.match(/(?:^|;)\s*session-id\s*=\s*([^\s;]+)/);
+                return match ? match[1] : "";
+            }
+            catch (_a) {
+                /* istanbul ignore next */
+                return "";
+            }
+        })();
+        const getHiddenInputValue = (name) => {
+            /* istanbul ignore next -- defensive guard: rufusFlyoutDiv is always present at init */
+            const inputs = rufusFlyoutDiv === null || rufusFlyoutDiv === void 0 ? void 0 : rufusFlyoutDiv.getElementsByTagName("input");
+            /* istanbul ignore next */
+            if (!inputs)
+                return "";
+            const input = Array.from(inputs).find(i => i.name === name);
+            return (input === null || input === void 0 ? void 0 : input.value) || "";
+        };
+        const currentEventTimeUTC = new Date().toISOString();
+        const cachedRequestId = getCachedNileRequestId();
+        return {
+            timestamp: currentEventTimeUTC,
+            messageId: `${Date.now()}-${Math.random()
+                .toString(36)
+                .slice(2)}`,
+            eventName: eventName,
+            eventDetail: eventDetail || "",
+            eventTimeUTC: currentEventTimeUTC,
+            sessionId: sessionId,
+            obfuscatedCustomerId: getHiddenInputValue("customerId"),
+            locale: getHiddenInputValue("locale"),
+            marketplaceId: getHiddenInputValue("marketplaceId"),
+            metadata: JSON.stringify({
+                program: "nile-classic-desktop",
+                fe_client: "navx"
+            }),
+            isBeta: false,
+            deviceTypeId: "",
+            directedCustomerId: "",
+            appVersion: "",
+            nileRequestId: cachedRequestId,
+            clickstreamRequestId: cachedRequestId,
+            uxSessionId: ""
+        };
+    }
+    function flushPendingNexusEvents() {
+        var _a;
+        if (!((_a = extendedWindow.ue) === null || _a === void 0 ? void 0 : _a.event)) {
+            if (++nexusFlushAttempts >= MAX_FLUSH_ATTEMPTS) {
+                pendingNexusEvents.length = 0; // drop undeliverable events
+                if (nexusFlushIntervalId !== null) {
+                    clearInterval(nexusFlushIntervalId);
+                    nexusFlushIntervalId = null;
+                }
+            }
+            return;
+        }
+        while (pendingNexusEvents.length > 0) {
+            const metric = pendingNexusEvents.shift();
+            extendedWindow.ue.event(metric, "desktop-nile", "mshop.nile.events.5");
+        }
+        // Stop polling once queue is drained
+        if (nexusFlushIntervalId !== null) {
+            clearInterval(nexusFlushIntervalId);
+            nexusFlushIntervalId = null;
+        }
+    }
+    function recordNexusEvent(eventName, eventDetail) {
+        var _a;
+        const metric = buildNexusMetric(eventName, eventDetail);
+        if ((_a = extendedWindow.ue) === null || _a === void 0 ? void 0 : _a.event) {
+            // Flush any previously queued events first (preserves ordering)
+            flushPendingNexusEvents();
+            extendedWindow.ue.event(metric, "desktop-nile", "mshop.nile.events.5");
+        }
+        else {
+            pendingNexusEvents.push(metric);
+            // Start polling for ue.event availability if not already polling
+            if (nexusFlushIntervalId === null) {
+                nexusFlushAttempts = 0;
+                nexusFlushIntervalId = setInterval(flushPendingNexusEvents, 1000);
+            }
+        }
+    }
+    function applyAnimationAndStateUpdate(currentState, newState) {
+        if (!currentState || !newState || closeAnimationRunning) {
+            return;
+        }
+        // Emit PANEL_RESIZE Nexus event for state transitions (mirrors thick client)
+        if (currentState !== newState) {
+            const panelStateResize = `${currentState}_to_${newState}`;
+            recordNexusEvent("PANEL_RESIZE", panelStateResize);
+        }
+        function resetRufusPanelClassName() {
+            rufusFlyoutDiv.className = "rufus-panel-container";
+        }
+        function addAnimationToPanel(animation) {
+            rufusFlyoutDiv.classList.add(animation);
+            // Start resize interval for docking animations
+            if (isRufusPanelDocking(currentState, newState)) {
+                if (resizeInterval) {
+                    window.clearInterval(resizeInterval);
+                }
+                resizeInterval = window.setInterval(() => {
+                    triggerLayoutRecalculation();
+                }, RESIZE_INTERVAL_MS);
+            }
+        }
+        // If currentState is equal to newState(refresh page), handle the element state and return
+        if (currentState === newState) {
+            handleRufusElementState(newState, currentState);
+            return;
+        }
+        // emit an AUI event to indicate the rufus panel state change so feature outside Rufus can respond to it accordingly to avoid CX conflict.
+        if (extendedWindow.P && typeof extendedWindow.P.when === "function") {
+            extendedWindow.P.when("A").execute(function (A) {
+                try {
+                    A.trigger("rufus-panel-state-change", currentState, newState);
+                }
+                catch (error) {
+                    logError(new Error(`AUI event trigger failed: ${error}`));
+                }
+            });
+        }
+        resetRufusPanelClassName();
+        let transitionKey = currentState + "_" + newState;
+        // Special handling when docked-right is involved so it animates to the right ingress
+        if (movableCLEnabled && dockingSide === "docked-right") {
+            if (currentState === "expanded" && newState === "closed") {
+                transitionKey = "expanded_closed_right_ingress";
+            }
+            else if (currentState === "closed" && newState === "expanded") {
+                transitionKey = "closed_expanded_right_ingress";
+            }
+        }
+        // Use the appropriate animation map based on movableCLEnabled weblab
+        const selectedAnimationMap = movableCLEnabled
+            ? animationMapMovableCL
+            : animationMap;
+        const animationClass = selectedAnimationMap.get(transitionKey) || "";
+        // 1. Add animation class
+        if (animationClass) {
+            addAnimationToPanel(animationClass);
+        }
+        else {
+            logError(new Error("Error adding animation to panel, animationClass should not be empty"));
+        }
+        // 2. Update panel state
+        function animationEndHandler() {
+            // Animation has ended, remove transitions if present, update panel state and
+            // trigger resize at animation end to reflect latest sizes
+            handleRufusElementState(newState, currentState);
+            rufusFlyoutDiv.removeEventListener("animationend", animationEndHandler);
+            document.body.classList.remove("rufus-docked-opening-transition", "rufus-docked-closing-transition");
+            if (currentState === "closed" || currentState === "expanded") {
+                // Need to trigger resize at animation end to reflect latest sizes.
+                if (checkIfStateIsDocked(currentState) ||
+                    checkIfStateIsDocked(newState)) {
+                    triggerLayoutRecalculation();
+                }
+            }
+            // Clean up resize interval (only if one exists and cleanup isn't already scheduled)
+            if (resizeInterval && !cleanupScheduled) {
+                cleanupScheduled = true;
+                window.setTimeout(() => {
+                    if (resizeInterval) {
+                        window.clearInterval(resizeInterval);
+                        resizeInterval = undefined;
+                    }
+                    cleanupScheduled = false;
+                }, CLEANUP_DELAY_MS);
+            }
+            closeAnimationRunning = false;
+        }
+        if (newState === "closed") {
+            closeAnimationRunning = true;
+            rufusFlyoutDiv.addEventListener("animationend", animationEndHandler);
+        }
+        else if (isRufusPanelDocking(currentState, newState)) {
+            rufusFlyoutDiv.addEventListener("animationend", animationEndHandler);
+        }
+        else {
+            handleRufusElementState(newState, currentState);
+        }
+    }
+    function restoreRNWStyles() {
+        const CL_RNW_STYLE_CACHE_KEY = "rufus:reactStyles";
+        try {
+            let cached = sessionStorage.getItem(CL_RNW_STYLE_CACHE_KEY);
+            if (!cached)
+                return;
+            cached = cached.replace(/\s+/g, " ").trim(); // applying normalization
+            let styleEl = document.getElementById("react-native-stylesheet");
+            if (!styleEl) {
+                styleEl = document.createElement("style");
+                styleEl.id = "react-native-stylesheet";
+                document.head.appendChild(styleEl);
+            }
+            styleEl.textContent = cached;
+        }
+        catch (error) {
+            const errorMessage = `Error while restoring React Native Web Styles: ${error}`;
+            logError(new Error(errorMessage));
+        }
+    }
+    function handleRufusPanelStateAndContent() {
+        navbar.appendChild(rufusFlyoutDiv);
+        const defaultPanelHeight = window.innerHeight * Number(rufusPanelConfig.panelHeightRatio);
+        // Weblab trigger for state persistence experiment:
+        // Eligible users are those who left the panel open (localStorage has docked state)
+        // and are starting a new browser session (no cachedState from sessionStorage)
+        let localStorageDockedState = null;
+        try {
+            localStorageDockedState = localStorage.getItem("rufus:panel:dockedState");
+        }
+        catch (_a) {
+            logCount("rufus-localStorage-not-available");
+        }
+        const isReturningUserWithPanelOpen = localStorageDockedState &&
+            localStorageDockedState !== "closed" &&
+            !cachedState;
+        if (isReturningUserWithPanelOpen && statePersistenceTreatment) {
+            if (extendedWindow.ue && extendedWindow.ue.trigger) {
+                extendedWindow.ue.trigger("RUFUS_DESKTOP_STATE_PERSISTENCE_1357774", statePersistenceTreatment);
+            }
+        }
+        setElementProperty(rufusFlyoutDiv, "--expanded-container-width", rufusPanelConfig.panelWidth);
+        setElementProperty(rufusFlyoutDiv, "--minimized-container-width", rufusPanelConfig.minimizedPanelWidth);
+        setElementProperty(rufusFlyoutDiv, "--peekView-container-width", rufusPanelConfig.peekViewPanelWidth);
+        // handle panel state
+        if (cachedState) {
+            handleRufusElementState(cachedState.viewState);
+            const height = cachedState.height
+                ? cachedState.height
+                : defaultPanelHeight;
+            const width = cachedState.width
+                ? cachedState.width
+                : rufusPanelConfig.panelWidth.slice(0, rufusPanelConfig.panelWidth.indexOf("px"));
+            const left = cachedState.left ? cachedState.left : DEFAULT_PANEL_LEFT;
+            const bottom = cachedState.bottom
+                ? cachedState.bottom
+                : DEFAULT_PANEL_BOTTOM;
+            setElementProperty(rufusFlyoutDiv, "--expanded-container-height", height + "px");
+            setElementProperty(rufusFlyoutDiv, "--expanded-container-width", width + "px");
+            setElementProperty(rufusFlyoutDiv, "--expanded-container-left", left + "px");
+            setElementProperty(rufusFlyoutDiv, "--expanded-container-bottom", bottom + "px");
+        }
+        else {
+            const persistedDockedState = sessionStorage.getItem("rufus:panel:dockedState");
+            // Only restore valid docked states - cross-session persistence is for docked panels only
+            if (persistedDockedState === "docked-left" ||
+                persistedDockedState === "docked-right") {
+                handleRufusElementState(persistedDockedState);
+            }
+            setElementProperty(rufusFlyoutDiv, "--expanded-container-height", defaultPanelHeight + "px");
+            setElementProperty(rufusFlyoutDiv, "--expanded-container-width", rufusPanelConfig.panelWidth);
+            setElementProperty(rufusFlyoutDiv, "--expanded-container-left", DEFAULT_PANEL_LEFT + "px");
+            setElementProperty(rufusFlyoutDiv, "--expanded-container-bottom", DEFAULT_PANEL_BOTTOM + "px");
+        }
+        // handle panel content
+        const cacheHitMetricName = "rufus-content-cache-hit"; // emit this metric when cached content is rendered
+        const cacheMissMetricName = "rufus-content-cache-miss"; // emit this metric when no cached content available
+        const cacheErrorMetricName = "rufus-content-cache-error"; // emit this metric when render cache failed
+        if (rufusContent && !!cacheContent) {
+            restoreRNWStyles();
+            const cacheContentRendered = updateCurrentRufusContent(cacheContent, true, noScrollTreatment);
+            logCount(cacheContentRendered ? cacheHitMetricName : cacheErrorMetricName);
+        }
+        else {
+            logCount(cacheMissMetricName);
+        }
+    }
+    function handleRufusIngressClick() {
+        const currentState = rufusFlyoutDiv.getAttribute("data-state");
+        let newState;
+        if (dockingSide === "none") {
+            newState = currentState === "expanded" ? "closed" : "expanded";
+        }
+        else {
+            if (currentState === "closed") {
+                const undock = shouldAutoUndock();
+                newState = undock ? "expanded" : dockingSide;
+                if (undock) {
+                    logCount("RUFUS_PANEL_AUTO_UNDOCK");
+                    recordNexusEvent("RUFUS_PANEL_AUTO_UNDOCK");
+                }
+            }
+            else {
+                newState = "closed";
+            }
+        }
+        const newText = newState === "expanded" ||
+            newState === "docked-left" ||
+            newState === "docked-right"
+            ? "Close Rufus panel"
+            : "Open Rufus panel";
+        rufusButton.setAttribute("aria-label", newText);
+        rufusViewContext.panelStateOnIngressClick = newState;
+        rufusViewContextDiv.value = JSON.stringify(rufusViewContext);
+        applyAnimationAndStateUpdate(currentState, newState);
+    }
+    function triggerRufusCXOnInitialLoading(data) {
+        rufusViewContext.keyword = data.query;
+        rufusViewContext.qis = data.qis;
+        rufusViewContext.metadata = data.metadata;
+        rufusViewContext.ingressPayload = data.ingressPayload;
+        rufusViewContext.refmarker = data.refmarker;
+        if (data.inContextAsin) {
+            rufusViewContext.asin = data.inContextAsin;
+        }
+        rufusViewContextDiv.value = JSON.stringify(rufusViewContext);
+        const currentState = rufusFlyoutDiv.getAttribute("data-state");
+        const newState = dockingSide !== "none" && !shouldAutoUndock() ? dockingSide : "expanded";
+        applyAnimationAndStateUpdate(currentState, newState);
+    }
+    /**
+     * It is required to pass necessary data before external client (Atocomplete widgets/Ads pills)
+     * can trigger Rufus experience.
+     */
+    function validateDataBeforeHandlingRufusStream(params) {
+        return !!(params.qis &&
+            params.metricName &&
+            (params.query || isFtuxRuxEligibleSource(params.qis)));
+    }
+    function handleRufusPanelCloseButtonClick() {
+        const currentState = rufusFlyoutDiv.getAttribute("data-state");
+        applyAnimationAndStateUpdate(currentState, "closed");
+    }
+    function handleRufusPanelDockUndockButtonClick() {
+        const currentState = rufusFlyoutDiv.getAttribute("data-state");
+        // Only allow docking/undocking if docking is enabled
+        if (dockingSide !== "none") {
+            let newState;
+            if (currentState === "expanded") {
+                // Dock the panel to the configured side
+                newState = dockingSide;
+                logCount("RUFUS_PANEL_CLICK_DOCK");
+                recordNexusEvent("RUFUS_PANEL_CLICK_DOCK");
+            }
+            else {
+                // Undock the panel back to expanded (current state must be docked)
+                newState = "expanded";
+                logCount("RUFUS_PANEL_CLICK_UNDOCK");
+                recordNexusEvent("RUFUS_PANEL_CLICK_UNDOCK");
+            }
+            // Update undock button icon for the new state
+            setUndockButtonIconForTreatment(newState);
+            applyAnimationAndStateUpdate(currentState, newState);
+        }
+    }
+    function handleRufusPanelMinimizeButtonClick() {
+        let newAnimationClass;
+        const currentState = rufusFlyoutDiv.getAttribute("data-state");
+        const newState = currentState === "minimized" ? "expanded" : "minimized";
+        applyAnimationAndStateUpdate(currentState, newState);
+    }
+    // istanbul ignore next
+    function removeEventListenerFromThinClient() {
+        rufusButton.removeEventListener("click", handleRufusIngressClick);
+        rufusPanelCloseButton.removeEventListener("click", handleRufusPanelCloseButtonClick);
+        rufusPanelMinimizeButton.removeEventListener("click", handleRufusPanelMinimizeButtonClick);
+        // Only remove dock button listener if it was added (not auto-undocking or deprecated)
+        if (dockingSide !== "none" &&
+            rufusPanelDockButton &&
+            !shouldAutoUndock() &&
+            !deprecateMovableCLEnabled) {
+            rufusPanelDockButton.removeEventListener("click", handleRufusPanelDockUndockButtonClick);
+        }
+    }
+    handleRufusPanelStateAndContent();
+    // Set initial undock button icon when docking is enabled
+    if (dockingSide !== "none") {
+        const initialState = rufusFlyoutDiv.getAttribute("data-state") || "closed";
+        setUndockButtonIconForTreatment(initialState);
+    }
+    // bind ingressButton and panelCloseButton actions in thin client to allow fundamental interaction before thick client is loaded
+    rufusButton.addEventListener("click", handleRufusIngressClick);
+    rufusPanelCloseButton.addEventListener("click", handleRufusPanelCloseButtonClick);
+    rufusPanelMinimizeButton.addEventListener("click", handleRufusPanelMinimizeButtonClick);
+    // Add dock/undock button event listener only if docking is enabled, not auto-undocking,
+    // and movable CL is not deprecated. When deprecated, undock is unreachable so hide the button
+    // immediately to prevent a flash before thick client loads and hides it.
+    if (dockingSide !== "none" &&
+        rufusPanelDockButton &&
+        !shouldAutoUndock() &&
+        !deprecateMovableCLEnabled) {
+        rufusPanelDockButton.addEventListener("click", handleRufusPanelDockUndockButtonClick);
+        rufusPanelDockButton.style.display = "block";
+    }
+    else if (rufusPanelDockButton) {
+        // Hide the dock button when auto-undocking (small screen without adjustable width),
+        // docking is disabled, or movable CL is deprecated (NILE-55788)
+        rufusPanelDockButton.style.display = "none";
+    }
+    // TODO: find ways to test it
+    // istanbul ignore next
+    if (extendedWindow.P && typeof extendedWindow.P.declare === "function") {
+        // declare a variable to allow thick client to unload thin client actions to give full control over thick client
+        extendedWindow.P.declare("rufus-thin-client", {
+            thickClientLoaded: removeEventListenerFromThinClient,
+            cacheEnabled: isCacheEnabled,
+            uniqueId: uniqueId,
+            latencyRegressionMitigationStrategy: latencyRegressionMitigationStrategy,
+            rufusNavOnlyHoldoutTreatment: rufusNavOnlyHoldoutTreatment,
+            rufusTriggerMarkerMapping: rufusTriggerMarkerMappingString,
+            pageType: rufusViewContext.pageType,
+            dockedSidePanelTreatment: dockedSidePanelTreatment,
+            dockedPanelAdjustableWidthTreatment: dockedPanelAdjustableWidthTreatment,
+            deprecateMovableCLEnabled: deprecateMovableCLEnabled,
+            // Pass the RUFUS_DESKTOP_AFO_NO_SCROLL_1414612 weblab treatment so the thick client
+            // can gate its own scroll-to-bottom logic on the same treatment value.
+            noScrollTreatment: noScrollTreatment
+        });
+        // declare a variable to allow platform outside Navyaan able to access
+        // whether Rufus feature is eligible in current browser environment
+        extendedWindow.P.declare("rufus-eligible", true);
+        extendedWindow.P.declare("rufus-nav-only-treatment", rufusNavOnlyHoldoutTreatment);
+        extendedWindow.P.declare("rufus-handle-expand", function (rufusClient) {
+            if (!rufusClient) {
+                const errorMessage = "Error handling rufus panel expand with empty rufusClient name";
+                logError(new Error(errorMessage));
+                return;
+            }
+            const metricName = rufusClient + "_expand_rufus";
+            logCount(metricName);
+            if (extendedWindow.P && typeof extendedWindow.P.now === "function") {
+                extendedWindow.P.now("rufus-expand").execute(function (expandRufus) {
+                    if (expandRufus) {
+                        expandRufus();
+                    }
+                    else {
+                        const currentState = rufusFlyoutDiv.getAttribute("data-state");
+                        const newState = dockingSide !== "none" && !shouldAutoUndock()
+                            ? dockingSide
+                            : "expanded";
+                        applyAnimationAndStateUpdate(currentState, newState);
+                    }
+                });
+            }
+        });
+        // handle streaming request outside of Navyaan eg: Rufus Autocomplete click
+        extendedWindow.P.declare("rufus-handle-stream", function (streamParams) {
+            if (!validateDataBeforeHandlingRufusStream(streamParams)) {
+                const errorMessage = "Error handling rufus stream with params: " +
+                    JSON.stringify(streamParams);
+                logError(new Error(errorMessage));
+                return;
+            }
+            logCount(streamParams.metricName);
+            if (extendedWindow.P && typeof extendedWindow.P.now === "function") {
+                extendedWindow.P.now("rufus-thick-client").execute(function (thickClient) {
+                    if (thickClient) {
+                        const startRufusStreamWithQis = featureScope.startRufusStream + ":" + streamParams.qis;
+                        logLatency(startRufusStreamWithQis, true);
+                        // directly start streaming through thick client
+                        extendedWindow.P &&
+                            extendedWindow.P.when("rufus-stream").execute(function (stream) {
+                                logLatency(startRufusStreamWithQis, false);
+                                logCount(startRufusStreamWithQis);
+                                stream(streamParams);
+                            });
+                    }
+                    else {
+                        // If thick client not loaded yet. Should initiate Rufus panel first by expanding it
+                        // and start initial streaming request in thick client with related payload
+                        const startRufusInitialLoadingWithQis = featureScope.startRufusInitialLoading + ":" + streamParams.qis;
+                        logLatency(startRufusInitialLoadingWithQis, true);
+                        logCount(startRufusInitialLoadingWithQis);
+                        triggerRufusCXOnInitialLoading(streamParams);
+                        extendedWindow.P &&
+                            extendedWindow.P.when("rufus-stream").execute(function () {
+                                logLatency(startRufusInitialLoadingWithQis, false);
+                            });
+                    }
+                });
+            }
+        });
+    }
+    function extractIngressLinkParameters(urlString) {
+        const url = new URL(urlString);
+        return {
+            rufusAction: url.searchParams.get("rufus-action"),
+            rufusClient: url.searchParams.get("rufus-client"),
+            rufusQuery: url.searchParams.get("rufus-query"),
+            rufusPayload: url.searchParams.get("rufus-payload"),
+            refmarker: url.searchParams.get("ref_")
+        };
+    }
+    function parseRufusPayloadContent(payload, allowedKeys) {
+        if (!payload) {
+            return undefined;
+        }
+        try {
+            const parsed = JSON.parse(payload);
+            // Runtime validation: ensure all values are strings
+            if (!Object.values(parsed).every(v => typeof v === "string")) {
+                return undefined;
+            }
+            if (!allowedKeys || allowedKeys.length === 0) {
+                return undefined;
+            }
+            const filtered = {};
+            for (const key of allowedKeys) {
+                if (key in parsed) {
+                    filtered[key] = parsed[key];
+                }
+            }
+            return Object.keys(filtered).length > 0 ? filtered : undefined;
+        }
+        catch (error) {
+            const errorMessage = "Error parsing rufus-payload: " + error;
+            logError(new Error(errorMessage));
+            return undefined;
+        }
+    }
+    function getClientActionPayload(clientConfigString, clientActionName) {
+        let clientConfig;
+        try {
+            clientConfig = JSON.parse(clientConfigString);
+        }
+        catch (error) {
+            const errorMessage = "Error parsing clientConfig: " + clientConfig + ". " + error;
+            logError(new Error(errorMessage));
+            return undefined;
+        }
+        const clientActionsList = clientConfig.actions ? clientConfig.actions : [];
+        return clientActionsList.find(function (action) {
+            return action.name === clientActionName;
+        });
+    }
+    function handleStream(query, qis, metricName, ingressPayload, refmarker) {
+        var _a;
+        const streamParams = {
+            query: query ? query : "",
+            qis: qis,
+            metricName: metricName,
+            metadata: {},
+            ingressPayload: ingressPayload,
+            refmarker: refmarker
+        };
+        // Further input validation for streaming is performed in stream callback
+        (_a = extendedWindow.P) === null || _a === void 0 ? void 0 : _a.when("rufus-handle-stream").execute(function (stream) {
+            stream(streamParams);
+        });
+    }
+    function handleIngressLink(externalClientsData) {
+        if (!externalClientsData) {
+            const errorMessage = "externalClients Linktree child node is undefined.";
+            logError(new Error(errorMessage));
+            return;
+        }
+        const currentPageUrl = window.location.href;
+        const rufusIngressLinkParams = extractIngressLinkParameters(currentPageUrl);
+        const rufusClient = rufusIngressLinkParams.rufusClient;
+        const rufusAction = rufusIngressLinkParams.rufusAction;
+        const rufusQuery = rufusIngressLinkParams.rufusQuery;
+        const rufusRawPayload = rufusIngressLinkParams.rufusPayload;
+        const refmarker = rufusIngressLinkParams.refmarker;
+        if (!rufusAction || !rufusClient) {
+            // Insufficient Ingress Link Parameters to trigger Rufus.
+            // This is not an error as non-Ingress Link use-cases fall under this condition.
+            return;
+        }
+        const clientConfigString = externalClientsData[rufusClient];
+        const clientActionPayload = getClientActionPayload(clientConfigString, rufusAction);
+        if (!clientActionPayload) {
+            const errorMessage = "rufus-action: " +
+                rufusAction +
+                " is not defined as an available action for rufus-client: " +
+                rufusClient +
+                " in the ExternalClients LinkTree.";
+            logError(new Error(errorMessage));
+            return;
+        }
+        const allowedPayloadKeys = clientActionPayload.context.allowedPayloadKeys;
+        const payload = parseRufusPayloadContent(rufusRawPayload, allowedPayloadKeys);
+        const clientActionType = clientActionPayload.type;
+        const metricName = rufusClient + "_" + rufusAction; // e.g. heroBanner_HolidayShopRedirect
+        switch (clientActionType) {
+            case "stream":
+                handleStream(rufusQuery, clientActionPayload.context.qis, metricName, payload, refmarker ? refmarker : undefined);
+                return;
+            default:
+                const errorMessage = "No handler exists for given Rufus actionType: " +
+                    clientActionType +
+                    ".";
+                logError(new Error(errorMessage));
+                return;
+        }
+    }
+    handleIngressLink(params.externalClientsData);
+    function makeRenderRequest() {
+        try {
+            // Render immediately when: all page types enabled, on Search/Detail pages,
+            // or panel is docked (always visible, IntersectionObserver unreliable with horizontal scroll).
+            // Otherwise, defer render until the panel becomes visible.
+            const shouldRenderImmediately = renderRequestForAllPageTypesEnabled ||
+                rufusViewContext.pageType === "Search" ||
+                rufusViewContext.pageType === "Detail" ||
+                checkIfStateIsDocked(rufusFlyoutDiv.getAttribute("data-state"));
+            if (shouldRenderImmediately) {
+                renderRufusContent(!!cacheContent, errorMessageTextToRender);
+            }
+            else {
+                observeVisibility(rufusFlyoutDiv, function () {
+                    renderRufusContent(!!cacheContent, errorMessageTextToRender);
+                });
+            }
+        }
+        catch (error) {
+            const errorMessage = "Error loading rufus content: " + error;
+            logError(new Error(errorMessage));
+        }
+    }
+    const rufusTriggerMarker = fetchRufusTriggerMarker(rufusTriggerMarkerMappingString, rufusViewContext.pageType);
+    // this timeout make sures in some edge case when latency marker is not available after specific threshold,
+    // Rufus will still continue to trigger render request accordingly as a fallback plan
+    const rufusLatencyMarkerFallbackTimeout = isValidNumber(rufusTriggerMarkerFallbackTimeoutString)
+        ? Number(rufusTriggerMarkerFallbackTimeoutString)
+        : 3000;
+    if (latencyRegressionMitigationStrategy ===
+        "shouldDelayThinClientRenderRequest" &&
+        rufusTriggerMarker &&
+        rufusTriggerMarker != "" &&
+        typeof ((_a = extendedWindow.P) === null || _a === void 0 ? void 0 : _a.when) === "function") {
+        const wrapper = wrapFunctionWithSchedulerAndExecutor(makeRenderRequest, rufusLatencyMarkerFallbackTimeout);
+        wrapper.schedule();
+        extendedWindow.P &&
+            extendedWindow.P.when(rufusTriggerMarker).execute(wrapper.forceExecute);
+    }
+    else {
+        makeRenderRequest();
+    }
+}({"rufusPanelConfigString":"{\"panelWidth\":\"320px\",\"panelHeightRatio\":\"0.5\",\"minimizedPanelWidth\":\"240px\",\"peekViewPanelWidth\":\"320px\"}","rufusViewContext":{"pageType":"F3OmnichannelPostOrder"},"isCacheEnabled":true,"uniqueId":"707afab1ed61b9dc404266b656c5b6617604c26db3858d1b24806799f479db7e","renderRequestForAllPageTypesEnabled":true,"rufusErrorMessageText":"Something went wrong. Try again later.","latencyRegressionMitigationStrategy":"shouldDelayThinClientRenderRequest","rufusTriggerMarkerMappingString":"{\"Detail\":\"dp-latency-marker\",\"Search\":\"af\",\"Gateway\":\"af\",\"ShoppingCart\":\"cf\"}","rufusTriggerMarkerFallbackTimeoutString":"3000","externalClientsData":{"rufusPricing":"{\"actions\":[{\"name\":\"ManagePriceAlertsRedirect\",\"type\":\"stream\",\"context\":{\"qis\":\"NileManagePriceAlertsExternalIngress\"}}]}","rufusAutomations":"{\"actions\":[{\"name\":\"ViewResultRedirect\",\"type\":\"stream\",\"context\":{\"qis\":\"RufusAutomations\",\"allowedPayloadKeys\":[\"automationExecutionId\",\"conversationMode\"]}}]}","rufusMarketing":"{\"actions\":[{\"name\":\"DealsRedirect\",\"type\":\"stream\",\"context\":{\"qis\":\"NileIngressOnsiteMarketing\"}},{\"name\":\"GiftingRedirect\",\"type\":\"stream\",\"context\":{\"qis\":\"NileIngressOnsiteMarketing\"}},{\"name\":\"CategoryRedirect\",\"type\":\"stream\",\"context\":{\"qis\":\"NileIngressOnsiteMarketing\"}},{\"name\":\"RecRedirect\",\"type\":\"stream\",\"context\":{\"qis\":\"RECIngressLinkExternal\"}},{\"name\":\"MerchRedirect\",\"type\":\"stream\",\"context\":{\"qis\":\"MerchAIOptionInAutocomplete\"}}]}","deepResearch":"{\"actions\":[{\"name\":\"ViewResultRedirect\",\"type\":\"stream\",\"context\":{\"qis\":\"DeepResearch\",\"allowedPayloadKeys\":[\"automationExecutionId\",\"conversationMode\"]}}]}","heroBanner":"{\"actions\":[{\"name\":\"HolidayShopRedirect\",\"type\":\"stream\",\"context\":{\"qis\":\"NileIngressLink\"}},{\"name\":\"GetStartedRedirect\",\"type\":\"stream\",\"context\":{\"qis\":\"NileIngressLink\"}}]}"},"rufusNavOnlyHoldoutTreatment":"C","movableCLEnabled":true,"dockedSidePanelTreatment":"T1","statePersistenceTreatment":"T1","dockedPanelAdjustableWidthTreatment":"C","isB2B":false,"blueHeronGatingTreatment":"T1","movableCLPersistenceTreatment":"T1","deprecateMovableCLEnabled":true,"noScrollTreatment":"T1"}));
+    })()</script>
+        
+        
+      </div>
+      <div class='nav-fill'>
+        
+ <div id="nav-shop">
+ </div>
+        <div id='nav-xshop-container'>
+          <div id='nav-xshop' class="nav-progressive-content">
+            <script type='text/javascript'>window.navmet.tmp=+new Date();</script>
+  <ul class="nav-ul">
+      
+<li class="nav-li">
+<div class="nav-div">
+<a id="nav-primeday" href="/primeday?ref_=nav_cs_td_pd_dt_cr" class="nav-a  " tabindex="0" data-csa-c-type="link" data-csa-c-slot-id="nav_cs_0" data-csa-c-content-id="nav_cs_td_pd_dt_cr">Early Prime Day</a>
+</div>
+</li>
+
+
+<li class="nav-li">
+<div class="nav-div">
+<a href="https://health.amazon.com/health-ai?ref_=nav_cs_health_ai" class="nav-a  " tabindex="0" data-csa-c-type="link" data-csa-c-slot-id="nav_cs_1" data-csa-c-content-id="nav_cs_health_ai">Health AI</a>
+</div>
+</li>
+
+
+<li class="nav-li">
+<div class="nav-div">
+<a href="/haul/store?ref_=nav_cs_hul_disb" class="nav-a  " tabindex="0" data-csa-c-type="link" data-csa-c-slot-id="nav_cs_2" data-csa-c-content-id="nav_cs_hul_disb">Amazon Haul</a>
+</div>
+</li>
+
+
+<li class="nav-li">
+<div class="nav-div" id="nav_link_allhealthingress">
+<a href="https://health.amazon.com/health-ai?ref_=nav_cs_medical_care_health_ai" class="nav-a  " data-ux-jq-mouseenter="true" tabindex="0"  data-csa-c-type="link" data-csa-c-slot-id="nav_link_allhealthingress" data-csa-c-content-id="nav_cs_medical_care_health_ai"><span>Medical Care</span>
+</a>
+<button aria-expanded="false" class="nav-flyout-button nav-icon nav-arrow" aria-label="Medical Care Details" tabindex=0></button>
+</div>
+</li>
+
+<li class="nav-li">
+<div class="nav-div">
+<a href="/gp/video/storefront?ref_=nav_cs_prime_video" class="nav-a  " tabindex="0" data-csa-c-type="link" data-csa-c-slot-id="nav_cs_4" data-csa-c-content-id="nav_cs_prime_video">Prime Video</a>
+</div>
+</li>
+
+
+<li class="nav-li">
+<div class="nav-div">
+<a href="/gp/buyagain?ie=UTF8&ref_=nav_cs_buy_again" class="nav-a  " tabindex="0" data-csa-c-type="link" data-csa-c-slot-id="nav_cs_5" data-csa-c-content-id="nav_cs_buy_again">Buy Again</a>
+</div>
+</li>
+
+
+<li class="nav-li">
+<div class="nav-div" id="nav-link-groceries">
+<a href="/fmc/learn-more?ref_=nav_cs_groceries" class="nav-a  " data-ux-jq-mouseenter="true" tabindex="0"  data-csa-c-type="link" data-csa-c-slot-id="nav-link-groceries" data-csa-c-content-id="nav_cs_groceries"><span>Groceries</span>
+</a>
+<button aria-expanded="false" class="nav-flyout-button nav-icon nav-arrow" aria-label="Groceries Details" tabindex=0></button>
+</div>
+</li>
+
+<li class="nav-li">
+<div class="nav-div">
+<a href="/live?ref_=nav_cs_amazonlive" class="nav-a  " tabindex="0" data-csa-c-type="link" data-csa-c-slot-id="nav_cs_7" data-csa-c-content-id="nav_cs_amazonlive">Livestreams</a>
+</div>
+</li>
+
+
+<li class="nav-li">
+<div class="nav-div">
+<a href="/hz/mobile/mission?ref_=nav_cs_ci_mcx_mi_d_db" class="nav-a  " tabindex="0" data-csa-c-type="link" data-csa-c-slot-id="nav_cs_8" data-csa-c-content-id="nav_cs_ci_mcx_mi_d_db">Keep Shopping For</a>
+</div>
+</li>
+
+
+<li class="nav-li">
+<div class="nav-div">
+<a href="/computer-video-games-hardware-accessories/b/?ie=UTF8&node=468642&ref_=nav_cs_video_games" class="nav-a  " tabindex="0" data-csa-c-type="link" data-csa-c-slot-id="nav_cs_9" data-csa-c-content-id="nav_cs_video_games">Video Games</a>
+</div>
+</li>
+
+
+<li class="nav-li">
+<div class="nav-div">
+<a href="https://pharmacy.amazon.com/?nodl=0&ref_=nav_cs_pharmacy" class="nav-a  " tabindex="0" data-csa-c-type="link" data-csa-c-slot-id="nav_cs_10" data-csa-c-content-id="nav_cs_pharmacy">Pharmacy</a>
+</div>
+</li>
+
+
+<li class="nav-li">
+<div class="nav-div">
+<a href="/Amazon_Basics?channel=discovbar&field-lbr_brands_browse-bin=AmazonBasics&ref_=nav_cs_amazonbasics" class="nav-a  " tabindex="0" data-csa-c-type="link" data-csa-c-slot-id="nav_cs_11" data-csa-c-content-id="nav_cs_amazonbasics">Amazon Basics</a>
+</div>
+</li>
+
+
+<li class="nav-li">
+<div class="nav-div">
+<a href="/Beauty-Makeup-Skin-Hair-Products/b/?ie=UTF8&node=3760911&ref_=nav_cs_beauty" class="nav-a  " tabindex="0" data-csa-c-type="link" data-csa-c-slot-id="nav_cs_12" data-csa-c-content-id="nav_cs_beauty">Beauty & Personal Care</a>
+</div>
+</li>
+
+
+<li class="nav-li">
+<div class="nav-div">
+<a href="/gp/bestsellers/?ref_=nav_cs_bestsellers" class="nav-a  " tabindex="0" data-csa-c-type="link" data-csa-c-slot-id="nav_cs_13" data-csa-c-content-id="nav_cs_bestsellers">Best Sellers</a>
+</div>
+</li>
+
+
+<li class="nav-li">
+<div class="nav-div">
+<a href="/hz/contact-us/foresight/hubgateway?ref_=nav_cs_fs_hybridhub_navbar_c" class="nav-a  " tabindex="0" data-csa-c-type="link" data-csa-c-slot-id="nav_cs_14" data-csa-c-content-id="nav_cs_fs_hybridhub_navbar_c">Customer Service</a>
+</div>
+</li>
+
+
+<li class="nav-li">
+<div class="nav-div">
+<a href="/Audible-Books-and-Originals/b/?ie=UTF8&node=18145289011&ref_=nav_cs_audible" class="nav-a  " tabindex="0" data-csa-c-type="link" data-csa-c-slot-id="nav_cs_15" data-csa-c-content-id="nav_cs_audible">Audible</a>
+</div>
+</li>
+
+
+<li class="nav-li">
+<div class="nav-div">
+<a href="/pet-shops-dogs-cats-hamsters-kittens/b/?ie=UTF8&node=2619533011&ref_=nav_cs_pets" class="nav-a  " tabindex="0" data-csa-c-type="link" data-csa-c-slot-id="nav_cs_16" data-csa-c-content-id="nav_cs_pets">Pet Supplies</a>
+</div>
+</li>
+
+
+<li class="nav-li">
+<div class="nav-div" id="nav-recently-viewed">
+<a href="/gp/history?ref_=nav_cs_timeline" class="nav-a  " data-ux-jq-mouseenter="true" tabindex="0"  data-csa-c-type="link" data-csa-c-slot-id="nav-recently-viewed" data-csa-c-content-id="nav_cs_timeline"><span>Browsing History</span>
+</a>
+<button aria-expanded="false" class="nav-flyout-button nav-icon nav-arrow" aria-label="Browsing History Details" tabindex=0></button>
+</div>
+</li>
+
+<li class="nav-li">
+<div class="nav-div">
+<a href="/gp/browse.html?node=120955898011&ref_=nav_cs_handmade" class="nav-a  " tabindex="0" data-csa-c-type="link" data-csa-c-slot-id="nav_cs_18" data-csa-c-content-id="nav_cs_handmade">Handmade</a>
+</div>
+</li>
+
+
+<li class="nav-li">
+<div class="nav-div">
+<a href="/auto-deliveries/landing?ref_=nav_cs_sns" class="nav-a  " tabindex="0" data-csa-c-type="link" data-csa-c-slot-id="nav_cs_19" data-csa-c-content-id="nav_cs_sns">Subscribe & Save</a>
+</div>
+</li>
+
+
+<li class="nav-li">
+<div class="nav-div">
+<a href="/computer-pc-hardware-accessories-add-ons/b/?ie=UTF8&node=541966&ref_=nav_cs_pc" class="nav-a  " tabindex="0" data-csa-c-type="link" data-csa-c-slot-id="nav_cs_20" data-csa-c-content-id="nav_cs_pc">Computers</a>
+</div>
+</li>
+
+
+<li class="nav-li">
+<div class="nav-div">
+<a href="/b/?_encoding=UTF8&ld=AZUSSOA-sell&node=12766669011&ref_=nav_cs_sell" class="nav-a  " tabindex="0" data-csa-c-type="link" data-csa-c-slot-id="nav_cs_21" data-csa-c-content-id="nav_cs_sell">Sell</a>
+</div>
+</li>
+
+
+<li class="nav-li">
+<div class="nav-div">
+<a id="nav-your-amazon" href="/gp/yourstore/home?ref_=nav_cs_ys" class="nav-a  " tabindex="0" data-csa-c-type="link" data-csa-c-slot-id="nav_cs_22" data-csa-c-content-id="nav_cs_ys"><span id="nav-your-amazon-text"><span class="nav-shortened-name">Customer</span>'s Amazon.com</span></a>
+</div>
+</li>
+
+
+<li class="nav-li">
+<div class="nav-div">
+<a href="/health-personal-care-nutrition-fitness/b/?ie=UTF8&node=3760901&ref_=nav_cs_hpc" class="nav-a  " tabindex="0" data-csa-c-type="link" data-csa-c-slot-id="nav_cs_23" data-csa-c-content-id="nav_cs_hpc">Household, Health & Baby Care</a>
+</div>
+</li>
+
+
+<li class="nav-li">
+<div class="nav-div">
+<a href="/tvs/b/?ie=UTF8&node=172659&ref_=nav_cs_tv" class="nav-a  " tabindex="0" data-csa-c-type="link" data-csa-c-slot-id="nav_cs_24" data-csa-c-content-id="nav_cs_tv">TV & Video</a>
+</div>
+</li>
+
+
+<li class="nav-li">
+<div class="nav-div">
+<a href="/gp/browse.html?node=16115931011&ref_=nav_cs_registry" class="nav-a  " tabindex="0" data-csa-c-type="link" data-csa-c-slot-id="nav_cs_25" data-csa-c-content-id="nav_cs_registry">Registry</a>
+</div>
+</li>
+
+
+<li class="nav-li">
+<div class="nav-div">
+<a href="/finds?ref_=nav_cs_foundit" class="nav-a  " tabindex="0" data-csa-c-type="link" data-csa-c-slot-id="nav_cs_26" data-csa-c-content-id="nav_cs_foundit">Shop By Interest</a>
+</div>
+</li>
+
+
+<li class="nav-li">
+<div class="nav-div" id="nav-link-amazonprime">
+<a href="/prime?ref_=nav_cs_primelink_member" class="nav-a  " data-ux-jq-mouseenter="true" tabindex="0"  data-csa-c-type="link" data-csa-c-slot-id="nav-link-amazonprime" data-csa-c-content-id="nav_cs_primelink_member"><span>Prime</span>
+</a>
+<button aria-expanded="false" class="nav-flyout-button nav-icon nav-arrow" aria-label="Prime Details" tabindex=0></button>
+</div>
+</li>
+
+<li class="nav-li">
+<div class="nav-div">
+<a href="/books-used-books-textbooks/b/?ie=UTF8&node=283155&ref_=nav_cs_books" class="nav-a  " tabindex="0" data-csa-c-type="link" data-csa-c-slot-id="nav_cs_28" data-csa-c-content-id="nav_cs_books">Books</a>
+</div>
+</li>
+
+
+<li class="nav-li">
+<div class="nav-div">
+<a href="/Kindle-eBooks/b/?ie=UTF8&node=154606011&ref_=nav_cs_kindle_books" class="nav-a  " tabindex="0" data-csa-c-type="link" data-csa-c-slot-id="nav_cs_29" data-csa-c-content-id="nav_cs_kindle_books">Kindle Books</a>
+</div>
+</li>
+
+
+<li class="nav-li">
+<div class="nav-div">
+<a href="/gp/new-releases/?ref_=nav_cs_newreleases" class="nav-a  " tabindex="0" data-csa-c-type="link" data-csa-c-slot-id="nav_cs_30" data-csa-c-content-id="nav_cs_newreleases">New Releases</a>
+</div>
+</li>
+
+
+<li class="nav-li">
+<div class="nav-div">
+<a href="/home-garden-kitchen-furniture-bedding/b/?ie=UTF8&node=1055398&ref_=nav_cs_home" class="nav-a  " tabindex="0" data-csa-c-type="link" data-csa-c-slot-id="nav_cs_31" data-csa-c-content-id="nav_cs_home">Amazon Home</a>
+</div>
+</li>
+
+
+  </ul>
+  <script type='text/javascript'>window.navmet.push({key:'CrossShop',end:+new Date(),begin:window.navmet.tmp});</script>
+          </div>
+        </div>
+      </div>
+      <div class='nav-right'>
+        <script type='text/javascript'>window.navmet.tmp=+new Date();</script><!-- Navyaan SWM -->
+<div id="nav-swmslot">
+  <!-- Scheduled SWM widget failed to render -->
+</div><script type='text/javascript'>window.navmet.push({key:'SWM',end:+new Date(),begin:window.navmet.tmp});</script>
+        
+      </div>
+    </div>
+
+    <div id='nav-subnav-toaster'></div>
+
+    
+    <div id="nav-progressive-subnav">
+      
+    </div>
+
+    <div id='nav-flyout-ewc' class='nav-ewc-lazy-align nav-ewc-hide-head'><div class='nav-flyout-body ewc-beacon' tabindex='-1'><div class='nav-ewc-arrow'></div><div class='nav-ewc-content'></div></div></div><script type='text/javascript'>
+(function() {
+  var viewportWidth = function() {
+    return window.innerWidth ||
+      document.documentElement.clientWidth ||
+      document.body.clientWidth;
+  };
+
+  if (typeof uet === 'function') {  uet('x1', 'ewc', {wb: 1}); }
+
+  window.$Nav && $Nav.declare('config.ewc', (function() {
+    var config = {"enablePersistent":true,"viewportWidthForPersistent":1400,"EWCWideViewWidth":130,"EWCCompactViewWidth":100,"rufusDockedPanelWidth":320,"rufusDockedPanelBrowserMargin":12,"isEWCLogging":1,"isEWCStateExpanded":true,"EWCStateReason":"fixed","isSmallScreenEnabled":true,"isFreshCustomer":false,"errorContent":{"html":"<div class='nav-ewc-error'><span class='nav-title'>Oops!</span><p class='nav-paragraph'>There's a problem loading your cart right now.</p><a href='/gp/cart/view.html?ref_=nav_err_ewc_timeout' class='nav-action-button'><span class='nav-action-inner'>Your Cart</span></a></div>"},"url":"/cart/ewc/compact?hostPageType=F3OmnichannelPostOrder&hostSubPageType=OrderDetails&hostPageRID=RBWFGARJB4TBW5KMJP91&prerender=0","cartCount":1,"freshCartCount":0,"almCartCount":0,"primeWardrobeCartCount":0,"bazaarCartCount":0,"isCompactViewEnabled":true,"isCompactEWCRendered":true,"isWiderCompactEWCRendered":true,"EWCBrowserCacheKey":"EWC_Cache_147-7999693-6862434_AEXAMPLE00000_USD_en_US","isContentRepainted":false,"clearCache":false,"loadFromCacheWithDelay":0,"delayRenderingTillATF":false};
+    var hasAui = window.P && window.P.AUI_BUILD_DATE;
+    var isRTLEnabled = (document.dir === 'rtl');
+    config.pinnable = config.pinnable && hasAui;
+    config.isMigrationTreatment = true;
+
+    config.flyout = (function() {
+      var navbelt = document.getElementById('nav-belt');
+      var navCart = document.getElementById('nav-cart');
+      var ewcFlyout = document.getElementById('nav-flyout-ewc');
+      var persistentClassOnBody = 'nav-ewc-persistent-hover nav-ewc-full-height-persistent-hover';
+      var flyout = {};
+
+      var getDocumentScrollTop = function() {
+        return (document.documentElement && document.documentElement.scrollTop) || document.body.scrollTop;
+      };
+
+      var isWindow = function(obj) {
+        return obj != null && obj === obj.window;
+      };
+
+      var getWindow = function(elem) {
+        return isWindow(elem) ? elem : elem.nodeType === 9 && elem.defaultView;
+      };
+
+      var getOffset = function(elem) {
+        if (elem.getClientRects && !elem.getClientRects().length) {
+          return {top: 0};
+        }
+
+        var rect = elem.getBoundingClientRect
+          ? elem.getBoundingClientRect()
+          : {top: 0};
+
+        if (rect.width || rect.height) {
+          var doc = elem.ownerDocument;
+          var win = getWindow(doc);
+          return {
+            top: rect.top + win.pageYOffset - doc.documentElement.clientTop
+          };
+        }
+        return rect;
+      };
+
+      flyout.align = function() {
+        var newTop = getOffset(navbelt).top - getDocumentScrollTop();
+        ewcFlyout.style.top = (newTop > 0 ? newTop + 'px' : 0);
+      };
+
+      flyout.hide = function() {
+        isRTLEnabled
+          ? (ewcFlyout.style.left = '')
+          : (ewcFlyout.style.right = '');
+      };
+
+      if(typeof config.isCompactEWCRendered === 'undefined') {
+        if (
+          (config.isSmallScreenEnabled && viewportWidth() < 1400) ||
+          (config.isCompactViewEnabled && viewportWidth() >= 1400)
+        ) {
+          config.isCompactEWCRendered = true;
+          config.isEWCStateExpanded = true;
+          config.url = config.url.replace("/gp/navcart/sidebar", "/cart/ewc/compact");
+        } else {
+          config.isCompactEWCRendered = false;
+        }
+      }
+
+      var viewportQualifyForPersistent = function () {
+        return (config.isCompactEWCRendered)
+          ? true
+          : viewportWidth() >= 1400;
+      }
+
+      flyout.hasQualifiedViewportForPersistent = viewportQualifyForPersistent;
+
+      var rufusPanelState;
+      try {
+        rufusPanelState = sessionStorage.getItem('rufus:panel:dockedState');
+      } catch (e) {
+        rufusPanelState = null;
+      }
+
+      var rufusPanelIsDocked = function(rufusPanelViewState) {
+        return rufusPanelViewState === 'docked-right' || rufusPanelViewState === 'docked-left';
+      }
+
+      var getEWCRightOffset = function() {
+        if (rufusPanelIsDocked(rufusPanelState)) {
+          return 0 - config.EWCWideViewWidth;
+        }
+
+        if (!config.isCompactEWCRendered) {
+          return 0;
+        }
+
+        var $navbelt = document.getElementById('nav-belt');
+        if ($navbelt === undefined || $navbelt === null) {
+          return 0;
+        }
+
+        var EWCCompactViewWidth = (config.isWiderCompactEWCRendered  && viewportWidth() >= 1280) ? 130 : 100;
+        var scrollLeft = (window.pageXOffset !== undefined)
+          ? window.pageXOffset
+          : (document.documentElement || document.body.parentNode || document.body).scrollLeft;
+        var scrollXAxis = Math.abs(scrollLeft);
+        var windowWidth = document.documentElement.clientWidth;
+        var navbeltWidth = $navbelt.offsetWidth;
+        var isPartOfNavbarNotVisible = (navbeltWidth + EWCCompactViewWidth) > windowWidth;
+
+        if (isPartOfNavbarNotVisible) {
+          return 0 - (navbeltWidth - scrollXAxis - windowWidth + EWCCompactViewWidth);
+        } else {
+          return 0;
+        }
+      }
+
+      flyout.getEWCRightOffsetCssProperty = function () {
+        return getEWCRightOffset() + 'px';
+      }
+
+      if (config.isCompactEWCRendered) {
+        persistentClassOnBody = 'nav-ewc-persistent-hover nav-ewc-compact-view';
+        if (config.isWiderCompactEWCRendered) { persistentClassOnBody += ' nav-ewc-wider-compact-view'; }
+      }
+
+      flyout.show = function() {
+        isRTLEnabled
+          ? (ewcFlyout.style.left = flyout.getEWCRightOffsetCssProperty())
+          : (ewcFlyout.style.right = flyout.getEWCRightOffsetCssProperty());
+      };
+
+      var isIOSDevice = function() {
+        return (/iPad|iPhone|iPod/.test(navigator.platform) ||
+                (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1)) &&
+                !window.MSStream;
+      }
+
+      var checkForPersistent = function() {
+        if (!hasAui) {
+          return { result: false, reason: 'noAui' };
+        }
+        if (!config.enablePersistent) {
+          return { result: false, reason: 'config' };
+        }
+        if (!viewportQualifyForPersistent()) {
+          return { result: false, reason: 'viewport' };
+        }
+        if (isIOSDevice()) {
+          return { result: false, reason: 'iOS' };
+        }
+        if (!config.cartCount > 0) {
+          return { result: false, reason: 'emptycart' };
+        }
+        return { result: true };
+      };
+
+      flyout.ableToPersist = function() {
+        return checkForPersistent().result;
+      };
+      var persistentClassRegExp = '(?:^|\\s)' + persistentClassOnBody + '(?!\\S)';
+      flyout.applyPageLayoutForPersistent = function() {
+        if (!document.documentElement.className.match( new RegExp(persistentClassRegExp) )) {
+          document.documentElement.className += ' ' + persistentClassOnBody;
+        }
+      };
+
+      if (rufusPanelIsDocked(rufusPanelState) && flyout.ableToPersist()) {
+        document.body.style.transition = 'none';
+        if (rufusPanelState === 'docked-left') {
+            document.body.style.paddingRight = (config.EWCCompactViewWidth + config.rufusDockedPanelBrowserMargin) + 'px';
+        } else if (rufusPanelState === 'docked-right') {
+            document.body.style.paddingRight = (config.EWCCompactViewWidth + config.rufusDockedPanelWidth) + 'px';
+        }
+      }
+
+      P.when('A').execute('RufusPanelListener', function(A) {
+        A.on('rufus-panel-state-change', function(currentPanelState, newPanelState) {
+            rufusPanelState = newPanelState;
+            if (rufusPanelIsDocked(currentPanelState) || rufusPanelIsDocked(newPanelState)) {
+                if (flyout.ableToPersist()) {
+                    ewcFlyout.style.right = flyout.getEWCRightOffsetCssProperty();
+                }
+            }
+        });
+      });
+
+      flyout.unapplyPageLayoutForPersistent = function() {
+        document.documentElement.className = document.documentElement.className.replace( new RegExp(persistentClassRegExp, 'g'), '');
+      };
+
+      flyout.persist = function() {
+        flyout.applyPageLayoutForPersistent();
+        flyout.show();
+        if (config.isCompactEWCRendered) {
+          flyout.align();
+        }
+      };
+
+      flyout.unpersist = function() {
+        flyout.unapplyPageLayoutForPersistent();
+        flyout.hide();
+      };
+      
+      var persistentCheck = checkForPersistent();
+    
+
+      var resizeCallback = function(e) {
+        if (e && e.detail && e.detail.rufusAction) {
+          return;
+        }
+
+        
+        if (flyout.ableToPersist()) {
+          flyout.persist();
+        }
+        else {
+          flyout.unpersist();
+        }
+      };
+
+      flyout.bindEvents = function() {
+        if (window.addEventListener) {
+          window.addEventListener('resize', resizeCallback, false);
+          
+          if (config.isCompactEWCRendered) {
+            window.addEventListener('scroll', flyout.align, false);
+          }
+        }
+      };
+
+      flyout.unbindEvents = function() {
+        if (window.removeEventListener) {
+          window.removeEventListener('resize', resizeCallback, false);
+          
+          if (config.isCompactEWCRendered) {
+            window.removeEventListener('scroll', flyout.align, false);
+          }
+        }
+      };
+      
+      var ewcDefaultPersistence = function() {
+      
+        if (persistentCheck.result) {
+          flyout.persist();
+          if (window.ue && ue.tag) {
+            ue.tag('ewc:persist');
+          }
+        } else {
+          if (window.ue && ue.tag) {
+            ue.tag('ewc:unpersist');
+            if (persistentCheck.reason === 'noAui') {
+              ue.tag('ewc:unpersist:noAui');
+            }
+            if (persistentCheck.reason === 'viewport') {
+              ue.tag('ewc:unpersist:viewport');
+            }
+            if (persistentCheck.reason === 'emptycart') {
+              ue.tag('ewc:unpersist:emptycart');
+            }
+            if (persistentCheck.reason === 'iOS') {
+              ue.tag('ewc:unpersist:iOS');
+            }
+          }
+        }
+      };
+      
+      ewcDefaultPersistence();
+      
+      if (window.ue && ue.tag)  {
+        if (flyout.hasQualifiedViewportForPersistent()) {
+          ue.tag('ewc:bview');
+        }
+        else {
+          ue.tag('ewc:sview');
+        }
+      }
+      flyout.bindEvents();
+      flyout.cache = function () {
+    const cache = window.sessionStorage;
+    const CACHE_KEY = "EWCBrowserCacheKey";
+    const CACHE_EXPIRY = "EWCBrowserCacheExpiry"; 
+    const CACHE_VALUE = "EWCBrowserCacheValue"; 
+    const isSessionStorageValid = function () {
+        return window && cache && cache instanceof Storage;
+    };
+    const isCachePresent = function (key) {
+        return cache.length > 0 && cache.getItem(key);
+    }
+    const isValidType = function (value) {
+        // Prevents accessing empty key-value and internal methods(prototypes) of storage
+        // TODO: Log metrics for invalid access;
+        return value && value.constructor == String;
+    }
+    return {
+        getCache: function (key) {
+            const value = isCachePresent(key);
+            return (isValidType(value)) ? value : null;
+        },
+        setCache: function (key, value) {
+            const oldValue = isCachePresent(key);
+            const cacheExpiryTime = isCachePresent(CACHE_EXPIRY);
+            // Set the expiry when there's no existing cache - to prevent resetting expiry on page navigation
+            if (!cacheExpiryTime) {
+                var currentTime = new Date();
+                cache.setItem(CACHE_EXPIRY, new Date(currentTime.getTime() + 5 * 60000))
+            }
+            // TODO: Log length of old and new cache values when logMetrics is true
+            cache.setItem(key, value);
+        },
+        updateCacheAndEwcContainer: function (cacheKey, newEwcContent) {
+            const $ = $Nav.getNow("$");
+            const $currentEwc = $("#ewc-content");
+            if (!$currentEwc.length) {
+                var $content = $('#nav-flyout-ewc .nav-ewc-content');
+                $content.html(newEwcContent);
+                this.setCache(CACHE_KEY, cacheKey);
+                if (window.ue && window.ue.count) {
+                    var current = window.ue.count("ewc-init-cache") || 0;
+                    window.ue.count("ewc-init-cache", current + 1);
+                }
+            } else {
+                var $newEwcContent = $('<div />');
+                var EWC_CONTENT_BODY_SCROLL_SELECTOR = ".ewc-scroller--selected";
+                if (newEwcContent) { // 1. Updates EWC container with new HTML 
+                    var domParser = new DOMParser();
+                    var sandboxedEwcContent = domParser.parseFromString(newEwcContent, 'text/html');
+                    var newEwcHtmlNoScript = sandboxedEwcContent.getElementById('ewc-content');
+                    const $newEwcHtml = $newEwcContent.html(newEwcHtmlNoScript);
+
+                    const offSet = $currentEwc.find(EWC_CONTENT_BODY_SCROLL_SELECTOR).position().top - $currentEwc.find(".ewc-active-cart--selected").position().top;
+                    $currentEwc.html($newEwcHtml.html());
+                    $currentEwc.find(EWC_CONTENT_BODY_SCROLL_SELECTOR).scrollTop(offSet);
+                    if (typeof window.uex === 'function') {
+                        window.uex('ld', 'ewc-reflect-new-state', {wb: 1});
+                    }
+                } else {
+                    // 2. Fetches cached response and updates it's html with new state on EWC Update
+                    const cachedEwc = this.getCache(CACHE_VALUE);
+                    $newEwcContent = $newEwcContent[0];
+                    $(cachedEwc).map(function (elementIndex, element) {
+                         $newEwcContent.appendChild((element.id === "ewc-content") ? $currentEwc.clone()[0] : element);
+                    });
+                    newEwcContent = $newEwcContent.innerHTML;
+                    if (window.ue && window.ue.count) {
+                        var current = window.ue.count("ewc-update-cache") || 0;
+                        window.ue.count("ewc-update-cache", current + 1);
+                    }
+                }
+                $newEwcContent.remove();
+            }
+            this.setCache(CACHE_VALUE, newEwcContent);
+        },
+        removeCache: function (key) {
+            return cache.removeItem(key);
+        }
+    }
+}
+;
+      return flyout;
+    }());
+     
+     
+     
+const CACHE_KEY = "EWCBrowserCacheKey";
+const CACHE_VALUE = "EWCBrowserCacheValue"; 
+const CACHE_EXPIRY = "EWCBrowserCacheExpiry"; 
+var cache = config.flyout.cache();
+
+const isCacheValid = function () {
+  // Check for page types and tenure of the cache
+  const clearCache = config.clearCache;
+  const cacheExpiryTime = cache.getCache(CACHE_EXPIRY);
+  const isCacheExpired = new Date() > new Date(cacheExpiryTime);
+  const cacheKey = config.EWCBrowserCacheKey;
+  const oldCacheKey = cache.getCache(CACHE_KEY);
+  const isCacheValid = !clearCache && !isCacheExpired && cacheKey == oldCacheKey;
+  if (!isCacheValid && window.ue && window.ue.count) {
+    var current = window.ue.count("ewc-cache-invalidated") || 0;
+    window.ue.count("ewc-cache-invalidated", current + 1);
+  }
+  return isCacheValid;
+}
+function loadFromCache() {
+    if (window.uet && typeof window.uet === 'function') {
+        window.uet('bb', 'ewc-loaded-from-cache', {wb: 1});
+    }
+    if (cache) {
+        if (isCacheValid()) {
+            var content = cache.getCache(CACHE_VALUE);
+            if (content) {
+                var $ewcContainer = document.getElementById("nav-flyout-ewc").getElementsByClassName("nav-ewc-content")[0];
+                var $ewcContent = document.getElementById("ewc-content");
+                if ($ewcContainer && !$ewcContent) {
+                    $ewcContainer.innerHTML = content;
+                    // Execute scripts from cache
+                    const ewcJavascript = document.getElementById("ewc-content").parentNode.querySelectorAll(':scope > script');
+                    ewcJavascript.forEach(function (script) {
+                        var scriptTag = document.createElement("script");
+                        scriptTag.innerHTML = script.innerHTML;
+                        document.body.appendChild(scriptTag);
+                    });
+                    if (typeof window.uex === 'function') {
+                        window.uex('ld', 'ewc-loaded-from-cache', {wb: 1});
+                    }
+                } else if (window.ue && window.ue.count && typeof window.ue.count === 'function') {
+                    var currentFailure = window.ue.count("ewc-slow-cache") || 0;
+                    window.ue.count("ewc-slow-cache", currentFailure + 1);
+                }
+            }
+        } else {
+            cache.removeCache(CACHE_VALUE);
+            cache.removeCache(CACHE_KEY);
+            cache.removeCache(CACHE_EXPIRY);
+        }
+    }
+}
+function delayBy(delayTime) {
+    if (delayTime) {
+        window.setTimeout(function() {
+            loadFromCache();
+        }, delayTime)
+    } else {
+        loadFromCache();
+    }
+}
+if(config.delayRenderingTillATF) {
+    (window.AmazonUIPageJS ? AmazonUIPageJS : P).when('atf').execute("EverywhereCartLoadFromCacheOnAtf", function () {
+        delayBy(config.loadFromCacheWithDelay);
+    });
+} else {
+    delayBy(config.loadFromCacheWithDelay);
+}
+
+    return config;
+  }()));
+
+  if (typeof uet === 'function') {
+    uet('x2', 'ewc', {wb: 1});
+  }
+
+  if (window.ue && ue.tag) {
+    ue.tag('ewc');
+    ue.tag('ewc:prime');
+    ue.tag('ewc:cartsize:1-10');
+
+    if ( window.P && window.P.AUI_BUILD_DATE ) {
+      ue.tag('ewc:aui');
+    } else {
+      ue.tag('ewc:noAui');
+    }
+  }
+}());
+</script>
+  </div>
+
+  
+  
+
+</header>
+
+
+<script type='text/javascript'>window.navmet.push({key:'NavBar',end:+new Date(),begin:window.navmet.main});</script>
+
+
+<script type="text/javascript">
+  if (window.ue_t0) {
+    window.navmet.push({key:"NavMainPaintEnd",end:+new Date(),begin:window.ue_t0});
+    window.navmet.push({key:"NavFirstPaintEnd",end:+new Date(),begin:window.ue_t0});
+  }
+</script>
+
+
+<script type='text/javascript'>
+    <!--
+    window.$Nav && $Nav.declare('config.fixedBarBeacon',false);
+    window.$Nav && $Nav.when("data").run(function(data) { data({"freshTimeout":{"template":{"name":"flyoutError","data":{"error":{"title":"<style>#nav-flyout-fresh{width:269px;padding:0;}#nav-flyout-fresh .nav-flyout-content{padding:0;}</style><a href='/amazonfresh'><img src='https://images-na.ssl-images-amazon.com/images/G/01/omaha/images/yoda/flyout_72dpi._V270255989_.png' /></a>"}}}},"cartTimeout":{"template":{"name":"flyoutError","data":{"error":{"button":{"text":"Your Cart","url":"/gp/cart/view.html?ref_=nav_err_cart_timeout"},"title":"Oops!","paragraph":"Unable to retrieve your cart."}}}},"primeTimeout":{"template":{"name":"flyoutError","data":{"error":{"title":"<a href='/gp/prime'><img src='https://images-na.ssl-images-amazon.com/images/G/01/prime/piv/YourPrimePIV_fallback_CTA._V327346943_.jpg' /></a>"}}}},"ewcTimeout":{"template":{"name":"flyoutError","data":{"error":{"button":{"text":"Your Cart","url":"/gp/cart/view.html?ref_=nav_err_ewc_timeout"},"title":"Oops!","paragraph":"There's a problem loading your cart right now."}}}},"errorWishlist":{"template":{"name":"flyoutError","data":{"error":{"button":{"text":"Your Wishlist","url":"/gp/registry/wishlist/?ref_=nav_err_wishlist"},"title":"Oops!","paragraph":"Unable to retrieve your wishlist"}}}},"emptyWishlist":{"template":{"name":"flyoutError","data":{"error":{"button":{"text":"Your Wishlist","url":"/gp/registry/wishlist/?ref_=nav_err_empty_wishlist"},"title":"Oops!","paragraph":"Your list is empty"}}}},"yourAccountContent":{"template":{"name":"flyoutError","data":{"error":{"button":{"text":"Your Account","url":"/gp/css/homepage.html?ref_=nav_err_youraccount"},"title":"Oops!","paragraph":"Unable to retrieve your account"}}}},"shopAllTimeout":{"template":{"name":"flyoutError","data":{"error":{"paragraph":"Unable to retrieve departments, please try again later"}}}},"kindleTimeout":{"template":{"name":"flyoutError","data":{"error":{"paragraph":"Unable to retrieve list, please try again later"}}}}}); });
+window.$Nav && $Nav.when("util.templates").run("FlyoutErrorTemplate", function(templates) {
+      templates.add("flyoutError", "<# if(error.title) { #><span class='nav-title'><#=error.title #></span><# } #><# if(error.paragraph) { #><p class='nav-paragraph'><#=error.paragraph #></p><# } #><# if(error.button) { #><a href='<#=error.button.url #>' class='nav-action-button' ><span class='nav-action-inner'><#=error.button.text #></span></a><# } #>");
+    });
+window.$Nav && $Nav.when("data").run(function(data) { data({"timelineTimeout":{"html":"<div id='nav-timeline'><div id='nav-timeline-error-content'><span class='nav-title'>There’s a problem showing your shopping history right now</span><p class='nav-paragraph'>Please check your network connection or come back in a few minutes.</p></div></div>"}}); });
+    if (typeof uet == 'function') {
+    uet('bb', 'iss-init-pc', {wb: 1});
+  }
+  if (!window.$SearchJS && window.$Nav) {
+    window.$SearchJS = $Nav.make('sx');
+  }
+
+  var opts = {
+    host: "completion.amazon.com/search/complete"
+  , marketId: "1"
+  , obfuscatedMarketId: "ATVPDKIKX0DER"
+  , searchAliases: []
+  , filterAliases: []
+  , pageType: "F3OmnichannelPostOrder"
+  , requestId: "RBWFGARJB4TBW5KMJP91"
+  , sessionId: "147-7999693-6862434"
+  , language: "en_US"
+  , customerId: "AEXAMPLE00000"
+  , asin: ""
+  , b2b: 0
+  , fresh: 0
+  , isJpOrCn: 0
+  , isUseAuiIss: 1
+};
+
+var issOpts = {
+    fallbackFlag: 1
+  , isDigitalFeaturesEnabled: 0
+  , isWayfindingEnabled: 1
+  , dropdown: "select.searchSelect"
+  , departmentText: "in {department}"
+  , suggestionText: "Search suggestions"
+  , recentSearchesTreatment: "C"
+  , authorSuggestionText: "Explore books by XXAUTHXX"
+  , translatedStringsMap: {"sx-recent-searches":"Recent searches","sx-your-recent-search":"Inspired by your recent search"}
+  , biaTitleText: ""
+  , biaPurchasedText: ""
+  , biaViewAllText: ""
+  , biaViewAllManageText: ""
+  , biaAndText: ""
+  , biaManageText: ""
+  , biaWeblabTreatment: ""
+  , issNavConfig: {}
+  , np: 0
+  , issCorpus: []
+  , cf: 1
+  , removeDeepNodeISS: ""
+  , trendingTreatment: "C"
+  , useAPIV2: ""
+  , opfSwitch: ""
+  , isISSDesktopRefactorEnabled: "1"
+  , useServiceHighlighting: "true"
+  , isInternal: 0
+  , isAPICachingDisabled: true
+  , isBrowseNodeScopingEnabled: false
+  , isStorefrontTemplateEnabled: false
+  , disableAutocompleteOnFocus: ""
+};
+
+  if (opts.isUseAuiIss === 1 && window.$Nav) {
+  window.$Nav.when('sx.iss').run('iss-mason-init', function(iss){
+    var issInitObj = buildIssInitObject(opts, issOpts, true);
+    new iss.IssParentCoordinator(issInitObj);
+
+    $SearchJS.declare('canCreateAutocomplete', issInitObj);
+  });
+} else if (window.$SearchJS) {
+  var iss;
+
+  // BEGIN Deprecated globals
+  var issHost = opts.host
+    , issMktid = opts.marketId
+    , issSearchAliases = opts.searchAliases
+    , updateISSCompletion = function() { iss.updateAutoCompletion(); };
+  // END deprecated globals
+
+
+  $SearchJS.when('jQuery', 'search-js-autocomplete-lib').run('autocomplete-init', initializeAutocomplete);
+  $SearchJS.when('canCreateAutocomplete').run('createAutocomplete', createAutocomplete);
+
+} // END conditional for window.$SearchJS
+  function initializeAutocomplete(jQuery) {
+  var issInitObj = buildIssInitObject(opts, issOpts);
+  $SearchJS.declare("canCreateAutocomplete", issInitObj);
+} // END initializeAutocomplete
+  function initSearchCsl(searchCSL, issInitObject) {
+  searchCSL.init(
+    opts.pageType,
+    (window.ue && window.ue.rid) || opts.requestId
+  );
+  $SearchJS.declare("canCreateAutocomplete", issInitObject);
+} // END initSearchCsl
+  function createAutocomplete(issObject) {
+  iss = new AutoComplete(issObject);
+
+  $SearchJS.publish("search-js-autocomplete", iss);
+
+  logMetrics();
+} // END createAutocomplete
+  function buildIssInitObject(opts, issOpts, isNewIss) {
+    var issInitObj = {
+        src: opts.host
+      , sessionId: opts.sessionId
+      , requestId: opts.requestId
+      , mkt: opts.marketId
+      , obfMkt: opts.obfuscatedMarketId
+      , pageType: opts.pageType
+      , language: opts.language
+      , customerId: opts.customerId
+      , fresh: opts.fresh
+      , b2b: opts.b2b
+      , aliases: opts.searchAliases
+      , fb: issOpts.fallbackFlag
+      , isDigitalFeaturesEnabled: issOpts.isDigitalFeaturesEnabled
+      , isWayfindingEnabled: issOpts.isWayfindingEnabled
+      , issPrimeEligible: issOpts.issPrimeEligible
+      , deptText: issOpts.departmentText
+      , sugText: issOpts.suggestionText
+      , filterAliases: opts.filterAliases
+      , biaWidgetUrl: opts.biaWidgetUrl
+      , recentSearchesTreatment: issOpts.recentSearchesTreatment
+      , authorSuggestionText: issOpts.authorSuggestionText
+      , translatedStringsMap: issOpts.translatedStringsMap
+      , biaTitleText: ""
+      , biaPurchasedText: ""
+      , biaViewAllText: ""
+      , biaViewAllManageText: ""
+      , biaAndText: ""
+      , biaManageText: ""
+      , biaWeblabTreatment: ""
+      , issNavConfig: issOpts.issNavConfig
+      , cf: issOpts.cf
+      , ime: opts.isJpOrCn
+      , mktid: opts.marketId
+      , qs: opts.isJpOrCn
+      , issCorpus: issOpts.issCorpus
+      , deepNodeISS: {
+          searchAliasAccessor: function($) {
+            return (window.SearchPageAccess && window.SearchPageAccess.searchAlias()) ||
+                   $('select.searchSelect').children().attr('data-root-alias');
+          },
+          searchAliasDisplayNameAccessor: function() {
+            return (window.SearchPageAccess && window.SearchPageAccess.searchAliasDisplayName());
+          }
+        }
+      , removeDeepNodeISS: issOpts.removeDeepNodeISS
+      , trendingTreatment: issOpts.trendingTreatment
+      , useAPIV2: issOpts.useAPIV2
+      , opfSwitch: issOpts.opfSwitch
+      , isISSDesktopRefactorEnabled: issOpts.isISSDesktopRefactorEnabled
+      , useServiceHighlighting: issOpts.useServiceHighlighting
+      , isInternal: issOpts.isInternal
+      , isAPICachingDisabled: issOpts.isAPICachingDisabled
+      , isBrowseNodeScopingEnabled: issOpts.isBrowseNodeScopingEnabled
+      , isStorefrontTemplateEnabled: issOpts.isStorefrontTemplateEnabled
+      , disableAutocompleteOnFocus: issOpts.disableAutocompleteOnFocus
+      , asin: opts.asin
+    };
+  
+    // If we aren't using the new ISS then we need to add these properties
+    
+    if (!isNewIss) {
+      issInitObj.dd = issOpts.dropdown; // The element with id searchDropdownBox doesn't exist in C.
+      issInitObj.imeSpacing = issOpts.imeSpacing;
+      issInitObj.isNavInline = 1;
+      issInitObj.triggerISSOnClick = 0;
+      issInitObj.sc = 1;
+      issInitObj.np = issOpts.np;
+    }
+  
+    return issInitObj;
+  } // END buildIssInitObject
+  function logMetrics() {
+  if (typeof uet == 'function' && typeof uex == 'function') {
+      uet('be', 'iss-init-pc',
+          {
+              wb: 1
+          });
+      uex('ld', 'iss-init-pc',
+          {
+              wb: 1
+          });
+  }
+} // END logMetrics
+  
+    
+window.$Nav && $Nav.declare('config.navDeviceType','desktop');
+
+window.$Nav && $Nav.declare('config.navDebugHighres',false);
+
+window.$Nav && $Nav.declare('config.pageType','F3OmnichannelPostOrder');
+window.$Nav && $Nav.declare('config.subPageType','OrderDetails');
+
+window.$Nav && $Nav.declare('config.dynamicMenuUrl','\x2Fgp\x2Fnavigation\x2Fajax\x2Fdynamic\x2Dmenu.html');
+
+window.$Nav && $Nav.declare('config.dismissNotificationUrl','\x2Fgp\x2Fnavigation\x2Fajax\x2Fdismissnotification.html');
+
+window.$Nav && $Nav.declare('config.enableDynamicMenus',true);
+
+window.$Nav && $Nav.declare('config.isInternal',false);
+
+window.$Nav && $Nav.declare('config.isBackup',false);
+
+window.$Nav && $Nav.declare('config.isRecognized',true);
+
+window.$Nav && $Nav.declare('config.transientFlyoutTrigger','\x23nav\x2Dtransient\x2Dflyout\x2Dtrigger');
+
+window.$Nav && $Nav.declare('config.subnavFlyoutUrl','\x2Fnav\x2Fajax\x2FsubnavFlyout');
+window.$Nav && $Nav.declare('config.isSubnavFlyoutMigrationEnabled',true);
+
+window.$Nav && $Nav.declare('config.recordEvUrl','\x2Fgp\x2Fnavigation\x2Fajax\x2Frecordevent.html');
+window.$Nav && $Nav.declare('config.recordEvInterval',15000);
+window.$Nav && $Nav.declare('config.sessionId','147\x2D7999693\x2D6862434');
+window.$Nav && $Nav.declare('config.requestId','RBWFGARJB4TBW5KMJP91');
+
+window.$Nav && $Nav.declare('config.alexaListEnabled',true);
+
+window.$Nav && $Nav.declare('config.readyOnATF',false);
+
+window.$Nav && $Nav.declare('config.dynamicMenuArgs',{"rid":"RBWFGARJB4TBW5KMJP91","isFullWidthPrime":0,"isPrime":1,"dynamicRequest":1,"weblabs":"","isFreshRegionAndCustomer":"","primeMenuWidth":450});
+
+window.$Nav && $Nav.declare('config.customerName','Customer');
+
+window.$Nav && $Nav.declare('config.customerCountryCode','US');
+
+window.$Nav && $Nav.declare('config.yourAccountPrimeURL','https\x3A\x2F\x2Fwww.amazon.com\x2Fgp\x2Fcss\x2Forder\x2Dhistory\x2Futils\x2Ffirst\x2Dorder\x2Dfor\x2Dcustomer.html\x2Fref\x3Dya_prefetch_beacon\x3Fie\x3DUTF8\x26s\x3D147\x2D7999693\x2D6862434');
+
+window.$Nav && $Nav.declare('config.yourAccountPrimeHover',true);
+
+window.$Nav && $Nav.declare('config.searchBackState',{});
+
+window.$Nav && $Nav.declare('nav.inline');
+
+(function (i) {
+  if(window._navbarSpriteUrl) {
+    i.onload = function() {window.uet && uet('ne')};
+    i.src = window._navbarSpriteUrl;
+  }
+}(new Image()));
+
+window.$Nav && $Nav.declare('config.autoFocus',false);
+
+window.$Nav && $Nav.declare('config.responsiveTouchAgents',["ieTouch"]);
+
+window.$Nav && $Nav.declare('config.responsiveGW',false);
+
+window.$Nav && $Nav.declare('config.pageHideEnabled',false);
+
+window.$Nav && $Nav.declare('config.sslTriggerType','flyoutProximityLarge');
+window.$Nav && $Nav.declare('config.sslTriggerRetry',0);
+
+window.$Nav && $Nav.declare('config.doubleCart',false);
+
+window.$Nav && $Nav.declare('config.signInOverride',false);
+
+window.$Nav && $Nav.declare('config.signInTooltip',false);
+
+window.$Nav && $Nav.declare('config.isPrimeMember',true);
+
+window.$Nav && $Nav.declare('config.packardGlowTooltip',false);
+
+window.$Nav && $Nav.declare('config.packardGlowFlyout',false);
+
+window.$Nav && $Nav.declare('config.rightMarginAlignEnabled',true);
+
+window.$Nav && $Nav.declare('config.flyoutAnimation',false);
+
+window.$Nav && $Nav.declare('config.primeTooltip',{"url":"/gp/prime/digital-adoption/navigation-bar"});
+
+window.$Nav && $Nav.declare('config.primeDay',false);
+
+window.$Nav && $Nav.declare('config.disableBuyItAgain',false);
+
+window.$Nav && $Nav.declare('config.enableCrossShopBiaFlyout',false);
+
+window.$Nav && $Nav.declare('config.pseudoPrimeFirstBrowse',null);
+
+window.$Nav && $Nav.declare('config.csYourAccount',false);
+
+window.$Nav && $Nav.declare('config.cartFlyoutDisabled',true);
+
+window.$Nav && $Nav.declare('config.isTabletBrowser',false);
+
+window.$Nav && $Nav.declare('config.HmenuProximityArea',[200,200,200,200]);
+
+window.$Nav && $Nav.declare('config.HMenuIsProximity',true);
+
+window.$Nav && $Nav.declare('config.isPureAjaxALF',false);
+
+window.$Nav && $Nav.declare('config.accountListFlyoutRedesign',false);
+
+window.$Nav && $Nav.declare('config.navfresh',false);
+
+window.$Nav && $Nav.declare('config.isFreshRegion',false);
+
+if (window.ue && ue.tag) { ue.tag('navbar'); };
+
+window.$Nav && $Nav.declare('config.blackbelt',true);
+
+window.$Nav && $Nav.declare('config.beaconbelt',true);
+
+window.$Nav && $Nav.declare('config.accountList',true);
+
+window.$Nav && $Nav.declare('config.iPadTablet',false);
+
+window.$Nav && $Nav.declare('config.searchapiEndpoint',false);
+
+window.$Nav && $Nav.declare('config.timeline',true);
+
+window.$Nav && $Nav.declare('config.timelineAsinPriceEnabled',false);
+
+window.$Nav && $Nav.declare('config.timelineDeleteEnabled',true);
+
+window.$Nav && $Nav.declare('config.dynamicTimelineDeleteArgs','0');
+
+window.$Nav && $Nav.declare('config.extendedFlyout',false);
+
+window.$Nav && $Nav.declare('config.flyoutCloseDelay',600);
+
+window.$Nav && $Nav.declare('config.pssFlag',0);
+
+window.$Nav && $Nav.declare('config.isPrimeTooltipMigrated',false);
+
+window.$Nav && $Nav.declare('config.hashCustomerAndSessionId','15c4204703b06687d5b32d2b532a3bb745f85ef0');
+
+window.$Nav && $Nav.declare('config.isExportMode',false);
+
+window.$Nav && $Nav.declare('config.languageCode','en_US');
+
+window.$Nav && $Nav.declare('config.environmentVFI','AmazonNavigationOrchestrator\x2Fdevelopment\x40B6465513042\x2DAL2023_aarch64');
+
+window.$Nav && $Nav.declare('config.isHMenuBrowserCacheDisable',false);
+
+window.$Nav && $Nav.declare('config.signInUrlWithRefTag','null');
+
+window.$Nav && $Nav.declare('config.regionalStores',[]);
+
+window.$Nav && $Nav.declare('config.isALFRedesignPT2',true);
+
+window.$Nav && $Nav.declare('config.isNavALFRegistryGiftList',false);
+
+window.$Nav && $Nav.declare('config.marketplaceId','ATVPDKIKX0DER');
+
+window.$Nav && $Nav.declare('config.exportTransitionState',null);
+
+window.$Nav && $Nav.declare('config.enableAeeXopFlyout',false);
+
+window.$Nav && $Nav.declare('config.isPrimeFlyoutMigrationEnabled',false);
+
+
+
+window.$Nav && $Nav.declare('config.isAjaxPaymentNotificationMigrated',false);
+
+window.$Nav && $Nav.declare('config.isAjaxPaymentSuppressNotificationMigrated',false);
+
+if (window.P && typeof window.P.declare === "function" && typeof window.P.now === "function") {
+  window.P.now('packardGlowIngressJsEnabled').execute(function(glowEnabled) {
+    if (!glowEnabled) {
+      window.P.declare('packardGlowIngressJsEnabled', true);
+    }
+  });
+  window.P.now('packardGlowStoreName').execute(function(storeName) {
+    if (!storeName) {
+      window.P.declare('packardGlowStoreName','generic');
+    }
+  });
+}
+
+window.$Nav && $Nav.declare('configComplete');
+
+    -->
+</script>
+
+
+<a id="skippedLink" tabindex="-1"></a>
+
+<script type='text/javascript'>window.navmet.MainEnd = new Date();</script>
+<script type="text/javascript">
+    if (window.ue_t0) {
+      window.navmet.push({key:"NavMainEnd",end:+new Date(),begin:window.ue_t0});
+    }
+</script>
+<!-- sp:end-feature:navbar -->
+<!-- sp:feature:configured-sitewide-before-host-atf-assets -->
+<!-- sp:end-feature:configured-sitewide-before-host-atf-assets -->
+<!-- sp:feature:host-atf -->
+
+
+
+<!-- Page ATF -->
+<script>
+    window.P && P.register('sp.load.js');
+</script>
+
+
+
+
+
+
+<div id="odp-header-section">
+    
+
+
+<div id="ufpo-subheader-nav-list-section" class="a-section a-spacing-base a-spacing-top-base a-padding-base a-subheader a-breadcrumb">
+    
+        <ul class="a-unordered-list a-horizontal" role="navigation">
+            <li><span class="a-list-item">
+                <a class="a-link-normal" href="/gp/css/homepage.html/ref=fopo_odp">
+                    <span class="a-color-secondary">
+                        Your Account
+                    </span>
+                </a>
+            </span></li>
+            <li class="a-breadcrumb-divider"><span class="a-list-item">
+                <span class="a-color-secondary">&#8250;</span>
+            </span></li>
+            <li><span class="a-list-item">
+                <a class="a-link-normal" href="/gp/css/order-history?ref_=fopo_odp">
+                    <span class="a-color-secondary">
+                        Your Orders
+                    </span>
+                </a>
+            </span></li>
+            <li class="a-breadcrumb-divider"><span class="a-list-item">
+                <span class="a-color-secondary">&#8250;</span>
+            </span></li>
+            <li><span class="a-list-item">
+                <span class="a-color-state">
+                    Order Details
+                </span>
+            </span></li>
+        </ul>
+    
+</div>
+
+</div>
+
+<div id="odp__spinner-utils__container">
+    <div id="odp__spinner-utils__backdrop"> </div>
+    <div id="odp__spinner-utils__spinner" class="a-spinner-wrapper"><span class="a-spinner a-spinner-medium"></span></div>
+</div>
+
+<div id="odp-main-section">
+    
+
+
+<div id="imb__alert-container">
+    <template id="imb__alert-template__text">
+        <div class="a-box a-alert a-alert-info" aria-live="polite" aria-atomic="true"><div class="a-box-inner a-alert-container"><h4 class="a-alert-heading">&nbsp</h4><i class="a-icon a-icon-alert" aria-hidden="true"></i><div class="a-alert-content">
+            &nbsp
+        </div></div></div>
+    </template>
+    <template id="imb__alert-template__button">
+        <div class="a-box a-alert a-alert-info imb__button-alert" aria-live="polite" aria-atomic="true"><div class="a-box-inner a-alert-container"><h4 class="a-alert-heading">&nbsp</h4><i class="a-icon a-icon-alert" aria-hidden="true"></i><div class="a-alert-content">
+            <span class="imb__button-alert__text">
+                &nbsp
+            </span>
+            <span class="a-button a-button-primary"><span class="a-button-inner"><a href="/" class="a-button-text">
+                &nbsp
+            </a></span></span>
+        </div></div></div>
+    </template>
+</div>
+
+
+    <div id="od-banner-container">
+        
+            <div id="f3_food_ProgressTracker" class="odp-widget-wrapper celwidget" cel_widget_id="f3_food_ProgressTracker">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<div id="progress-tracker" class="a-section">
+    <div id="ufpo-order-status-container" class="a-section a-spacing-top-base">
+        <h2 id="ufpo-order-status-primary" class="a-size-medium-plus a-spacing-none a-color-base a-text-bold">
+            Purchased at Whole Foods Market - Domain
+        </h2>
+        
+        
+            
+            
+                <img alt="Whole Foods Market" src="https://m.media-amazon.com/images/I/21HB0K7NhPL._SS60_.png" class="ufpo-brand-logo" data-a-hires="https://m.media-amazon.com/images/I/21HB0K7NhPL._SS120_.png"/>
+            
+        
+        
+            <span id="ufpo-order-status-secondary" class="a-size-base a-color-secondary">
+                
+                    Purchased on Sunday, October 5, 2025
+                
+            </span>
+        
+    </div>
+
+    
+
+    
+    
+    
+    
+    
+    
+    <div id="progress-tracker-refresh-data" data-orderId="113-4055495-4107437" data-primaryStatus="PURCHASED_INSTORE" class="a-section"></div>
+</div>
+
+
+</div>
+
+        
+            <div id="f3_food_ItemList" class="odp-widget-wrapper celwidget" cel_widget_id="f3_food_ItemList">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<div class="a-row a-spacing-base">
+    <h2 class="widget-title-string">
+        <span id="ufpo-item-list-title" class="a-size-medium">
+            Items in your order
+        </span>
+    </h2>
+</div>
+
+<hr aria-hidden="true" class="a-spacing-small a-spacing-top-small a-divider-normal"/>
+
+
+
+
+
+
+
+
+
+
+
+
+
+    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<div class="a-row a-spacing-base">
+    <div class="a-column a-span2 a-ws-span1">
+        <img alt="B0BQCG1XVZ-0" src="https://m.media-amazon.com/images/I/41xED25fm8L._SS70_.jpg" class="ufpo-itemListWidget-image" data-a-hires="https://m.media-amazon.com/images/I/61MuUoYKZOL._SS110_.jpg"/>
+    </div>
+    <div class="a-column a-span10 a-ws-span11 a-span-last">
+        <div class="a-row a-spacing-none">
+            <div class="a-column a-span10">
+                
+                    
+                        <a class="a-size-small a-link-normal" target="_blank" rel="noopener" href="/dp/B0BQCG1XVZ?ref_=wfmInStore_food_od_product_details">
+                            Frankies 457 Whole Castelvetrano Olives - Authentic Sicilian - Premium Handpicked - Snacking-Aperitif-Cooking-Baking-Heart-Healthy-Product Of Italy - Great For Every Occasion - 19 oz Jar
+                        </a>
+                    
+                    
+                
+            </div>
+            <div class="a-column a-span2 a-span-last">
+                <div class="a-section a-spacing-none a-text-right">
+                    <div class="a-row a-spacing-none">
+                        <span class="a-size-small">
+                            $6.50
+                        </span>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="a-row a-spacing-none">
+            <span class="a-size-small">
+                Qty: 1
+            </span>
+            <span class="a-size-small">
+                 @ 
+            </span>
+            
+                
+                
+                    <span class="a-size-small">
+                        $9.29 each
+                    </span>
+                
+            
+        </div>
+        
+        
+            <div class="a-row a-spacing-top-micro">
+                <i class="a-icon a-icon-success" role="presentation"></i>
+                <span class="a-size-small a-color-success">
+                    $2.79 promotions applied
+                </span>
+            </div>
+        
+        
+        <div class="a-row a-spacing-top-micro">
+            
+        </div>
+    </div>
+</div>
+    <hr aria-hidden="true" class="a-spacing-small a-spacing-top-small a-divider-normal"/>
+
+    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<div class="a-row a-spacing-base">
+    <div class="a-column a-span2 a-ws-span1">
+        <img alt="B0DK817T35-1" src="https://m.media-amazon.com/images/I/518FUTZIibL._SS70_.jpg" class="ufpo-itemListWidget-image" data-a-hires="https://m.media-amazon.com/images/I/81kA0al5QbL._SS110_.jpg"/>
+    </div>
+    <div class="a-column a-span10 a-ws-span11 a-span-last">
+        <div class="a-row a-spacing-none">
+            <div class="a-column a-span10">
+                
+                    
+                        <a class="a-size-small a-link-normal" target="_blank" rel="noopener" href="/dp/B0DK817T35?ref_=wfmInStore_food_od_product_details">
+                            Sanpellegrino Italian Sparkling Drink Ciliegia and Limone, Sparkling Cherry and Lemon Beverage, 11.15 fl oz. 6 Pack
+                        </a>
+                    
+                    
+                
+            </div>
+            <div class="a-column a-span2 a-span-last">
+                <div class="a-section a-spacing-none a-text-right">
+                    <div class="a-row a-spacing-none">
+                        <span class="a-size-small">
+                            $6.49
+                        </span>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="a-row a-spacing-none">
+            <span class="a-size-small">
+                Qty: 1
+            </span>
+            <span class="a-size-small">
+                 @ 
+            </span>
+            
+                
+                
+                    <span class="a-size-small">
+                        $6.49 each
+                    </span>
+                
+            
+        </div>
+        
+        
+        
+        <div class="a-row a-spacing-top-micro">
+            
+        </div>
+    </div>
+</div>
+    <hr aria-hidden="true" class="a-spacing-small a-spacing-top-small a-divider-normal"/>
+
+    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<div class="a-row a-spacing-base">
+    <div class="a-column a-span2 a-ws-span1">
+        <img alt="_ASINLESS_141142562300681:-2" src="https://m.media-amazon.com/images/I/01RmK+J4pJL.gif" class="ufpo-itemListWidget-image" data-a-hires="https://m.media-amazon.com/images/I/01RmK+J4pJL.SS75.gif"/>
+    </div>
+    <div class="a-column a-span10 a-ws-span11 a-span-last">
+        <div class="a-row a-spacing-none">
+            <div class="a-column a-span10">
+                
+                    
+                    
+                        <span class="a-size-small">
+                            Moon Drop Grapes
+                        </span>
+                    
+                
+            </div>
+            <div class="a-column a-span2 a-span-last">
+                <div class="a-section a-spacing-none a-text-right">
+                    <div class="a-row a-spacing-none">
+                        <span class="a-size-small">
+                            $12.18
+                        </span>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="a-row a-spacing-none">
+            <span class="a-size-small">
+                Qty: 2.44 lb
+            </span>
+            <span class="a-size-small">
+                 @ 
+            </span>
+            
+                
+                
+                    <span class="a-size-small">
+                        $4.99/lb
+                    </span>
+                
+            
+        </div>
+        
+            
+                <div class="a-row a-spacing-none">
+                    <span class="a-size-small">
+                        Tare Weight: 0.02 lb
+                    </span>
+                </div>
+            
+        
+        
+        
+        <div class="a-row a-spacing-top-micro">
+            
+        </div>
+    </div>
+</div>
+    <hr aria-hidden="true" class="a-spacing-small a-spacing-top-small a-divider-normal"/>
+
+
+
+
+
+<!-- Order Returns -->
+<script type="a-state" data-a-state="{&quot;key&quot;:&quot;order-returns-page-state&quot;}">{"orderHasReturns":false,"alertText":"One or more items in this order were either unavailable or returned. Your refund will be processed by Amazon immediately; however, it may take 3-5 business days to see the funds in your account depending on your financial institution."}</script>
+</div>
+
+        
+    </div>
+
+    <div id="odp-widget-grid-container">
+        
+            <div id="f3_food_HelpLinks" class="odp-widget-wrapper celwidget" cel_widget_id="f3_food_HelpLinks">
+
+
+
+
+
+
+
+
+
+
+
+<div class="a-row a-spacing-base">
+    <h2 class="widget-title-string">
+        <span id="ufpo-help-links-title" class="a-size-medium">
+            Need help with this order?
+        </span>
+    </h2>
+</div>
+
+
+    <div class="a-row a-spacing-base">
+        <a class="a-link-normal" href="/fmc/m/30001803?almBrandId=VUZHIFdob2xlIEZvb2Rz&amp;ref_=wfm_food_od_help_customer_care">
+            <span>
+                Contact Customer Support
+            </span>
+        </a>
+    </div>
+
+    <div class="a-row a-spacing-base">
+        <a class="a-link-normal" href="https://www.wholefoodsmarket.com/company-info/whole-foods-market-return-policy?ref_=wfm_food_od_help_refund">
+            <span>
+                Learn more about refunds
+            </span>
+        </a>
+    </div>
+
+    <div class="a-row a-spacing-base">
+        <a class="a-link-normal" href="https://www.wholefoodsmarket.com/customer-service/topics/amazon?ref_=wfm_food_od_help_why_am_i_seeing_wfm_orders#00000194-d7d2-d7f8-a9dc-d7f2c1f30000">
+            <span>
+                Why am I seeing my Whole Foods Market Orders?
+            </span>
+        </a>
+    </div>
+
+    <div class="a-row a-spacing-base">
+        <a class="a-link-normal" href="https://www.wholefoodsmarket.com/customer-service/topics/amazon?ref_=wfm_food_od_help_i_do_not_recognize_order#00000194-d7d5-d7f8-a9dc-d7f536fa0000">
+            <span>
+                I don't recognize this order
+            </span>
+        </a>
+    </div>
+
+</div>
+
+        
+            <div id="f3_food_DestinationInfo" class="odp-widget-wrapper celwidget" cel_widget_id="f3_food_DestinationInfo">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<!-- Delivery/Pickup Address -->
+<div class="a-row a-spacing-base">
+    <h2 class="widget-title-string">
+        <span class="a-size-medium">
+            Purchased at  store
+        </span>
+    </h2>
+</div>
+<div class="a-row">
+    <span class="a-size-base">
+        
+<script type="text/javascript">
+	
+;try {
+  window.uet('bb', 'Siege:Csd:LibraryEval', {wb: 1});
+} catch (e) {}
+(function(f) {
+  if (typeof window !== 'undefined') {
+    
+    try {
+      performance.mark("Siege:Csd:LibStart");
+    } catch (e) {}
+    try {
+      if (window.SiegeClientSideDecryption) {
+        
+        return;
+      }
+      f();
+    } catch (e) {
+      P.logError(e, 'siege-client-side-decryption init error: ', 'WARN', 'siege-client-side-decryption');
+      try {
+        window.ue.count('Siege:Csd:LibraryInitFailed', 1, {bf: '1'});
+      } catch (e) {}
+    }
+    return;
+  } else {
+    throw new Error('Cannot initialize SiegeClientSideDecryption outside window');
+  }
+})(function() {
+  !function(e,t){"object"==typeof exports&&"object"==typeof module?module.exports=t():"function"==typeof define&&define.amd?define([],t):"object"==typeof exports?exports.SiegeClientSideDecryption=t():e.SiegeClientSideDecryption=t()}(window,(function(){return function(e){var t={};function n(r){if(t[r])return t[r].exports;var A=t[r]={i:r,l:!1,exports:{}};return e[r].call(A.exports,A,A.exports,n),A.l=!0,A.exports}return n.m=e,n.c=t,n.d=function(e,t,r){n.o(e,t)||Object.defineProperty(e,t,{enumerable:!0,get:r})},n.r=function(e){"undefined"!=typeof Symbol&&Symbol.toStringTag&&Object.defineProperty(e,Symbol.toStringTag,{value:"Module"}),Object.defineProperty(e,"__esModule",{value:!0})},n.t=function(e,t){if(1&t&&(e=n(e)),8&t)return e;if(4&t&&"object"==typeof e&&e&&e.__esModule)return e;var r=Object.create(null);if(n.r(r),Object.defineProperty(r,"default",{enumerable:!0,value:e}),2&t&&"string"!=typeof e)for(var A in e)n.d(r,A,function(t){return e[t]}.bind(null,A));return r},n.n=function(e){var t=e&&e.__esModule?function(){return e["default"]}:function(){return e};return n.d(t,"a",t),t},n.o=function(e,t){return Object.prototype.hasOwnProperty.call(e,t)},n.p="",n(n.s=179)}([function(e,t,n){var r=n(1),A=n(22).f,o=n(14),i=n(15),a=n(103),u=n(135),c=n(61);e.exports=function(e,t){var n,s,f,g,l,d=e.target,p=e.global,y=e.stat;if(n=p?r:y?r[d]||a(d,{}):(r[d]||{}).prototype)for(s in t){if(g=t[s],f=e.noTargetGet?(l=A(n,s))&&l.value:n[s],!c(p?s:d+(y?".":"#")+s,e.forced)&&f!==undefined){if(typeof g==typeof f)continue;u(g,f)}(e.sham||f&&f.sham)&&o(g,"sham",!0),i(n,s,g,e)}}},function(e,t,n){(function(t){var n=function(e){return e&&e.Math==Math&&e};e.exports=n("object"==typeof globalThis&&globalThis)||n("object"==typeof window&&window)||n("object"==typeof self&&self)||n("object"==typeof t&&t)||Function("return this")()}).call(this,n(100))},function(e,t){e.exports=function(e){try{return!!e()}catch(t){return!0}}},function(e,t,n){"use strict";var r,A=n(128),o=n(5),i=n(1),a=n(8),u=n(10),c=n(63),s=n(14),f=n(15),g=n(9).f,l=n(57),d=n(44),p=n(4),y=n(49),h=i.Int8Array,I=h&&h.prototype,C=i.Uint8ClampedArray,B=C&&C.prototype,E=h&&l(h),v=I&&l(I),Q=Object.prototype,w=Q.isPrototypeOf,m=p("toStringTag"),b=y("TYPED_ARRAY_TAG"),x=A&&!!d&&"Opera"!==c(i.opera),S=!1,D={Int8Array:1,Uint8Array:1,Uint8ClampedArray:1,Int16Array:2,Uint16Array:2,Int32Array:4,Uint32Array:4,Float32Array:4,Float64Array:8},k=function(e){return a(e)&&u(D,c(e))};for(r in D)i[r]||(x=!1);if((!x||"function"!=typeof E||E===Function.prototype)&&(E=function(){throw TypeError("Incorrect invocation")},x))for(r in D)i[r]&&d(i[r],E);if((!x||!v||v===Q)&&(v=E.prototype,x))for(r in D)i[r]&&d(i[r].prototype,v);if(x&&l(B)!==v&&d(B,v),o&&!u(v,m))for(r in S=!0,g(v,m,{get:function(){return a(this)?this[b]:undefined}}),D)i[r]&&s(i[r],b,r);e.exports={NATIVE_ARRAY_BUFFER_VIEWS:x,TYPED_ARRAY_TAG:S&&b,aTypedArray:function(e){if(k(e))return e;throw TypeError("Target is not a typed array")},aTypedArrayConstructor:function(e){if(d){if(w.call(E,e))return e}else for(var t in D)if(u(D,r)){var n=i[t];if(n&&(e===n||w.call(n,e)))return e}throw TypeError("Target is not a typed array constructor")},exportTypedArrayMethod:function(e,t,n){if(o){if(n)for(var r in D){var A=i[r];A&&u(A.prototype,e)&&delete A.prototype[e]}v[e]&&!n||f(v,e,n?t:x&&I[e]||t)}},exportTypedArrayStaticMethod:function(e,t,n){var r,A;if(o){if(d){if(n)for(r in D)(A=i[r])&&u(A,e)&&delete A[e];if(E[e]&&!n)return;try{return f(E,e,n?t:x&&h[e]||t)}catch(a){}}for(r in D)!(A=i[r])||A[e]&&!n||f(A,e,t)}},isView:function(e){var t=c(e);return"DataView"===t||u(D,t)},isTypedArray:k,TypedArray:E,TypedArrayPrototype:v}},function(e,t,n){var r=n(1),A=n(105),o=n(10),i=n(49),a=n(109),u=n(142),c=A("wks"),s=r.Symbol,f=u?s:s&&s.withoutSetter||i;e.exports=function(e){return o(c,e)||(a&&o(s,e)?c[e]=s[e]:c[e]=f("Symbol."+e)),c[e]}},function(e,t,n){var r=n(2);e.exports=!r((function(){return 7!=Object.defineProperty({},1,{get:function(){return 7}})[1]}))},function(e,t,n){var r=n(24),A=Math.min;e.exports=function(e){return e>0?A(r(e),9007199254740991):0}},function(e,t,n){var r=n(110),A=n(15),o=n(183);r||A(Object.prototype,"toString",o,{unsafe:!0})},function(e,t){e.exports=function(e){return"object"==typeof e?null!==e:"function"==typeof e}},function(e,t,n){var r=n(5),A=n(133),o=n(11),i=n(48),a=Object.defineProperty;t.f=r?a:function(e,t,n){if(o(e),t=i(t,!0),o(n),A)try{return a(e,t,n)}catch(r){}if("get"in n||"set"in n)throw TypeError("Accessors not supported");return"value"in n&&(e[t]=n.value),e}},function(e,t){var n={}.hasOwnProperty;e.exports=function(e,t){return n.call(e,t)}},function(e,t,n){var r=n(8);e.exports=function(e){if(!r(e))throw TypeError(String(e)+" is not an object");return e}},function(e,t,n){"use strict";var r,A,o,i,a=n(0),u=n(30),c=n(1),s=n(31),f=n(145),g=n(15),l=n(111),d=n(25),p=n(53),y=n(8),h=n(54),I=n(55),C=n(23),B=n(104),E=n(112),v=n(64),Q=n(26),w=n(147).set,m=n(184),b=n(149),x=n(185),S=n(150),D=n(186),k=n(21),R=n(61),F=n(4),O=n(115),M=F("species"),G="Promise",N=k.get,T=k.set,L=k.getterFor(G),H=f,j=c.TypeError,Y=c.document,U=c.process,P=s("fetch"),K=S.f,_=K,X="process"==C(U),J=!!(Y&&Y.createEvent&&c.dispatchEvent),q=R(G,(function(){if(!(B(H)!==String(H))){if(66===O)return!0;if(!X&&"function"!=typeof PromiseRejectionEvent)return!0}if(u&&!H.prototype["finally"])return!0;if(O>=51&&/native code/.test(H))return!1;var e=H.resolve(1),t=function(e){e((function(){}),(function(){}))};return(e.constructor={})[M]=t,!(e.then((function(){}))instanceof t)})),Z=q||!v((function(e){H.all(e)["catch"]((function(){}))})),z=function(e){var t;return!(!y(e)||"function"!=typeof(t=e.then))&&t},V=function(e,t,n){if(!t.notified){t.notified=!0;var r=t.reactions;m((function(){for(var A=t.value,o=1==t.state,i=0;r.length>i;){var a,u,c,s=r[i++],f=o?s.ok:s.fail,g=s.resolve,l=s.reject,d=s.domain;try{f?(o||(2===t.rejection&&te(e,t),t.rejection=1),!0===f?a=A:(d&&d.enter(),a=f(A),d&&(d.exit(),c=!0)),a===s.promise?l(j("Promise-chain cycle")):(u=z(a))?u.call(a,g,l):g(a)):l(A)}catch(p){d&&!c&&d.exit(),l(p)}}t.reactions=[],t.notified=!1,n&&!t.rejection&&$(e,t)}))}},W=function(e,t,n){var r,A;J?((r=Y.createEvent("Event")).promise=t,r.reason=n,r.initEvent(e,!1,!0),c.dispatchEvent(r)):r={promise:t,reason:n},(A=c["on"+e])?A(r):"unhandledrejection"===e&&x("Unhandled promise rejection",n)},$=function(e,t){w.call(c,(function(){var n,r=t.value;if(ee(t)&&(n=D((function(){X?U.emit("unhandledRejection",r,e):W("unhandledrejection",e,r)})),t.rejection=X||ee(t)?2:1,n.error))throw n.value}))},ee=function(e){return 1!==e.rejection&&!e.parent},te=function(e,t){w.call(c,(function(){X?U.emit("rejectionHandled",e):W("rejectionhandled",e,t.value)}))},ne=function(e,t,n,r){return function(A){e(t,n,A,r)}},re=function(e,t,n,r){t.done||(t.done=!0,r&&(t=r),t.value=n,t.state=2,V(e,t,!0))},Ae=function(e,t,n,r){if(!t.done){t.done=!0,r&&(t=r);try{if(e===n)throw j("Promise can't be resolved itself");var A=z(n);A?m((function(){var r={done:!1};try{A.call(n,ne(Ae,e,r,t),ne(re,e,r,t))}catch(o){re(e,r,o,t)}})):(t.value=n,t.state=1,V(e,t,!1))}catch(o){re(e,{done:!1},o,t)}}};q&&(H=function(e){I(this,H,G),h(e),r.call(this);var t=N(this);try{e(ne(Ae,this,t),ne(re,this,t))}catch(n){re(this,t,n)}},(r=function(e){T(this,{type:G,done:!1,notified:!1,parent:!1,reactions:[],rejection:!1,state:0,value:undefined})}).prototype=l(H.prototype,{then:function(e,t){var n=L(this),r=K(Q(this,H));return r.ok="function"!=typeof e||e,r.fail="function"==typeof t&&t,r.domain=X?U.domain:undefined,n.parent=!0,n.reactions.push(r),0!=n.state&&V(this,n,!1),r.promise},"catch":function(e){return this.then(undefined,e)}}),A=function(){var e=new r,t=N(e);this.promise=e,this.resolve=ne(Ae,e,t),this.reject=ne(re,e,t)},S.f=K=function(e){return e===H||e===o?new A(e):_(e)},u||"function"!=typeof f||(i=f.prototype.then,g(f.prototype,"then",(function(e,t){var n=this;return new H((function(e,t){i.call(n,e,t)})).then(e,t)}),{unsafe:!0}),"function"==typeof P&&a({global:!0,enumerable:!0,forced:!0},{fetch:function(e){return b(H,P.apply(c,arguments))}}))),a({global:!0,wrap:!0,forced:q},{Promise:H}),d(H,G,!1,!0),p(G),o=s(G),a({target:G,stat:!0,forced:q},{reject:function(e){var t=K(this);return t.reject.call(undefined,e),t.promise}}),a({target:G,stat:!0,forced:u||q},{resolve:function(e){return b(u&&this===o?H:this,e)}}),a({target:G,stat:!0,forced:Z},{all:function(e){var t=this,n=K(t),r=n.resolve,A=n.reject,o=D((function(){var n=h(t.resolve),o=[],i=0,a=1;E(e,(function(e){var u=i++,c=!1;o.push(undefined),a++,n.call(t,e).then((function(e){c||(c=!0,o[u]=e,--a||r(o))}),A)})),--a||r(o)}));return o.error&&A(o.value),n.promise},race:function(e){var t=this,n=K(t),r=n.reject,A=D((function(){var A=h(t.resolve);E(e,(function(e){A.call(t,e).then(n.resolve,r)}))}));return A.error&&r(A.value),n.promise}})},function(e,t,n){var r=n(29);e.exports=function(e){return Object(r(e))}},function(e,t,n){var r=n(5),A=n(9),o=n(37);e.exports=r?function(e,t,n){return A.f(e,t,o(1,n))}:function(e,t,n){return e[t]=n,e}},function(e,t,n){var r=n(1),A=n(14),o=n(10),i=n(103),a=n(104),u=n(21),c=u.get,s=u.enforce,f=String(String).split("String");(e.exports=function(e,t,n,a){var u=!!a&&!!a.unsafe,c=!!a&&!!a.enumerable,g=!!a&&!!a.noTargetGet;"function"==typeof n&&("string"!=typeof t||o(n,"name")||A(n,"name",t),s(n).source=f.join("string"==typeof t?t:"")),e!==r?(u?!g&&e[t]&&(c=!0):delete e[t],c?e[t]=n:A(e,t,n)):c?e[t]=n:i(t,n)})(Function.prototype,"toString",(function(){return"function"==typeof this&&c(this).source||a(this)}))},function(e,t,n){"use strict";var r=n(19),A=n(141),o=n(56),i=n(21),a=n(118),u=i.set,c=i.getterFor("Array Iterator");e.exports=a(Array,"Array",(function(e,t){u(this,{type:"Array Iterator",target:r(e),index:0,kind:t})}),(function(){var e=c(this),t=e.target,n=e.kind,r=e.index++;return!t||r>=t.length?(e.target=undefined,{value:undefined,done:!0}):"keys"==n?{value:r,done:!1}:"values"==n?{value:t[r],done:!1}:{value:[r,t[r]],done:!1}}),"values"),o.Arguments=o.Array,A("keys"),A("values"),A("entries")},function(e,t,n){var r=n(0),A=n(5);r({target:"Object",stat:!0,forced:!A,sham:!A},{defineProperty:n(9).f})},function(e,t,n){"use strict";(function(e){function t(e){return(t="function"==typeof Symbol&&"symbol"==typeof Symbol.iterator?function(e){return typeof e}:function(e){return e&&"function"==typeof Symbol&&e.constructor===Symbol&&e!==Symbol.prototype?"symbol":typeof e})(e)}
+/**
+ * Copyright (c) 2014-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */n(34),n(42),n(190),n(43),n(191),n(66),n(16),n(194),n(58),n(35),n(119),n(195),n(196),n(197),n(198),n(199),n(7),n(12),n(45),n(36),n(68),n(27);var r=function(e){var n=Object.prototype,r=n.hasOwnProperty,A="function"==typeof Symbol?Symbol:{},o=A.iterator||"@@iterator",i=A.asyncIterator||"@@asyncIterator",a=A.toStringTag||"@@toStringTag";function u(e,t,n,r){var A=t&&t.prototype instanceof f?t:f,o=Object.create(A.prototype),i=new Q(r||[]);return o._invoke=function(e,t,n){var r="suspendedStart";return function(A,o){if("executing"===r)throw new Error("Generator is already running");if("completed"===r){if("throw"===A)throw o;return m()}for(n.method=A,n.arg=o;;){var i=n.delegate;if(i){var a=B(i,n);if(a){if(a===s)continue;return a}}if("next"===n.method)n.sent=n._sent=n.arg;else if("throw"===n.method){if("suspendedStart"===r)throw r="completed",n.arg;n.dispatchException(n.arg)}else"return"===n.method&&n.abrupt("return",n.arg);r="executing";var u=c(e,t,n);if("normal"===u.type){if(r=n.done?"completed":"suspendedYield",u.arg===s)continue;return{value:u.arg,done:n.done}}"throw"===u.type&&(r="completed",n.method="throw",n.arg=u.arg)}}}(e,n,i),o}function c(e,t,n){try{return{type:"normal",arg:e.call(t,n)}}catch(err){return{type:"throw",arg:err}}}e.wrap=u;var s={};function f(){}function g(){}function l(){}var d={};d[o]=function(){return this};var p=Object.getPrototypeOf,y=p&&p(p(w([])));y&&y!==n&&r.call(y,o)&&(d=y);var h=l.prototype=f.prototype=Object.create(d);function I(e){["next","throw","return"].forEach((function(t){e[t]=function(e){return this._invoke(t,e)}}))}function C(e){var n;this._invoke=function(A,o){function i(){return new Promise((function(n,i){!function a(n,A,o,i){var u=c(e[n],e,A);if("throw"!==u.type){var s=u.arg,f=s.value;return f&&"object"===t(f)&&r.call(f,"__await")?Promise.resolve(f.__await).then((function(e){a("next",e,o,i)}),(function(e){a("throw",e,o,i)})):Promise.resolve(f).then((function(e){s.value=e,o(s)}),(function(e){return a("throw",e,o,i)}))}i(u.arg)}(A,o,n,i)}))}return n=n?n.then(i,i):i()}}function B(e,t){var n=e.iterator[t.method];if(void 0===n){if(t.delegate=null,"throw"===t.method){if(e.iterator["return"]&&(t.method="return",t.arg=void 0,B(e,t),"throw"===t.method))return s;t.method="throw",t.arg=new TypeError("The iterator does not provide a 'throw' method")}return s}var r=c(n,e.iterator,t.arg);if("throw"===r.type)return t.method="throw",t.arg=r.arg,t.delegate=null,s;var A=r.arg;return A?A.done?(t[e.resultName]=A.value,t.next=e.nextLoc,"return"!==t.method&&(t.method="next",t.arg=void 0),t.delegate=null,s):A:(t.method="throw",t.arg=new TypeError("iterator result is not an object"),t.delegate=null,s)}function E(e){var t={tryLoc:e[0]};1 in e&&(t.catchLoc=e[1]),2 in e&&(t.finallyLoc=e[2],t.afterLoc=e[3]),this.tryEntries.push(t)}function v(e){var t=e.completion||{};t.type="normal",delete t.arg,e.completion=t}function Q(e){this.tryEntries=[{tryLoc:"root"}],e.forEach(E,this),this.reset(!0)}function w(e){if(e){var t=e[o];if(t)return t.call(e);if("function"==typeof e.next)return e;if(!isNaN(e.length)){var n=-1,A=function t(){for(;++n<e.length;)if(r.call(e,n))return t.value=e[n],t.done=!1,t;return t.value=void 0,t.done=!0,t};return A.next=A}}return{next:m}}function m(){return{value:void 0,done:!0}}return g.prototype=h.constructor=l,l.constructor=g,l[a]=g.displayName="GeneratorFunction",e.isGeneratorFunction=function(e){var t="function"==typeof e&&e.constructor;return!!t&&(t===g||"GeneratorFunction"===(t.displayName||t.name))},e.mark=function(e){return Object.setPrototypeOf?Object.setPrototypeOf(e,l):(e.__proto__=l,a in e||(e[a]="GeneratorFunction")),e.prototype=Object.create(h),e},e.awrap=function(e){return{__await:e}},I(C.prototype),C.prototype[i]=function(){return this},e.AsyncIterator=C,e.async=function(t,n,r,A){var o=new C(u(t,n,r,A));return e.isGeneratorFunction(n)?o:o.next().then((function(e){return e.done?e.value:o.next()}))},I(h),h[a]="Generator",h[o]=function(){return this},h.toString=function(){return"[object Generator]"},e.keys=function(e){var t=[];for(var n in e)t.push(n);return t.reverse(),function r(){for(;t.length;){var n=t.pop();if(n in e)return r.value=n,r.done=!1,r}return r.done=!0,r}},e.values=w,Q.prototype={constructor:Q,reset:function(e){if(this.prev=0,this.next=0,this.sent=this._sent=void 0,this.done=!1,this.delegate=null,this.method="next",this.arg=void 0,this.tryEntries.forEach(v),!e)for(var t in this)"t"===t.charAt(0)&&r.call(this,t)&&!isNaN(+t.slice(1))&&(this[t]=void 0)},stop:function(){this.done=!0;var e=this.tryEntries[0].completion;if("throw"===e.type)throw e.arg;return this.rval},dispatchException:function(e){if(this.done)throw e;var t=this;function n(n,r){return i.type="throw",i.arg=e,t.next=n,r&&(t.method="next",t.arg=void 0),!!r}for(var A=this.tryEntries.length-1;A>=0;--A){var o=this.tryEntries[A],i=o.completion;if("root"===o.tryLoc)return n("end");if(o.tryLoc<=this.prev){var a=r.call(o,"catchLoc"),u=r.call(o,"finallyLoc");if(a&&u){if(this.prev<o.catchLoc)return n(o.catchLoc,!0);if(this.prev<o.finallyLoc)return n(o.finallyLoc)}else if(a){if(this.prev<o.catchLoc)return n(o.catchLoc,!0)}else{if(!u)throw new Error("try statement without catch or finally");if(this.prev<o.finallyLoc)return n(o.finallyLoc)}}}},abrupt:function(e,t){for(var n=this.tryEntries.length-1;n>=0;--n){var A=this.tryEntries[n];if(A.tryLoc<=this.prev&&r.call(A,"finallyLoc")&&this.prev<A.finallyLoc){var o=A;break}}o&&("break"===e||"continue"===e)&&o.tryLoc<=t&&t<=o.finallyLoc&&(o=null);var i=o?o.completion:{};return i.type=e,i.arg=t,o?(this.method="next",this.next=o.finallyLoc,s):this.complete(i)},complete:function(e,t){if("throw"===e.type)throw e.arg;return"break"===e.type||"continue"===e.type?this.next=e.arg:"return"===e.type?(this.rval=this.arg=e.arg,this.method="return",this.next="end"):"normal"===e.type&&t&&(this.next=t),s},finish:function(e){for(var t=this.tryEntries.length-1;t>=0;--t){var n=this.tryEntries[t];if(n.finallyLoc===e)return this.complete(n.completion,n.afterLoc),v(n),s}},"catch":function(e){for(var t=this.tryEntries.length-1;t>=0;--t){var n=this.tryEntries[t];if(n.tryLoc===e){var r=n.completion;if("throw"===r.type){var A=r.arg;v(n)}return A}}throw new Error("illegal catch attempt")},delegateYield:function(e,t,n){return this.delegate={iterator:w(e),resultName:t,nextLoc:n},"next"===this.method&&(this.arg=void 0),s}},e}("object"===t(e)?e.exports:{});try{regeneratorRuntime=r}catch(A){Function("r","regeneratorRuntime = r")(r)}}).call(this,n(188)(e))},function(e,t,n){var r=n(47),A=n(29);e.exports=function(e){return r(A(e))}},function(e,t,n){var r=n(40),A=n(47),o=n(13),i=n(6),a=n(117),u=[].push,c=function(e){var t=1==e,n=2==e,c=3==e,s=4==e,f=6==e,g=5==e||f;return function(l,d,p,y){for(var h,I,C=o(l),B=A(C),E=r(d,p,3),v=i(B.length),Q=0,w=y||a,m=t?w(l,v):n?w(l,0):undefined;v>Q;Q++)if((g||Q in B)&&(I=E(h=B[Q],Q,C),e))if(t)m[Q]=I;else if(I)switch(e){case 3:return!0;case 5:return h;case 6:return Q;case 2:u.call(m,h)}else if(s)return!1;return f?-1:c||s?s:m}};e.exports={forEach:c(0),map:c(1),filter:c(2),some:c(3),every:c(4),find:c(5),findIndex:c(6)}},function(e,t,n){var r,A,o,i=n(181),a=n(1),u=n(8),c=n(14),s=n(10),f=n(60),g=n(50),l=a.WeakMap;if(i){var d=new l,p=d.get,y=d.has,h=d.set;r=function(e,t){return h.call(d,e,t),t},A=function(e){return p.call(d,e)||{}},o=function(e){return y.call(d,e)}}else{var I=f("state");g[I]=!0,r=function(e,t){return c(e,I,t),t},A=function(e){return s(e,I)?e[I]:{}},o=function(e){return s(e,I)}}e.exports={set:r,get:A,has:o,enforce:function(e){return o(e)?A(e):r(e,{})},getterFor:function(e){return function(t){var n;if(!u(t)||(n=A(t)).type!==e)throw TypeError("Incompatible receiver, "+e+" required");return n}}}},function(e,t,n){var r=n(5),A=n(101),o=n(37),i=n(19),a=n(48),u=n(10),c=n(133),s=Object.getOwnPropertyDescriptor;t.f=r?s:function(e,t){if(e=i(e),t=a(t,!0),c)try{return s(e,t)}catch(n){}if(u(e,t))return o(!A.f.call(e,t),e[t])}},function(e,t){var n={}.toString;e.exports=function(e){return n.call(e).slice(8,-1)}},function(e,t){var n=Math.ceil,r=Math.floor;e.exports=function(e){return isNaN(e=+e)?0:(e>0?r:n)(e)}},function(e,t,n){var r=n(9).f,A=n(10),o=n(4)("toStringTag");e.exports=function(e,t,n){e&&!A(e=n?e:e.prototype,o)&&r(e,o,{configurable:!0,value:t})}},function(e,t,n){var r=n(11),A=n(54),o=n(4)("species");e.exports=function(e,t){var n,i=r(e).constructor;return i===undefined||(n=r(i)[o])==undefined?t:A(n)}},function(e,t,n){var r=n(1),A=n(159),o=n(16),i=n(14),a=n(4),u=a("iterator"),c=a("toStringTag"),s=o.values;for(var f in A){var g=r[f],l=g&&g.prototype;if(l){if(l[u]!==s)try{i(l,u,s)}catch(p){l[u]=s}if(l[c]||i(l,c,f),A[f])for(var d in o)if(l[d]!==o[d])try{i(l,d,o[d])}catch(p){l[d]=o[d]}}}},function(e,t,n){"use strict";function r(e,t){return function(e){if(Array.isArray(e))return e}(e)||function(e,t){if(!(Symbol.iterator in Object(e)||"[object Arguments]"===Object.prototype.toString.call(e)))return;var n=[],r=!0,A=!1,o=undefined;try{for(var i,a=e[Symbol.iterator]();!(r=(i=a.next()).done)&&(n.push(i.value),!t||n.length!==t);r=!0);}catch(err){A=!0,o=err}finally{try{r||null==a["return"]||a["return"]()}finally{if(A)throw o}}return n}(e,t)||function(){throw new TypeError("Invalid attempt to destructure non-iterable instance")}()}function A(e,t){if(!(e instanceof t))throw new TypeError("Cannot call a class as a function")}function o(e,t){for(var n=0;n<t.length;n++){var r=t[n];r.enumerable=r.enumerable||!1,r.configurable=!0,"value"in r&&(r.writable=!0),Object.defineProperty(e,r.key,r)}}function i(e,t,n){return t in e?Object.defineProperty(e,t,{value:n,enumerable:!0,configurable:!0,writable:!0}):e[t]=n,e}function a(e){return!(!e.ue||!e.ue.count)}function u(e){return!!(e.ue&&e.uex&&e.uet)}n(34),n(42),n(43),n(99),n(140),n(166),n(16),n(35),n(119),n(17),n(7),n(45),n(151),n(36),n(27),Object.defineProperty(t,"__esModule",{value:!0}),t.logLibraryLoadMetrics=function(e){var t=r(performance.getEntriesByType("resource").filter((function(e){return e.name.includes("SiegeClientSideDecryption")})),1)[0];if(!t)throw new Error("No performance information about library available");e.updateCounter("Siege:Csd:LibraryDownloadTime",Math.ceil(t.duration));var n=r(performance.getEntriesByName("Siege:Csd:LibStart","mark"),1)[0];n&&e.updateCounter("Siege:Csd:LibraryEvalWaitTime",Math.ceil(n.startTime-(t.startTime+t.duration)))},t.Logger=void 0;var c=function(){function e(){var t=arguments.length>0&&arguments[0]!==undefined?arguments[0]:function(){return window.location};A(this,e),this._location=t}var t,n,r;return t=e,(n=[{key:"updateCounter",value:function(e,t){return a(window)?window.ue.count(e,t,{bf:"1"}):undefined}},{key:"incrementCounter",value:function(e){var t,n=arguments.length>1&&arguments[1]!==undefined?arguments[1]:1;return a(window)?this.updateCounter(e,(null!==(t=window.ue.count(e))&&void 0!==t?t:0)+n):undefined}},{key:"buildLogConfig",value:function(t){var n,r,A;return{logLevel:null!==(n=t.logLevel)&&void 0!==n?n:e.DEFAULT_LOG_LEVEL,attribution:null!==(r=t.attribution)&&void 0!==r?r:e.DEFAULT_LOG_ATTRIBUTION,message:null!==(A=t.message)&&void 0!==A?A:e.DEFAULT_LOG_MESSAGE}}},{key:"log",value:function(t,n){if(window.ueLogError){var r;r=n?this.buildLogConfig(n):this.buildLogConfig({});var A=this._location();return!(A.port!==undefined&&!e.ALLOWED_LOG_PORTS.includes(A.port)||(window.ueLogError(t,r),0))}return!1}},{key:"logError",value:function(t,n){var r=this.buildLogConfig({logLevel:e.ERROR_LOG_LEVEL,attribution:null!=n?n:e.DEFAULT_LOG_ATTRIBUTION});return this.log(t,r)}},{key:"logWarn",value:function(t,n){var r=this.buildLogConfig({logLevel:e.WARN_LOG_LEVEL,attribution:null!=n?n:e.DEFAULT_LOG_ATTRIBUTION});return this.log(t,r)}},{key:"getFullTimerName",value:function(t){return e.LATENCY_NAME_PREFIX+t}},{key:"startTimer",value:function(e){if(u(window))try{window.uet("bb",this.getFullTimerName(e),{wb:1})}catch(t){this.log(t,{message:"startTimer"})}}},{key:"stopTimer",value:function(e){if(u(window))try{window.uet("cf",this.getFullTimerName(e),{wb:1})}catch(t){this.log(t,{message:"endTimer"})}}},{key:"sendTimer",value:function(e){if(u(window))try{window.uex("ld",this.getFullTimerName(e),{wb:1})}catch(t){this.log(t,{message:"sendTimer"})}}},{key:"stopAndSendTimer",value:function(e){this.stopTimer(e),this.sendTimer(e)}}])&&o(t.prototype,n),r&&o(t,r),e}();t.Logger=c,i(c,"WARN_LOG_LEVEL","WARN"),i(c,"ERROR_LOG_LEVEL","ERROR"),i(c,"DEFAULT_LOG_LEVEL",c.ERROR_LOG_LEVEL),i(c,"DEFAULT_LOG_ATTRIBUTION","Siege:Csd"),i(c,"DEFAULT_LOG_MESSAGE","SiegeClientSideDecryptionJS "),i(c,"LATENCY_NAME_PREFIX","Siege:Csd:"),i(c,"ALLOWED_LOG_PORTS",["","443","80"])},function(e,t){e.exports=function(e){if(e==undefined)throw TypeError("Can't call method on "+e);return e}},function(e,t){e.exports=!1},function(e,t,n){var r=n(137),A=n(1),o=function(e){return"function"==typeof e?e:undefined};e.exports=function(e,t){return arguments.length<2?o(r[e])||o(A[e]):r[e]&&r[e][t]||A[e]&&A[e][t]}},function(e,t,n){var r=n(24),A=Math.max,o=Math.min;e.exports=function(e,t){var n=r(e);return n<0?A(n+t,0):o(n,t)}},function(e,t,n){var r=n(182),A=n(52);e.exports=function(e){return!!A(e)&&r.apply(this,arguments)}},function(e,t,n){"use strict";var r=n(0),A=n(1),o=n(31),i=n(30),a=n(5),u=n(109),c=n(142),s=n(2),f=n(10),g=n(41),l=n(8),d=n(11),p=n(13),y=n(19),h=n(48),I=n(37),C=n(39),B=n(62),E=n(38),v=n(189),Q=n(107),w=n(22),m=n(9),b=n(101),x=n(14),S=n(15),D=n(105),k=n(60),R=n(50),F=n(49),O=n(4),M=n(154),G=n(65),N=n(25),T=n(21),L=n(20).forEach,H=k("hidden"),j=O("toPrimitive"),Y=T.set,U=T.getterFor("Symbol"),P=Object.prototype,K=A.Symbol,_=o("JSON","stringify"),X=w.f,J=m.f,q=v.f,Z=b.f,z=D("symbols"),V=D("op-symbols"),W=D("string-to-symbol-registry"),$=D("symbol-to-string-registry"),ee=D("wks"),te=A.QObject,ne=!te||!te.prototype||!te.prototype.findChild,re=a&&s((function(){return 7!=C(J({},"a",{get:function(){return J(this,"a",{value:7}).a}})).a}))?function(e,t,n){var r=X(P,t);r&&delete P[t],J(e,t,n),r&&e!==P&&J(P,t,r)}:J,Ae=function(e,t){var n=z[e]=C(K.prototype);return Y(n,{type:"Symbol",tag:e,description:t}),a||(n.description=t),n},oe=c?function(e){return"symbol"==typeof e}:function(e){return Object(e)instanceof K},ie=function(e,t,n){e===P&&ie(V,t,n),d(e);var r=h(t,!0);return d(n),f(z,r)?(n.enumerable?(f(e,H)&&e[H][r]&&(e[H][r]=!1),n=C(n,{enumerable:I(0,!1)})):(f(e,H)||J(e,H,I(1,{})),e[H][r]=!0),re(e,r,n)):J(e,r,n)},ae=function(e,t){d(e);var n=y(t),r=B(n).concat(fe(n));return L(r,(function(t){a&&!ue.call(n,t)||ie(e,t,n[t])})),e},ue=function(e){var t=h(e,!0),n=Z.call(this,t);return!(this===P&&f(z,t)&&!f(V,t))&&(!(n||!f(this,t)||!f(z,t)||f(this,H)&&this[H][t])||n)},ce=function(e,t){var n=y(e),r=h(t,!0);if(n!==P||!f(z,r)||f(V,r)){var A=X(n,r);return!A||!f(z,r)||f(n,H)&&n[H][r]||(A.enumerable=!0),A}},se=function(e){var t=q(y(e)),n=[];return L(t,(function(e){f(z,e)||f(R,e)||n.push(e)})),n},fe=function(e){var t=e===P,n=q(t?V:y(e)),r=[];return L(n,(function(e){!f(z,e)||t&&!f(P,e)||r.push(z[e])})),r};(u||(S((K=function(){if(this instanceof K)throw TypeError("Symbol is not a constructor");var e=arguments.length&&arguments[0]!==undefined?String(arguments[0]):undefined,t=F(e),n=function(e){this===P&&n.call(V,e),f(this,H)&&f(this[H],t)&&(this[H][t]=!1),re(this,t,I(1,e))};return a&&ne&&re(P,t,{configurable:!0,set:n}),Ae(t,e)}).prototype,"toString",(function(){return U(this).tag})),S(K,"withoutSetter",(function(e){return Ae(F(e),e)})),b.f=ue,m.f=ie,w.f=ce,E.f=v.f=se,Q.f=fe,M.f=function(e){return Ae(O(e),e)},a&&(J(K.prototype,"description",{configurable:!0,get:function(){return U(this).description}}),i||S(P,"propertyIsEnumerable",ue,{unsafe:!0}))),r({global:!0,wrap:!0,forced:!u,sham:!u},{Symbol:K}),L(B(ee),(function(e){G(e)})),r({target:"Symbol",stat:!0,forced:!u},{"for":function(e){var t=String(e);if(f(W,t))return W[t];var n=K(t);return W[t]=n,$[n]=t,n},keyFor:function(e){if(!oe(e))throw TypeError(e+" is not a symbol");if(f($,e))return $[e]},useSetter:function(){ne=!0},useSimple:function(){ne=!1}}),r({target:"Object",stat:!0,forced:!u,sham:!a},{create:function(e,t){return t===undefined?C(e):ae(C(e),t)},defineProperty:ie,defineProperties:ae,getOwnPropertyDescriptor:ce}),r({target:"Object",stat:!0,forced:!u},{getOwnPropertyNames:se,getOwnPropertySymbols:fe}),r({target:"Object",stat:!0,forced:s((function(){Q.f(1)}))},{getOwnPropertySymbols:function(e){return Q.f(p(e))}}),_)&&r({target:"JSON",stat:!0,forced:!u||s((function(){var e=K();return"[null]"!=_([e])||"{}"!=_({a:e})||"{}"!=_(Object(e))}))},{stringify:function(e,t,n){for(var r,A=[e],o=1;arguments.length>o;)A.push(arguments[o++]);if(r=t,(l(t)||e!==undefined)&&!oe(e))return g(t)||(t=function(e,t){if("function"==typeof r&&(t=r.call(this,e,t)),!oe(t))return t}),A[1]=t,_.apply(null,A)}});K.prototype[j]||x(K.prototype,j,K.prototype.valueOf),N(K,"Symbol"),R[H]=!0},function(e,t,n){var r=n(15),A=Date.prototype,o=A.toString,i=A.getTime;new Date(NaN)+""!="Invalid Date"&&r(A,"toString",(function(){var e=i.call(this);return e==e?o.call(this):"Invalid Date"}))},function(e,t,n){"use strict";var r=n(158).charAt,A=n(21),o=n(118),i=A.set,a=A.getterFor("String Iterator");o(String,"String",(function(e){i(this,{type:"String Iterator",string:String(e),index:0})}),(function(){var e,t=a(this),n=t.string,A=t.index;return A>=n.length?{value:undefined,done:!0}:(e=r(n,A),t.index+=e.length,{value:e,done:!1})}))},function(e,t){e.exports=function(e,t){return{enumerable:!(1&e),configurable:!(2&e),writable:!(4&e),value:t}}},function(e,t,n){var r=n(138),A=n(106).concat("length","prototype");t.f=Object.getOwnPropertyNames||function(e){return r(e,A)}},function(e,t,n){var r,A=n(11),o=n(143),i=n(106),a=n(50),u=n(144),c=n(102),s=n(60),f=s("IE_PROTO"),g=function(){},l=function(e){return"<script>"+e+"<\/script>"},d=function(){try{r=document.domain&&new ActiveXObject("htmlfile")}catch(A){}var e,t;d=r?function(e){e.write(l("")),e.close();var t=e.parentWindow.Object;return e=null,t}(r):((t=c("iframe")).style.display="none",u.appendChild(t),t.src=String("javascript:"),(e=t.contentWindow.document).open(),e.write(l("document.F=Object")),e.close(),e.F);for(var n=i.length;n--;)delete d.prototype[i[n]];return d()};a[f]=!0,e.exports=Object.create||function(e,t){var n;return null!==e?(g.prototype=A(e),n=new g,g.prototype=null,n[f]=e):n=d(),t===undefined?n:o(n,t)}},function(e,t,n){var r=n(54);e.exports=function(e,t,n){if(r(e),t===undefined)return e;switch(n){case 0:return function(){return e.call(t)};case 1:return function(n){return e.call(t,n)};case 2:return function(n,r){return e.call(t,n,r)};case 3:return function(n,r,A){return e.call(t,n,r,A)}}return function(){return e.apply(t,arguments)}}},function(e,t,n){var r=n(23);e.exports=Array.isArray||function(e){return"Array"==r(e)}},function(e,t,n){"use strict";var r=n(0),A=n(5),o=n(1),i=n(10),a=n(8),u=n(9).f,c=n(135),s=o.Symbol;if(A&&"function"==typeof s&&(!("description"in s.prototype)||s().description!==undefined)){var f={},g=function(){var e=arguments.length<1||arguments[0]===undefined?undefined:String(arguments[0]),t=this instanceof g?new s(e):e===undefined?s():s(e);return""===e&&(f[t]=!0),t};c(g,s);var l=g.prototype=s.prototype;l.constructor=g;var d=l.toString,p="Symbol(test)"==String(s("test")),y=/^Symbol\((.*)\)[^)]+$/;u(l,"description",{configurable:!0,get:function(){var e=a(this)?this.valueOf():this,t=d.call(e);if(i(f,e))return"";var n=p?t.slice(7,-1):t.replace(y,"$1");return""===n?undefined:n}}),r({global:!0,forced:!0},{Symbol:g})}},function(e,t,n){n(65)("iterator")},function(e,t,n){var r=n(11),A=n(193);e.exports=Object.setPrototypeOf||("__proto__"in{}?function(){var e,t=!1,n={};try{(e=Object.getOwnPropertyDescriptor(Object.prototype,"__proto__").set).call(n,[]),t=n instanceof Array}catch(o){}return function(n,o){return r(n),A(o),t?e.call(n,o):n.__proto__=o,n}}():undefined)},function(e,t,n){"use strict";var r=n(15),A=n(11),o=n(2),i=n(120),a=RegExp.prototype,u=a.toString,c=o((function(){return"/a/b"!=u.call({source:"a",flags:"b"})})),s="toString"!=u.name;(c||s)&&r(RegExp.prototype,"toString",(function(){var e=A(this),t=String(e.source),n=e.flags;return"/"+t+"/"+String(n===undefined&&e instanceof RegExp&&!("flags"in a)?i.call(e):n)}),{unsafe:!0})},function(e,t,n){"use strict";n(34),n(99),n(66),n(129),n(17),n(130),n(131),n(73),n(68),Object.defineProperty(t,"__esModule",{value:!0}),t.cookieManagerSave=function(e,t,n){var A=arguments.length>3&&arguments[3]!==undefined?arguments[3]:{},i=o({},A,{v:1,kid:e,key:t});(0,r.cookieSet)("csd-key",btoa(JSON.stringify(i)),n)},t.cookieManagerDelete=function(){(0,r.cookieDelete)("csd-key")},t.cookieManagerDisable=function(){(0,r.cookieSet)("csd-key","disabled",30)},t.cookieManagerGet=a,t.cookieManagerGetRaw=function(){return(0,r.cookieGet)("csd-key")},t.cookieManagerIsDisabled=function(){return"disabled"===(0,r.cookieGet)("csd-key")},t.cookieManagerIsEnabled=function(){try{return a(),!0}catch(e){return!1}},t.CSD_COOKIE_NAME=void 0;var r=n(228);function A(e,t){var n=Object.keys(e);if(Object.getOwnPropertySymbols){var r=Object.getOwnPropertySymbols(e);t&&(r=r.filter((function(t){return Object.getOwnPropertyDescriptor(e,t).enumerable}))),n.push.apply(n,r)}return n}function o(e){for(var t=1;t<arguments.length;t++){var n=null!=arguments[t]?arguments[t]:{};t%2?A(Object(n),!0).forEach((function(t){i(e,t,n[t])})):Object.getOwnPropertyDescriptors?Object.defineProperties(e,Object.getOwnPropertyDescriptors(n)):A(Object(n)).forEach((function(t){Object.defineProperty(e,t,Object.getOwnPropertyDescriptor(n,t))}))}return e}function i(e,t,n){return t in e?Object.defineProperty(e,t,{value:n,enumerable:!0,configurable:!0,writable:!0}):e[t]=n,e}t.CSD_COOKIE_NAME="csd-key";function a(){var e,t=(0,r.cookieGet)("csd-key");if(""===t)throw new Error("Cookie value was empty");try{e=JSON.parse(atob(t))}catch(n){throw n instanceof Error&&(n.message="Could not parse cookie value. ".concat(n.message)),n}if(e===undefined||e.key===undefined||e.kid===undefined)throw new Error("Could not parse cookie value (2)");return e}},function(e,t,n){var r=n(2),A=n(23),o="".split;e.exports=r((function(){return!Object("z").propertyIsEnumerable(0)}))?function(e){return"String"==A(e)?o.call(e,""):Object(e)}:Object},function(e,t,n){var r=n(8);e.exports=function(e,t){if(!r(e))return e;var n,A;if(t&&"function"==typeof(n=e.toString)&&!r(A=n.call(e)))return A;if("function"==typeof(n=e.valueOf)&&!r(A=n.call(e)))return A;if(!t&&"function"==typeof(n=e.toString)&&!r(A=n.call(e)))return A;throw TypeError("Can't convert object to primitive value")}},function(e,t){var n=0,r=Math.random();e.exports=function(e){return"Symbol("+String(e===undefined?"":e)+")_"+(++n+r).toString(36)}},function(e,t){e.exports={}},function(e,t,n){var r=n(19),A=n(6),o=n(32),i=function(e){return function(t,n,i){var a,u=r(t),c=A(u.length),s=o(i,c);if(e&&n!=n){for(;c>s;)if((a=u[s++])!=a)return!0}else for(;c>s;s++)if((e||s in u)&&u[s]===n)return e||s||0;return!e&&-1}};e.exports={includes:i(!0),indexOf:i(!1)}},function(e,t,n){"use strict";var r=n(2);e.exports=function(e,t){var n=[][e];return!!n&&r((function(){n.call(null,t||function(){throw 1},1)}))}},function(e,t,n){"use strict";var r=n(31),A=n(9),o=n(4),i=n(5),a=o("species");e.exports=function(e){var t=r(e),n=A.f;i&&t&&!t[a]&&n(t,a,{configurable:!0,get:function(){return this}})}},function(e,t){e.exports=function(e){if("function"!=typeof e)throw TypeError(String(e)+" is not a function");return e}},function(e,t){e.exports=function(e,t,n){if(!(e instanceof t))throw TypeError("Incorrect "+(n?n+" ":"")+"invocation");return e}},function(e,t){e.exports={}},function(e,t,n){var r=n(10),A=n(13),o=n(60),i=n(157),a=o("IE_PROTO"),u=Object.prototype;e.exports=i?Object.getPrototypeOf:function(e){return e=A(e),r(e,a)?e[a]:"function"==typeof e.constructor&&e instanceof e.constructor?e.constructor.prototype:e instanceof Object?u:null}},function(e,t,n){"use strict";var r=n(0),A=n(8),o=n(41),i=n(32),a=n(6),u=n(19),c=n(59),s=n(4),f=n(67),g=n(33),l=f("slice"),d=g("slice",{ACCESSORS:!0,0:0,1:2}),p=s("species"),y=[].slice,h=Math.max;r({target:"Array",proto:!0,forced:!l||!d},{slice:function(e,t){var n,r,s,f=u(this),g=a(f.length),l=i(e,g),d=i(t===undefined?g:t,g);if(o(f)&&("function"!=typeof(n=f.constructor)||n!==Array&&!o(n.prototype)?A(n)&&null===(n=n[p])&&(n=undefined):n=undefined,n===Array||n===undefined))return y.call(f,l,d);for(r=new(n===undefined?Array:n)(h(d-l,0)),s=0;l<d;l++,s++)l in f&&c(r,s,f[l]);return r.length=s,r}})},function(e,t,n){"use strict";var r=n(48),A=n(9),o=n(37);e.exports=function(e,t,n){var i=r(t);i in e?A.f(e,i,o(0,n)):e[i]=n}},function(e,t,n){var r=n(105),A=n(49),o=r("keys");e.exports=function(e){return o[e]||(o[e]=A(e))}},function(e,t,n){var r=n(2),A=/#|\.prototype\./,o=function(e,t){var n=a[i(e)];return n==c||n!=u&&("function"==typeof t?r(t):!!t)},i=o.normalize=function(e){return String(e).replace(A,".").toLowerCase()},a=o.data={},u=o.NATIVE="N",c=o.POLYFILL="P";e.exports=o},function(e,t,n){var r=n(138),A=n(106);e.exports=Object.keys||function(e){return r(e,A)}},function(e,t,n){var r=n(110),A=n(23),o=n(4)("toStringTag"),i="Arguments"==A(function(){return arguments}());e.exports=r?A:function(e){var t,n,r;return e===undefined?"Undefined":null===e?"Null":"string"==typeof(n=function(e,t){try{return e[t]}catch(n){}}(t=Object(e),o))?n:i?A(t):"Object"==(r=A(t))&&"function"==typeof t.callee?"Arguments":r}},function(e,t,n){var r=n(4)("iterator"),A=!1;try{var o=0,i={next:function(){return{done:!!o++}},"return":function(){A=!0}};i[r]=function(){return this},Array.from(i,(function(){throw 2}))}catch(a){}e.exports=function(e,t){if(!t&&!A)return!1;var n=!1;try{var o={};o[r]=function(){return{next:function(){return{done:n=!0}}}},e(o)}catch(a){}return n}},function(e,t,n){var r=n(137),A=n(10),o=n(154),i=n(9).f;e.exports=function(e){var t=r.Symbol||(r.Symbol={});A(t,e)||i(t,e,{value:o.f(e)})}},function(e,t,n){"use strict";var r=n(0),A=n(155);r({target:"Array",proto:!0,forced:[].forEach!=A},{forEach:A})},function(e,t,n){var r=n(2),A=n(4),o=n(115),i=A("species");e.exports=function(e){return o>=51||!r((function(){var t=[];return(t.constructor={})[i]=function(){return{foo:1}},1!==t[e](Boolean).foo}))}},function(e,t,n){var r=n(1),A=n(159),o=n(155),i=n(14);for(var a in A){var u=r[a],c=u&&u.prototype;if(c&&c.forEach!==o)try{i(c,"forEach",o)}catch(s){c.forEach=o}}},function(e,t,n){"use strict";var r=n(0),A=n(51).indexOf,o=n(52),i=n(33),a=[].indexOf,u=!!a&&1/[1].indexOf(1,-0)<0,c=o("indexOf"),s=i("indexOf",{ACCESSORS:!0,1:0});r({target:"Array",proto:!0,forced:u||!c||!s},{indexOf:function(e){return u?a.apply(this,arguments)||0:A(this,e,arguments.length>1?arguments[1]:undefined)}})},function(e,t,n){"use strict";var r,A,o=n(120),i=n(164),a=RegExp.prototype.exec,u=String.prototype.replace,c=a,s=(r=/a/,A=/b*/g,a.call(r,"a"),a.call(A,"a"),0!==r.lastIndex||0!==A.lastIndex),f=i.UNSUPPORTED_Y||i.BROKEN_CARET,g=/()??/.exec("")[1]!==undefined;(s||g||f)&&(c=function(e){var t,n,r,A,i=this,c=f&&i.sticky,l=o.call(i),d=i.source,p=0,y=e;return c&&(-1===(l=l.replace("y","")).indexOf("g")&&(l+="g"),y=String(e).slice(i.lastIndex),i.lastIndex>0&&(!i.multiline||i.multiline&&"\n"!==e[i.lastIndex-1])&&(d="(?: "+d+")",y=" "+y,p++),n=new RegExp("^(?:"+d+")",l)),g&&(n=new RegExp("^"+d+"$(?!\\s)",l)),s&&(t=i.lastIndex),r=a.call(c?n:i,y),c?r?(r.input=r.input.slice(p),r[0]=r[0].slice(p),r.index=i.lastIndex,i.lastIndex+=r[0].length):i.lastIndex=0:s&&r&&(i.lastIndex=i.global?r.index+r[0].length:t),g&&r&&r.length>1&&u.call(r[0],n,(function(){for(A=1;A<arguments.length-2;A++)arguments[A]===undefined&&(r[A]=undefined)})),r}),e.exports=c},function(e,t,n){"use strict";var r=n(0),A=n(2),o=n(72),i=n(11),a=n(32),u=n(6),c=n(26),s=o.ArrayBuffer,f=o.DataView,g=s.prototype.slice;r({target:"ArrayBuffer",proto:!0,unsafe:!0,forced:A((function(){return!new s(2).slice(1,undefined).byteLength}))},{slice:function(e,t){if(g!==undefined&&t===undefined)return g.call(i(this),e);for(var n=i(this).byteLength,r=a(e,n),A=a(t===undefined?n:t,n),o=new(c(this,s))(u(A-r)),l=new f(this),d=new f(o),p=0;r<A;)d.setUint8(p++,l.getUint8(r++));return o}})},function(e,t,n){"use strict";var r=n(1),A=n(5),o=n(128),i=n(14),a=n(111),u=n(2),c=n(55),s=n(24),f=n(6),g=n(169),l=n(214),d=n(57),p=n(44),y=n(38).f,h=n(9).f,I=n(170),C=n(25),B=n(21),E=B.get,v=B.set,Q=r.ArrayBuffer,w=Q,m=r.DataView,b=m&&m.prototype,x=Object.prototype,S=r.RangeError,D=l.pack,k=l.unpack,R=function(e){return[255&e]},F=function(e){return[255&e,e>>8&255]},O=function(e){return[255&e,e>>8&255,e>>16&255,e>>24&255]},M=function(e){return e[3]<<24|e[2]<<16|e[1]<<8|e[0]},G=function(e){return D(e,23,4)},N=function(e){return D(e,52,8)},T=function(e,t){h(e.prototype,t,{get:function(){return E(this)[t]}})},L=function(e,t,n,r){var A=g(n),o=E(e);if(A+t>o.byteLength)throw S("Wrong index");var i=E(o.buffer).bytes,a=A+o.byteOffset,u=i.slice(a,a+t);return r?u:u.reverse()},H=function(e,t,n,r,A,o){var i=g(n),a=E(e);if(i+t>a.byteLength)throw S("Wrong index");for(var u=E(a.buffer).bytes,c=i+a.byteOffset,s=r(+A),f=0;f<t;f++)u[c+f]=s[o?f:t-f-1]};if(o){if(!u((function(){Q(1)}))||!u((function(){new Q(-1)}))||u((function(){return new Q,new Q(1.5),new Q(NaN),"ArrayBuffer"!=Q.name}))){for(var j,Y=(w=function(e){return c(this,w),new Q(g(e))}).prototype=Q.prototype,U=y(Q),P=0;U.length>P;)(j=U[P++])in w||i(w,j,Q[j]);Y.constructor=w}p&&d(b)!==x&&p(b,x);var K=new m(new w(2)),_=b.setInt8;K.setInt8(0,2147483648),K.setInt8(1,2147483649),!K.getInt8(0)&&K.getInt8(1)||a(b,{setInt8:function(e,t){_.call(this,e,t<<24>>24)},setUint8:function(e,t){_.call(this,e,t<<24>>24)}},{unsafe:!0})}else w=function(e){c(this,w,"ArrayBuffer");var t=g(e);v(this,{bytes:I.call(new Array(t),0),byteLength:t}),A||(this.byteLength=t)},m=function(e,t,n){c(this,m,"DataView"),c(e,w,"DataView");var r=E(e).byteLength,o=s(t);if(o<0||o>r)throw S("Wrong offset");if(o+(n=n===undefined?r-o:f(n))>r)throw S("Wrong length");v(this,{buffer:e,byteLength:n,byteOffset:o}),A||(this.buffer=e,this.byteLength=n,this.byteOffset=o)},A&&(T(w,"byteLength"),T(m,"buffer"),T(m,"byteLength"),T(m,"byteOffset")),a(m.prototype,{getInt8:function(e){return L(this,1,e)[0]<<24>>24},getUint8:function(e){return L(this,1,e)[0]},getInt16:function(e){var t=L(this,2,e,arguments.length>1?arguments[1]:undefined);return(t[1]<<8|t[0])<<16>>16},getUint16:function(e){var t=L(this,2,e,arguments.length>1?arguments[1]:undefined);return t[1]<<8|t[0]},getInt32:function(e){return M(L(this,4,e,arguments.length>1?arguments[1]:undefined))},getUint32:function(e){return M(L(this,4,e,arguments.length>1?arguments[1]:undefined))>>>0},getFloat32:function(e){return k(L(this,4,e,arguments.length>1?arguments[1]:undefined),23)},getFloat64:function(e){return k(L(this,8,e,arguments.length>1?arguments[1]:undefined),52)},setInt8:function(e,t){H(this,1,e,R,t)},setUint8:function(e,t){H(this,1,e,R,t)},setInt16:function(e,t){H(this,2,e,F,t,arguments.length>2?arguments[2]:undefined)},setUint16:function(e,t){H(this,2,e,F,t,arguments.length>2?arguments[2]:undefined)},setInt32:function(e,t){H(this,4,e,O,t,arguments.length>2?arguments[2]:undefined)},setUint32:function(e,t){H(this,4,e,O,t,arguments.length>2?arguments[2]:undefined)},setFloat32:function(e,t){H(this,4,e,G,t,arguments.length>2?arguments[2]:undefined)},setFloat64:function(e,t){H(this,8,e,N,t,arguments.length>2?arguments[2]:undefined)}});C(w,"ArrayBuffer"),C(m,"DataView"),e.exports={ArrayBuffer:w,DataView:m}},function(e,t,n){var r=n(0),A=n(13),o=n(62);r({target:"Object",stat:!0,forced:n(2)((function(){o(1)}))},{keys:function(e){return o(A(e))}})},function(e,t,n){n(215)("Uint8",(function(e){return function(t,n,r){return e(this,t,n,r)}}))},function(e,t,n){"use strict";var r=n(3),A=n(219),o=r.aTypedArray;(0,r.exportTypedArrayMethod)("copyWithin",(function(e,t){return A.call(o(this),e,t,arguments.length>2?arguments[2]:undefined)}))},function(e,t,n){"use strict";var r=n(3),A=n(20).every,o=r.aTypedArray;(0,r.exportTypedArrayMethod)("every",(function(e){return A(o(this),e,arguments.length>1?arguments[1]:undefined)}))},function(e,t,n){"use strict";var r=n(3),A=n(170),o=r.aTypedArray;(0,r.exportTypedArrayMethod)("fill",(function(e){return A.apply(o(this),arguments)}))},function(e,t,n){"use strict";var r=n(3),A=n(20).filter,o=n(26),i=r.aTypedArray,a=r.aTypedArrayConstructor;(0,r.exportTypedArrayMethod)("filter",(function(e){for(var t=A(i(this),e,arguments.length>1?arguments[1]:undefined),n=o(this,this.constructor),r=0,u=t.length,c=new(a(n))(u);u>r;)c[r]=t[r++];return c}))},function(e,t,n){"use strict";var r=n(3),A=n(20).find,o=r.aTypedArray;(0,r.exportTypedArrayMethod)("find",(function(e){return A(o(this),e,arguments.length>1?arguments[1]:undefined)}))},function(e,t,n){"use strict";var r=n(3),A=n(20).findIndex,o=r.aTypedArray;(0,r.exportTypedArrayMethod)("findIndex",(function(e){return A(o(this),e,arguments.length>1?arguments[1]:undefined)}))},function(e,t,n){"use strict";var r=n(3),A=n(20).forEach,o=r.aTypedArray;(0,r.exportTypedArrayMethod)("forEach",(function(e){A(o(this),e,arguments.length>1?arguments[1]:undefined)}))},function(e,t,n){"use strict";var r=n(3),A=n(51).includes,o=r.aTypedArray;(0,r.exportTypedArrayMethod)("includes",(function(e){return A(o(this),e,arguments.length>1?arguments[1]:undefined)}))},function(e,t,n){"use strict";var r=n(3),A=n(51).indexOf,o=r.aTypedArray;(0,r.exportTypedArrayMethod)("indexOf",(function(e){return A(o(this),e,arguments.length>1?arguments[1]:undefined)}))},function(e,t,n){"use strict";var r=n(1),A=n(3),o=n(16),i=n(4)("iterator"),a=r.Uint8Array,u=o.values,c=o.keys,s=o.entries,f=A.aTypedArray,g=A.exportTypedArrayMethod,l=a&&a.prototype[i],d=!!l&&("values"==l.name||l.name==undefined),p=function(){return u.call(f(this))};g("entries",(function(){return s.call(f(this))})),g("keys",(function(){return c.call(f(this))})),g("values",p,!d),g(i,p,!d)},function(e,t,n){"use strict";var r=n(3),A=r.aTypedArray,o=r.exportTypedArrayMethod,i=[].join;o("join",(function(e){return i.apply(A(this),arguments)}))},function(e,t,n){"use strict";var r=n(3),A=n(220),o=r.aTypedArray;(0,r.exportTypedArrayMethod)("lastIndexOf",(function(e){return A.apply(o(this),arguments)}))},function(e,t,n){"use strict";var r=n(3),A=n(20).map,o=n(26),i=r.aTypedArray,a=r.aTypedArrayConstructor;(0,r.exportTypedArrayMethod)("map",(function(e){return A(i(this),e,arguments.length>1?arguments[1]:undefined,(function(e,t){return new(a(o(e,e.constructor)))(t)}))}))},function(e,t,n){"use strict";var r=n(3),A=n(172).left,o=r.aTypedArray;(0,r.exportTypedArrayMethod)("reduce",(function(e){return A(o(this),e,arguments.length,arguments.length>1?arguments[1]:undefined)}))},function(e,t,n){"use strict";var r=n(3),A=n(172).right,o=r.aTypedArray;(0,r.exportTypedArrayMethod)("reduceRight",(function(e){return A(o(this),e,arguments.length,arguments.length>1?arguments[1]:undefined)}))},function(e,t,n){"use strict";var r=n(3),A=r.aTypedArray,o=r.exportTypedArrayMethod,i=Math.floor;o("reverse",(function(){for(var e,t=A(this).length,n=i(t/2),r=0;r<n;)e=this[r],this[r++]=this[--t],this[t]=e;return this}))},function(e,t,n){"use strict";var r=n(3),A=n(6),o=n(171),i=n(13),a=n(2),u=r.aTypedArray;(0,r.exportTypedArrayMethod)("set",(function(e){u(this);var t=o(arguments.length>1?arguments[1]:undefined,1),n=this.length,r=i(e),a=A(r.length),c=0;if(a+t>n)throw RangeError("Wrong length");for(;c<a;)this[t+c]=r[c++]}),a((function(){new Int8Array(1).set({})})))},function(e,t,n){"use strict";var r=n(3),A=n(26),o=n(2),i=r.aTypedArray,a=r.aTypedArrayConstructor,u=r.exportTypedArrayMethod,c=[].slice;u("slice",(function(e,t){for(var n=c.call(i(this),e,t),r=A(this,this.constructor),o=0,u=n.length,s=new(a(r))(u);u>o;)s[o]=n[o++];return s}),o((function(){new Int8Array(1).slice()})))},function(e,t,n){"use strict";var r=n(3),A=n(20).some,o=r.aTypedArray;(0,r.exportTypedArrayMethod)("some",(function(e){return A(o(this),e,arguments.length>1?arguments[1]:undefined)}))},function(e,t,n){"use strict";var r=n(3),A=r.aTypedArray,o=r.exportTypedArrayMethod,i=[].sort;o("sort",(function(e){return i.call(A(this),e)}))},function(e,t,n){"use strict";var r=n(3),A=n(6),o=n(32),i=n(26),a=r.aTypedArray;(0,r.exportTypedArrayMethod)("subarray",(function(e,t){var n=a(this),r=n.length,u=o(e,r);return new(i(n,n.constructor))(n.buffer,n.byteOffset+u*n.BYTES_PER_ELEMENT,A((t===undefined?r:o(t,r))-u))}))},function(e,t,n){"use strict";var r=n(1),A=n(3),o=n(2),i=r.Int8Array,a=A.aTypedArray,u=A.exportTypedArrayMethod,c=[].toLocaleString,s=[].slice,f=!!i&&o((function(){c.call(new i(1))}));u("toLocaleString",(function(){return c.apply(f?s.call(a(this)):a(this),arguments)}),o((function(){return[1,2].toLocaleString()!=new i([1,2]).toLocaleString()}))||!o((function(){i.prototype.toLocaleString.call([1,2])})))},function(e,t,n){"use strict";var r=n(3).exportTypedArrayMethod,A=n(2),o=n(1).Uint8Array,i=o&&o.prototype||{},a=[].toString,u=[].join;A((function(){a.call({})}))&&(a=function(){return u.call(this)});var c=i.toString!=a;r("toString",a,c)},function(e,t,n){"use strict";function r(e,t){for(var n=0;n<t.length;n++){var r=t[n];r.enumerable=r.enumerable||!1,r.configurable=!0,"value"in r&&(r.writable=!0),Object.defineProperty(e,r.key,r)}}n(16),n(71),n(223),n(17),n(7),n(74),n(75),n(76),n(77),n(78),n(79),n(80),n(81),n(82),n(83),n(84),n(85),n(86),n(87),n(88),n(89),n(90),n(91),n(92),n(93),n(94),n(95),n(96),n(97),Object.defineProperty(t,"__esModule",{value:!0}),t.Encoder=void 0;var A=function(){function e(){!function(e,t){if(!(e instanceof t))throw new TypeError("Cannot call a class as a function")}(this,e)}var t,n,A;return t=e,(n=[{key:"encode",value:function(e){for(var t="",n=new DataView(e),r=0;r<n.byteLength;r++)t+=String.fromCharCode(n.getUint8(r));return btoa(t)}},{key:"decode",value:function(e){for(var t=atob(e),n=t.length,r=new Uint8Array(n),A=0;A<n;A++)r[A]=t.charCodeAt(A);return r.buffer}}])&&r(t.prototype,n),A&&r(t,A),e}();t.Encoder=A},function(e,t,n){"use strict";var r=n(0),A=n(20).filter,o=n(67),i=n(33),a=o("filter"),u=i("filter");r({target:"Array",proto:!0,forced:!a||!u},{filter:function(e){return A(this,e,arguments.length>1?arguments[1]:undefined)}})},function(e,t){var n;n=function(){return this}();try{n=n||new Function("return this")()}catch(r){"object"==typeof window&&(n=window)}e.exports=n},function(e,t,n){"use strict";var r={}.propertyIsEnumerable,A=Object.getOwnPropertyDescriptor,o=A&&!r.call({1:2},1);t.f=o?function(e){var t=A(this,e);return!!t&&t.enumerable}:r},function(e,t,n){var r=n(1),A=n(8),o=r.document,i=A(o)&&A(o.createElement);e.exports=function(e){return i?o.createElement(e):{}}},function(e,t,n){var r=n(1),A=n(14);e.exports=function(e,t){try{A(r,e,t)}catch(n){r[e]=t}return t}},function(e,t,n){var r=n(134),A=Function.toString;"function"!=typeof r.inspectSource&&(r.inspectSource=function(e){return A.call(e)}),e.exports=r.inspectSource},function(e,t,n){var r=n(30),A=n(134);(e.exports=function(e,t){return A[e]||(A[e]=t!==undefined?t:{})})("versions",[]).push({version:"3.6.4",mode:r?"pure":"global",copyright:"© 2020 Denis Pushkarev (zloirock.ru)"})},function(e,t){e.exports=["constructor","hasOwnProperty","isPrototypeOf","propertyIsEnumerable","toLocaleString","toString","valueOf"]},function(e,t){t.f=Object.getOwnPropertySymbols},function(e,t,n){var r=n(31);e.exports=r("navigator","userAgent")||""},function(e,t,n){var r=n(2);e.exports=!!Object.getOwnPropertySymbols&&!r((function(){return!String(Symbol())}))},function(e,t,n){var r={};r[n(4)("toStringTag")]="z",e.exports="[object z]"===String(r)},function(e,t,n){var r=n(15);e.exports=function(e,t,n){for(var A in t)r(e,A,t[A],n);return e}},function(e,t,n){var r=n(11),A=n(113),o=n(6),i=n(40),a=n(114),u=n(146),c=function(e,t){this.stopped=e,this.result=t};(e.exports=function(e,t,n,s,f){var g,l,d,p,y,h,I,C=i(t,n,s?2:1);if(f)g=e;else{if("function"!=typeof(l=a(e)))throw TypeError("Target is not iterable");if(A(l)){for(d=0,p=o(e.length);p>d;d++)if((y=s?C(r(I=e[d])[0],I[1]):C(e[d]))&&y instanceof c)return y;return new c(!1)}g=l.call(e)}for(h=g.next;!(I=h.call(g)).done;)if("object"==typeof(y=u(g,C,I.value,s))&&y&&y instanceof c)return y;return new c(!1)}).stop=function(e){return new c(!0,e)}},function(e,t,n){var r=n(4),A=n(56),o=r("iterator"),i=Array.prototype;e.exports=function(e){return e!==undefined&&(A.Array===e||i[o]===e)}},function(e,t,n){var r=n(63),A=n(56),o=n(4)("iterator");e.exports=function(e){if(e!=undefined)return e[o]||e["@@iterator"]||A[r(e)]}},function(e,t,n){var r,A,o=n(1),i=n(108),a=o.process,u=a&&a.versions,c=u&&u.v8;c?A=(r=c.split("."))[0]+r[1]:i&&(!(r=i.match(/Edge\/(\d+)/))||r[1]>=74)&&(r=i.match(/Chrome\/(\d+)/))&&(A=r[1]),e.exports=A&&+A},function(e,t,n){var r=n(8),A=n(23),o=n(4)("match");e.exports=function(e){var t;return r(e)&&((t=e[o])!==undefined?!!t:"RegExp"==A(e))}},function(e,t,n){var r=n(8),A=n(41),o=n(4)("species");e.exports=function(e,t){var n;return A(e)&&("function"!=typeof(n=e.constructor)||n!==Array&&!A(n.prototype)?r(n)&&null===(n=n[o])&&(n=undefined):n=undefined),new(n===undefined?Array:n)(0===t?0:t)}},function(e,t,n){"use strict";var r=n(0),A=n(192),o=n(57),i=n(44),a=n(25),u=n(14),c=n(15),s=n(4),f=n(30),g=n(56),l=n(156),d=l.IteratorPrototype,p=l.BUGGY_SAFARI_ITERATORS,y=s("iterator"),h=function(){return this};e.exports=function(e,t,n,s,l,I,C){A(n,t,s);var B,E,v,Q=function(e){if(e===l&&S)return S;if(!p&&e in b)return b[e];switch(e){case"keys":case"values":case"entries":return function(){return new n(this,e)}}return function(){return new n(this)}},w=t+" Iterator",m=!1,b=e.prototype,x=b[y]||b["@@iterator"]||l&&b[l],S=!p&&x||Q(l),D="Array"==t&&b.entries||x;if(D&&(B=o(D.call(new e)),d!==Object.prototype&&B.next&&(f||o(B)===d||(i?i(B,d):"function"!=typeof B[y]&&u(B,y,h)),a(B,w,!0,!0),f&&(g[w]=h))),"values"==l&&x&&"values"!==x.name&&(m=!0,S=function(){return x.call(this)}),f&&!C||b[y]===S||u(b,y,S),g[t]=S,l)if(E={values:Q("values"),keys:I?S:Q("keys"),entries:Q("entries")},C)for(v in E)!p&&!m&&v in b||c(b,v,E[v]);else r({target:t,proto:!0,forced:p||m},E);return E}},function(e,t,n){var r=n(5),A=n(9).f,o=Function.prototype,i=o.toString,a=/^\s*function ([^ (]*)/;!r||"name"in o||A(o,"name",{configurable:!0,get:function(){try{return i.call(this).match(a)[1]}catch(e){return""}}})},function(e,t,n){"use strict";var r=n(11);e.exports=function(){var e=r(this),t="";return e.global&&(t+="g"),e.ignoreCase&&(t+="i"),e.multiline&&(t+="m"),e.dotAll&&(t+="s"),e.unicode&&(t+="u"),e.sticky&&(t+="y"),t}},function(e,t,n){var r=n(8),A=n(44);e.exports=function(e,t,n){var o,i;return A&&"function"==typeof(o=t.constructor)&&o!==n&&r(i=o.prototype)&&i!==n.prototype&&A(e,i),e}},function(e,t,n){"use strict";var r=n(0),A=n(70);r({target:"RegExp",proto:!0,forced:/./.exec!==A},{exec:A})},function(e,t,n){"use strict";n(17),Object.defineProperty(t,"__esModule",{value:!0}),t.getCryptoEngineSingleton=function(){r||(r=u());return r},t.createWasmCryptoEngine=u,t.BasicCryptoEngine=void 0;var r,A=n(124),o=n(127);function i(e,t){for(var n=0;n<t.length;n++){var r=t[n];r.enumerable=r.enumerable||!1,r.configurable=!0,"value"in r&&(r.writable=!0),Object.defineProperty(e,r.key,r)}}function a(e,t,n){return t in e?Object.defineProperty(e,t,{value:n,enumerable:!0,configurable:!0,writable:!0}):e[t]=n,e}function u(){var e=(new A.KeyManager).getKeyCache(),t=new o.AesWasmCrypto(e);return new c(t)}var c=function(){function e(t){!function(e,t){if(!(e instanceof t))throw new TypeError("Cannot call a class as a function")}(this,e),a(this,"name","BasicCryptoEngine"),a(this,"cryptoAlg",void 0),this.cryptoAlg=t}var t,n,r;return t=e,(n=[{key:"decrypt",value:function(e){return this.cryptoAlg.decrypt(e)}}])&&i(t.prototype,n),r&&i(t,r),e}();t.BasicCryptoEngine=c},function(e,t,n){"use strict";n(34),n(42),n(43),n(208),n(69),n(166),n(16),n(162),n(210),n(35),n(125),n(17),n(7),n(12),n(45),n(36),n(27),Object.defineProperty(t,"__esModule",{value:!0}),t.KeyManager=void 0,n(18);var r=n(126),A=n(168),o=n(229),i=n(174),a=n(175),u=n(98),c=n(46),s=n(28);function f(e,t){return function(e){if(Array.isArray(e))return e}(e)||function(e,t){if(!(Symbol.iterator in Object(e)||"[object Arguments]"===Object.prototype.toString.call(e)))return;var n=[],r=!0,A=!1,o=undefined;try{for(var i,a=e[Symbol.iterator]();!(r=(i=a.next()).done)&&(n.push(i.value),!t||n.length!==t);r=!0);}catch(err){A=!0,o=err}finally{try{r||null==a["return"]||a["return"]()}finally{if(A)throw o}}return n}(e,t)||function(){throw new TypeError("Invalid attempt to destructure non-iterable instance")}()}function g(e,t,n,r,A,o,i){try{var a=e[o](i),u=a.value}catch(c){return void n(c)}a.done?t(u):Promise.resolve(u).then(r,A)}function l(e){return function(){var t=this,n=arguments;return new Promise((function(r,A){var o=e.apply(t,n);function i(e){g(o,r,A,i,a,"next",e)}function a(e){g(o,r,A,i,a,"throw",e)}i(undefined)}))}}function d(e,t){for(var n=0;n<t.length;n++){var r=t[n];r.enumerable=r.enumerable||!1,r.configurable=!0,"value"in r&&(r.writable=!0),Object.defineProperty(e,r.key,r)}}function p(e,t,n){return t in e?Object.defineProperty(e,t,{value:n,enumerable:!0,configurable:!0,writable:!0}):e[t]=n,e}var y=new a.LocalStorage,h=new i.KeyCache(y),I=function(){function e(){!function(e,t){if(!(e instanceof t))throw new TypeError("Cannot call a class as a function")}(this,e),p(this,"encoder",new u.Encoder),p(this,"logger",new s.Logger),p(this,"COOKIE_KEY_STORAGE_PERIOD_DAYS",60),p(this,"ROTATION_PERIOD_MILLISECONDS",2592e6),p(this,"MAX_UNUSED_PERIOD_MILLISECONDS",6048e5),p(this,"temporaryRsaPublicKey",{alg:"RSA-OAEP-256",e:"AQAB",ext:!0,key_ops:["wrapKey"],kty:"RSA",n:"m8r2gkd7h4rm-MpK7axgjooGpepzaCohLoesAK3GRmIekT8Kq51n-FVib_KuiZE5evdoyf9s0bF4NSuGdecBs_arbeSzTiEHis23bpXevhNY54a_LbVRCiaQnG9KVonvOBW-PTFl5GWn4F7nx4pSz3ramYF8yc_I2MXXrEgNZvpU6Mmrn_KoyjxLitD-c9GcM5xVaR-riYXIdhC2zV-s07HhFXwo6gOKPSjD56HBbqauwkZH9XTTT7uTMT3flkAHqLxRJ157zj-as7QsVr7HM3MQyoHah0MurGUGaXe8Sutt03dnOL48ydzaIb2jDWDxl4nEWK_tcOseOStaUY0n3w"})}var t,n,i,a,g,I,C,B,E,v;return t=e,(n=[{key:"rsaEncryptKey",value:(v=l(regeneratorRuntime.mark((function Q(e){var t,n;return regeneratorRuntime.wrap((function(A){for(;;)switch(A.prev=A.next){case 0:return t=(0,r.aesImportKey)(e,!0,["wrapKey"]),n=(0,o.rsaImportKey)(this.temporaryRsaPublicKey,!1,["wrapKey"]),A.t0=o.rsaWrap,A.next=5,n;case 5:return A.t1=A.sent,A.next=8,t;case 8:return A.t2=A.sent,A.abrupt("return",(0,A.t0)(A.t1,A.t2));case 10:case"end":return A.stop()}}),Q,this)}))),function(e){return v.apply(this,arguments)})},{key:"createKey",value:(E=l(regeneratorRuntime.mark((function w(){var e,t,n,o;return regeneratorRuntime.wrap((function(i){for(;;)switch(i.prev=i.next){case 0:return i.next=2,(0,r.aesGenerateKey)();case 2:if(e=i.sent,t=(0,A.generateUid)(),n={wasmTested:!0,wasmCompatible:!0,webCryptoTested:!1},y.put(t,e),y.get(t)){i.next=8;break}throw new Error("New key disappeared after it was saved");case 8:return i.next=10,this.rsaEncryptKey(e);case 10:return o=i.sent,(0,c.cookieManagerSave)(t,this.encoder.encode(o),this.COOKIE_KEY_STORAGE_PERIOD_DAYS,n),this.logger.incrementCounter("Siege:Csd:KeyManager:CreateKey",1),i.abrupt("return",t);case 14:case"end":return i.stop()}}),w,this)}))),function(){return E.apply(this,arguments)})},{key:"getKeysThatExceededMaxUnusedPeriod",value:function(e){var t=new Map(e),n=!0,r=!1,A=undefined;try{for(var o,i=e[Symbol.iterator]();!(n=(o=i.next()).done);n=!0){var a=f(o.value,2),u=a[0],c=a[1];(!c.lastUsedDate||c.lastUsedDate>new Date(Date.now()-this.MAX_UNUSED_PERIOD_MILLISECONDS))&&t["delete"](u)}}catch(err){r=!0,A=err}finally{try{n||null==i["return"]||i["return"]()}finally{if(r)throw A}}return t}},{key:"getOlderKeys",value:function(e){var t=this.getKeysThatExceededMaxUnusedPeriod(e),n=Array.from(t.keys()),r=(0,c.cookieManagerGet)().kid,A=n.indexOf(r);return A>-1&&n.splice(A,1),n}},{key:"cacheActiveKey",value:(B=l(regeneratorRuntime.mark((function m(){return regeneratorRuntime.wrap((function(e){for(;;)switch(e.prev=e.next){case 0:return e.next=2,this.isInitialized();case 2:if(e.sent){e.next=4;break}return e.abrupt("return");case 4:this.getActiveKey();case 5:case"end":return e.stop()}}),m,this)}))),function(){return B.apply(this,arguments)})},{key:"rotateKeyIfNeeded",value:(C=l(regeneratorRuntime.mark((function b(){var e,t,n,r;return regeneratorRuntime.wrap((function(A){for(;;)switch(A.prev=A.next){case 0:return A.next=2,this.isInitialized();case 2:if(A.sent){A.next=4;break}return A.abrupt("return",!1);case 4:if(e=this.getActiveKey(),t=y.getAll(),n=this.getOlderKeys(t),y.removeKeys(n),this.logger.incrementCounter("Siege:Csd:KeyManager:DeleteOlderKeys",n.length),r=new Date(Date.now()-this.ROTATION_PERIOD_MILLISECONDS),!(e.issuedDate<r)){A.next=15;break}return A.next=13,this.createKey();case 13:return this.logger.incrementCounter("Siege:Csd:KeyManager:RotateKeys",1),A.abrupt("return",!0);case 15:return A.abrupt("return",!1);case 16:case"end":return A.stop()}}),b,this)}))),function(){return C.apply(this,arguments)})},{key:"getActiveKey",value:function(){var e=(0,c.cookieManagerGet)().kid;try{return h.get(e)}catch(t){throw this.logger.incrementCounter("Siege:Csd:KeyManager:ActiveKeyMissing",1),t}}},{key:"isInitialized",value:(I=l(regeneratorRuntime.mark((function x(){return regeneratorRuntime.wrap((function(e){for(;;)switch(e.prev=e.next){case 0:if(e.prev=0,(0,c.cookieManagerIsEnabled)()){e.next=3;break}return e.abrupt("return",!1);case 3:return this.getActiveKey(),e.abrupt("return",!0);case 7:return e.prev=7,e.t0=e["catch"](0),e.abrupt("return",!1);case 10:case"end":return e.stop()}}),x,this,[[0,7]])}))),function(){return I.apply(this,arguments)})},{key:"isDisabled",value:(g=l(regeneratorRuntime.mark((function S(){return regeneratorRuntime.wrap((function(e){for(;;)switch(e.prev=e.next){case 0:return e.abrupt("return",new Promise((function(e){e((0,c.cookieManagerIsDisabled)())})));case 1:case"end":return e.stop()}}),S)}))),function(){return g.apply(this,arguments)})},{key:"disable",value:function(){this.logger.incrementCounter("Siege:Csd:KeyManager:Disabling",1),(0,c.cookieManagerDisable)()}},{key:"delete",value:(a=l(regeneratorRuntime.mark((function D(){var e,t=arguments;return regeneratorRuntime.wrap((function(n){for(;;)switch(n.prev=n.next){case 0:if(e=t.length>0&&t[0]!==undefined&&t[0],this.logger.incrementCounter("Siege:Csd:KeyManager:Deleting",1),(0,c.cookieManagerDelete)(),!e){n.next=9;break}return this.logger.incrementCounter("Siege:Csd:KeyManager:DeletingStorage",1),n.next=7,y.clear();case 7:return n.next=9,h.cacheAllKeys();case 9:case"end":return n.stop()}}),D,this)}))),function(){return a.apply(this,arguments)})},{key:"getKeyCache",value:function(){return h}}])&&d(t.prototype,n),i&&d(t,i),e}();t.KeyManager=I},function(e,t,n){"use strict";var r=n(211),A=n(213);e.exports=r("Map",(function(e){return function(){return e(this,arguments.length?arguments[0]:undefined)}}),A)},function(e,t,n){"use strict";function r(e,t,n,r,A,o,i){try{var a=e[o](i),u=a.value}catch(c){return void n(c)}a.done?t(u):Promise.resolve(u).then(r,A)}function A(e){return function(){var t=this,n=arguments;return new Promise((function(A,o){var i=e.apply(t,n);function a(e){r(i,A,o,a,u,"next",e)}function u(e){r(i,A,o,a,u,"throw",e)}a(undefined)}))}}n(7),n(12),Object.defineProperty(t,"__esModule",{value:!0}),t.aesGenerateKey=function(){return o.apply(this,arguments)},t.aesImportKey=function(e,t,n){return i.apply(this,arguments)},t.AES_NAME=void 0,n(18);t.AES_NAME="AES-GCM";function o(){return(o=A(regeneratorRuntime.mark((function e(){var t,n;return regeneratorRuntime.wrap((function(e){for(;;)switch(e.prev=e.next){case 0:return e.next=2,crypto.subtle.generateKey({name:"AES-GCM",length:128},!0,["wrapKey"]);case 2:return t=e.sent,e.next=5,crypto.subtle.exportKey("raw",t);case 5:return n=e.sent,e.abrupt("return",n);case 7:case"end":return e.stop()}}),e)})))).apply(this,arguments)}function i(){return(i=A(regeneratorRuntime.mark((function e(t,n,r){return regeneratorRuntime.wrap((function(e){for(;;)switch(e.prev=e.next){case 0:return e.abrupt("return",crypto.subtle.importKey("raw",t,{name:"AES-GCM",length:128},n,r));case 1:case"end":return e.stop()}}),e)})))).apply(this,arguments)}},function(e,t,n){"use strict";n(16),n(58),n(71),n(17),n(73),n(7),n(12),n(74),n(75),n(76),n(77),n(78),n(79),n(80),n(81),n(82),n(83),n(84),n(85),n(86),n(87),n(88),n(89),n(90),n(91),n(92),n(93),n(94),n(95),n(96),n(97),n(27),Object.defineProperty(t,"__esModule",{value:!0}),t.AesWasmCrypto=void 0,n(18),n(221);var r=n(98),A=n(28),o=n(126),i=n(224),a=n(227);function u(e,t,n,r,A,o,i){try{var a=e[o](i),u=a.value}catch(c){return void n(c)}a.done?t(u):Promise.resolve(u).then(r,A)}function c(e,t){for(var n=0;n<t.length;n++){var r=t[n];r.enumerable=r.enumerable||!1,r.configurable=!0,"value"in r&&(r.writable=!0),Object.defineProperty(e,r.key,r)}}var s=new A.Logger;var f=function(){s.startTimer("AesWasm:Compilation");var e={};function t(){e.memory=new Uint8Array(e.exports.memory.buffer)}var n=(0,i.loadCondensedWasm)(a.program,{env:{emscripten_notify_memory_growth:t}});return n._initialize(),e.exports=n,t(),s.stopAndSendTimer("AesWasm:Compilation"),e}();function g(e){for(var t,n=0,r=Object.keys(e);n<r.length;n++){var A=r[n];try{f.exports.free(e[A]),delete e[A]}catch(o){t=o}}if(t!==undefined)throw t}function l(e){if(0!==e)throw new Error("Unexpected return from mbedtls: ".concat(e))}var d=function(){function e(t){var n,A,o;!function(e,t){if(!(e instanceof t))throw new TypeError("Cannot call a class as a function")}(this,e),this.keys=t,o=void 0,(A="encoder")in(n=this)?Object.defineProperty(n,A,{value:o,enumerable:!0,configurable:!0,writable:!0}):n[A]=o,this.encoder=new r.Encoder}var t,n,A,i,a;return t=e,(n=[{key:"unpack",value:function(e){return{ct:this.encoder.decode(e.ct),iv:this.encoder.decode(e.iv),kid:e.kid}}},{key:"pack",value:function(e){return{ct:this.encoder.encode(e.ct),iv:this.encoder.encode(e.iv),kid:e.kid}}},{key:"encrypt",value:(i=regeneratorRuntime.mark((function s(e,t){var n,r,A,i;return regeneratorRuntime.wrap((function(a){for(;;)switch(a.prev=a.next){case 0:return n=(new TextEncoder).encode(t),a.next=3,(0,o.aesImportKey)(this.keys.getCryptoKey(e),!1,["encrypt"]);case 3:return r=a.sent,A=crypto.getRandomValues(new Uint8Array(12)).buffer,a.next=7,crypto.subtle.encrypt({name:"AES-GCM",iv:A,tagLength:128},r,n);case 7:return i=a.sent,a.abrupt("return",this.pack({ct:i,iv:A,kid:e}));case 9:case"end":return a.stop()}}),s,this)})),a=function(){var e=this,t=arguments;return new Promise((function(n,r){var A=i.apply(e,t);function o(e){u(A,n,r,o,a,"next",e)}function a(e){u(A,n,r,o,a,"throw",e)}o(undefined)}))},function(e,t){return a.apply(this,arguments)})},{key:"internalDecrypt",value:function(e,t,n){var r=function(e){for(var t={},n=0,r=Object.keys(e);n<r.length;n++){var A=r[n];try{var o=f.exports.malloc(e[A]);if(0===o)throw new Error("malloc returned null");t[A]=o}catch(i){throw g(t),i}}return t}({ctx:f.exports.sizeof_mbedtls_gcm_context(),key:e.byteLength,tag:16,data:t.byteLength-16+8,iv:n.byteLength});try{f.exports.mbedtls_gcm_init(r.ctx);try{return f.memory.set(new Uint8Array(e),r.key),l(f.exports.mbedtls_gcm_setkey(r.ctx,f.exports.mbedtls_cipher_id_aes(),r.key,8*e.byteLength)),f.memory.set(new Uint8Array(t,t.byteLength-16,16),r.tag),f.memory.set(new Uint8Array(t,0,t.byteLength-16),r.data+8),f.memory.set(new Uint8Array(n),r.iv),l(f.exports.mbedtls_gcm_auth_decrypt(r.ctx,t.byteLength-16,r.iv,n.byteLength,0,0,r.tag,16,r.data+8,r.data)),f.memory.slice(r.data,r.data+t.byteLength-16)}finally{f.exports.mbedtls_gcm_free(r.ctx)}}finally{g(r)}}},{key:"decrypt",value:function(e){var t=this.unpack(e),n=this.internalDecrypt(this.keys.getCryptoKey(t.kid),t.ct,t.iv);return(new TextDecoder).decode(n)}}])&&c(t.prototype,n),A&&c(t,A),e}();t.AesWasmCrypto=d},function(e,t){e.exports="undefined"!=typeof ArrayBuffer&&"undefined"!=typeof DataView},function(e,t,n){var r=n(0),A=n(5);r({target:"Object",stat:!0,forced:!A,sham:!A},{defineProperties:n(143)})},function(e,t,n){var r=n(0),A=n(2),o=n(19),i=n(22).f,a=n(5),u=A((function(){i(1)}));r({target:"Object",stat:!0,forced:!a||u,sham:!a},{getOwnPropertyDescriptor:function(e,t){return i(o(e),t)}})},function(e,t,n){var r=n(0),A=n(5),o=n(136),i=n(19),a=n(22),u=n(59);r({target:"Object",stat:!0,sham:!A},{getOwnPropertyDescriptors:function(e){for(var t,n,r=i(e),A=a.f,c=o(r),s={},f=0;c.length>f;)(n=A(r,t=c[f++]))!==undefined&&u(s,t,n);return s}})},function(e,t,n){var r=n(0),A=n(1),o=n(108),i=[].slice,a=function(e){return function(t,n){var r=arguments.length>2,A=r?i.call(arguments,2):undefined;return e(r?function(){("function"==typeof t?t:Function(t)).apply(this,A)}:t,n)}};r({global:!0,bind:!0,forced:/MSIE .\./.test(o)},{setTimeout:a(A.setTimeout),setInterval:a(A.setInterval)})},function(e,t,n){var r=n(5),A=n(2),o=n(102);e.exports=!r&&!A((function(){return 7!=Object.defineProperty(o("div"),"a",{get:function(){return 7}}).a}))},function(e,t,n){var r=n(1),A=n(103),o=r["__core-js_shared__"]||A("__core-js_shared__",{});e.exports=o},function(e,t,n){var r=n(10),A=n(136),o=n(22),i=n(9);e.exports=function(e,t){for(var n=A(t),a=i.f,u=o.f,c=0;c<n.length;c++){var s=n[c];r(e,s)||a(e,s,u(t,s))}}},function(e,t,n){var r=n(31),A=n(38),o=n(107),i=n(11);e.exports=r("Reflect","ownKeys")||function(e){var t=A.f(i(e)),n=o.f;return n?t.concat(n(e)):t}},function(e,t,n){var r=n(1);e.exports=r},function(e,t,n){var r=n(10),A=n(19),o=n(51).indexOf,i=n(50);e.exports=function(e,t){var n,a=A(e),u=0,c=[];for(n in a)!r(i,n)&&r(a,n)&&c.push(n);for(;t.length>u;)r(a,n=t[u++])&&(~o(c,n)||c.push(n));return c}},function(e,t,n){"use strict";function r(e){return(r="function"==typeof Symbol&&"symbol"==typeof Symbol.iterator?function(e){return typeof e}:function(e){return e&&"function"==typeof Symbol&&e.constructor===Symbol&&e!==Symbol.prototype?"symbol":typeof e})(e)}n(140),n(7),n(12),n(187),n(151),Object.defineProperty(t,"__esModule",{value:!0}),t.csdStatus=function(){return(0,a.cookieManagerIsEnabled)()?"enabled":(0,a.cookieManagerIsDisabled)()?"disabled":"bootstrapping"},t.bootstrap=function(){return E.apply(this,arguments)},t.decryptInElementWithId=function(e,t,n){try{C.incrementCounter("Siege:Csd:decryptInElementWithId");var r=(0,o.getCryptoEngineSingleton)();l.decryptInPlace(e,t,C,I,r,n),C.updateCounter("Siege:Csd:Decrypt:Success",1)}catch(A){C.updateCounter("Siege:Csd:Decrypt:Failure",1),(0,u.csdDisable)(),C.logError(A,"Siege:Csd:Decrypt"),(0,f.reloadPage)()}},n(18);var A=p(n(200)),o=n(123),i=n(230),a=n(46),u=n(176),c=n(177),s=n(28),f=n(232),g=n(178),l=p(n(233));function d(){if("function"!=typeof WeakMap)return null;var e=new WeakMap;return d=function(){return e},e}function p(e){if(e&&e.__esModule)return e;if(null===e||"object"!==r(e)&&"function"!=typeof e)return{"default":e};var t=d();if(t&&t.has(e))return t.get(e);var n={},A=Object.defineProperty&&Object.getOwnPropertyDescriptor;for(var o in e)if(Object.prototype.hasOwnProperty.call(e,o)){var i=A?Object.getOwnPropertyDescriptor(e,o):null;i&&(i.get||i.set)?Object.defineProperty(n,o,i):n[o]=e[o]}return n["default"]=e,t&&t.set(e,n),n}function y(e,t,n,r,A,o,i){try{var a=e[o](i),u=a.value}catch(c){return void n(c)}a.done?t(u):Promise.resolve(u).then(r,A)}function h(e){return function(){var t=this,n=arguments;return new Promise((function(r,A){var o=e.apply(t,n);function i(e){y(o,r,A,i,a,"next",e)}function a(e){y(o,r,A,i,a,"throw",e)}i(undefined)}))}}var I=new i.NodeDisplay,C=new s.Logger;try{(0,s.logLibraryLoadMetrics)(C)}catch(v){}var B=!1;function E(){return(E=h(regeneratorRuntime.mark((function e(){return regeneratorRuntime.wrap((function(e){for(;;)switch(e.prev=e.next){case 0:if(e.prev=0,!B&&!g.bootstrapPromise){e.next=3;break}return e.abrupt("return");case 3:return B=!0,e.next=6,(0,u.csdBootstrap)();case 6:e.next=13;break;case 8:e.prev=8,e.t0=e["catch"](0),C.updateCounter("Siege:Csd:Bootstrap:Failure",1),(0,u.csdDisable)(),C.logWarn(e.t0,"Siege:Csd:Bootstrap");case 13:case"end":return e.stop()}}),e,null,[[0,8]])})))).apply(this,arguments)}A.before((function(e,t){(0,g.beforeHandler)(e)["catch"]((function(e){C.updateCounter("Siege:Csd:Bootstrap:Failure",1),(0,u.csdDisable)(),C.logWarn(e,"Siege:Csd:Bootstrap")}))["finally"]((function(){return t()}))})),A.after((function(e,t,n){var r=t instanceof Response?t.headers.get("content-type"):t.headers["content-type"];if(null==r?void 0:r.toLowerCase().includes("text/event-stream"))return C.incrementCounter("Siege:Csd:StreamSkipped"),void n(t);(0,g.afterHandler)(e,t).then((function(e){return n(e)}))["catch"]((function(e){n((0,c.reqResHandler)(t).errorResponse(e)),e instanceof SyntaxError||(C.updateCounter("Siege:Csd:Decrypt:Failure",1),(0,u.csdDisable)(),C.logError(e,"Siege:Csd:Decrypt"))}))}))},function(e,t,n){"use strict";var r=n(0),A=n(51).includes,o=n(141);r({target:"Array",proto:!0,forced:!n(33)("indexOf",{ACCESSORS:!0,1:0})},{includes:function(e){return A(this,e,arguments.length>1?arguments[1]:undefined)}}),o("includes")},function(e,t,n){var r=n(4),A=n(39),o=n(9),i=r("unscopables"),a=Array.prototype;a[i]==undefined&&o.f(a,i,{configurable:!0,value:A(null)}),e.exports=function(e){a[i][e]=!0}},function(e,t,n){var r=n(109);e.exports=r&&!Symbol.sham&&"symbol"==typeof Symbol.iterator},function(e,t,n){var r=n(5),A=n(9),o=n(11),i=n(62);e.exports=r?Object.defineProperties:function(e,t){o(e);for(var n,r=i(t),a=r.length,u=0;a>u;)A.f(e,n=r[u++],t[n]);return e}},function(e,t,n){var r=n(31);e.exports=r("document","documentElement")},function(e,t,n){var r=n(1);e.exports=r.Promise},function(e,t,n){var r=n(11);e.exports=function(e,t,n,A){try{return A?t(r(n)[0],n[1]):t(n)}catch(i){var o=e["return"];throw o!==undefined&&r(o.call(e)),i}}},function(e,t,n){var r,A,o,i=n(1),a=n(2),u=n(23),c=n(40),s=n(144),f=n(102),g=n(148),l=i.location,d=i.setImmediate,p=i.clearImmediate,y=i.process,h=i.MessageChannel,I=i.Dispatch,C=0,B={},E=function(e){if(B.hasOwnProperty(e)){var t=B[e];delete B[e],t()}},v=function(e){return function(){E(e)}},Q=function(e){E(e.data)},w=function(e){i.postMessage(e+"",l.protocol+"//"+l.host)};d&&p||(d=function(e){for(var t=[],n=1;arguments.length>n;)t.push(arguments[n++]);return B[++C]=function(){("function"==typeof e?e:Function(e)).apply(undefined,t)},r(C),C},p=function(e){delete B[e]},"process"==u(y)?r=function(e){y.nextTick(v(e))}:I&&I.now?r=function(e){I.now(v(e))}:h&&!g?(o=(A=new h).port2,A.port1.onmessage=Q,r=c(o.postMessage,o,1)):!i.addEventListener||"function"!=typeof postMessage||i.importScripts||a(w)?r="onreadystatechange"in f("script")?function(e){s.appendChild(f("script")).onreadystatechange=function(){s.removeChild(this),E(e)}}:function(e){setTimeout(v(e),0)}:(r=w,i.addEventListener("message",Q,!1))),e.exports={set:d,clear:p}},function(e,t,n){var r=n(108);e.exports=/(iphone|ipod|ipad).*applewebkit/i.test(r)},function(e,t,n){var r=n(11),A=n(8),o=n(150);e.exports=function(e,t){if(r(e),A(t)&&t.constructor===e)return t;var n=o.f(e);return(0,n.resolve)(t),n.promise}},function(e,t,n){"use strict";var r=n(54),A=function(e){var t,n;this.promise=new e((function(e,r){if(t!==undefined||n!==undefined)throw TypeError("Bad Promise constructor");t=e,n=r})),this.resolve=r(t),this.reject=r(n)};e.exports.f=function(e){return new A(e)}},function(e,t,n){"use strict";var r=n(0),A=n(152),o=n(29);r({target:"String",proto:!0,forced:!n(153)("includes")},{includes:function(e){return!!~String(o(this)).indexOf(A(e),arguments.length>1?arguments[1]:undefined)}})},function(e,t,n){var r=n(116);e.exports=function(e){if(r(e))throw TypeError("The method doesn't accept regular expressions");return e}},function(e,t,n){var r=n(4)("match");e.exports=function(e){var t=/./;try{"/./"[e](t)}catch(n){try{return t[r]=!1,"/./"[e](t)}catch(A){}}return!1}},function(e,t,n){var r=n(4);t.f=r},function(e,t,n){"use strict";var r=n(20).forEach,A=n(52),o=n(33),i=A("forEach"),a=o("forEach");e.exports=i&&a?[].forEach:function(e){return r(this,e,arguments.length>1?arguments[1]:undefined)}},function(e,t,n){"use strict";var r,A,o,i=n(57),a=n(14),u=n(10),c=n(4),s=n(30),f=c("iterator"),g=!1;[].keys&&("next"in(o=[].keys())?(A=i(i(o)))!==Object.prototype&&(r=A):g=!0),r==undefined&&(r={}),s||u(r,f)||a(r,f,(function(){return this})),e.exports={IteratorPrototype:r,BUGGY_SAFARI_ITERATORS:g}},function(e,t,n){var r=n(2);e.exports=!r((function(){function e(){}return e.prototype.constructor=null,Object.getPrototypeOf(new e)!==e.prototype}))},function(e,t,n){var r=n(24),A=n(29),o=function(e){return function(t,n){var o,i,a=String(A(t)),u=r(n),c=a.length;return u<0||u>=c?e?"":undefined:(o=a.charCodeAt(u))<55296||o>56319||u+1===c||(i=a.charCodeAt(u+1))<56320||i>57343?e?a.charAt(u):o:e?a.slice(u,u+2):i-56320+(o-55296<<10)+65536}};e.exports={codeAt:o(!1),charAt:o(!0)}},function(e,t){e.exports={CSSRuleList:0,CSSStyleDeclaration:0,CSSValueList:0,ClientRectList:0,DOMRectList:0,DOMStringList:0,DOMTokenList:1,DataTransferItemList:0,FileList:0,HTMLAllCollection:0,HTMLCollection:0,HTMLFormElement:0,HTMLSelectElement:0,MediaList:0,MimeTypeArray:0,NamedNodeMap:0,NodeList:1,PaintRequestList:0,Plugin:0,PluginArray:0,SVGLengthList:0,SVGNumberList:0,SVGPathSegList:0,SVGPointList:0,SVGStringList:0,SVGTransformList:0,SourceBufferList:0,StyleSheetList:0,TextTrackCueList:0,TextTrackList:0,TouchList:0}},function(e,t,n){"use strict";var r=n(0),A=n(2),o=n(41),i=n(8),a=n(13),u=n(6),c=n(59),s=n(117),f=n(67),g=n(4),l=n(115),d=g("isConcatSpreadable"),p=l>=51||!A((function(){var e=[];return e[d]=!1,e.concat()[0]!==e})),y=f("concat"),h=function(e){if(!i(e))return!1;var t=e[d];return t!==undefined?!!t:o(e)};r({target:"Array",proto:!0,forced:!p||!y},{concat:function(e){var t,n,r,A,o,i=a(this),f=s(i,0),g=0;for(t=-1,r=arguments.length;t<r;t++)if(o=-1===t?i:arguments[t],h(o)){if(g+(A=u(o.length))>9007199254740991)throw TypeError("Maximum allowed index exceeded");for(n=0;n<A;n++,g++)n in o&&c(f,g,o[n])}else{if(g>=9007199254740991)throw TypeError("Maximum allowed index exceeded");c(f,g++,o)}return f.length=g,f}})},function(e,t,n){"use strict";var r=n(0),A=n(47),o=n(19),i=n(52),a=[].join,u=A!=Object,c=i("join",",");r({target:"Array",proto:!0,forced:u||!c},{join:function(e){return a.call(o(this),e===undefined?",":e)}})},function(e,t,n){"use strict";var r=n(0),A=n(32),o=n(24),i=n(6),a=n(13),u=n(117),c=n(59),s=n(67),f=n(33),g=s("splice"),l=f("splice",{ACCESSORS:!0,0:0,1:2}),d=Math.max,p=Math.min;r({target:"Array",proto:!0,forced:!g||!l},{splice:function(e,t){var n,r,s,f,g,l,y=a(this),h=i(y.length),I=A(e,h),C=arguments.length;if(0===C?n=r=0:1===C?(n=0,r=h-I):(n=C-2,r=p(d(o(t),0),h-I)),h+n-r>9007199254740991)throw TypeError("Maximum allowed length exceeded");for(s=u(y,r),f=0;f<r;f++)(g=I+f)in y&&c(s,f,y[g]);if(s.length=r,n<r){for(f=I;f<h-r;f++)l=f+n,(g=f+r)in y?y[l]=y[g]:delete y[l];for(f=h;f>h-r+n;f--)delete y[f-1]}else if(n>r)for(f=h-r;f>I;f--)l=f+n-1,(g=f+r-1)in y?y[l]=y[g]:delete y[l];for(f=0;f<n;f++)y[f+I]=arguments[f+2];return y.length=h-r+n,s}})},function(e,t){e.exports="\t\n\x0B\f\r                　\u2028\u2029\ufeff"},function(e,t,n){"use strict";var r=n(2);function A(e,t){return RegExp(e,t)}t.UNSUPPORTED_Y=r((function(){var e=A("a","y");return e.lastIndex=2,null!=e.exec("abcd")})),t.BROKEN_CARET=r((function(){var e=A("^r","gy");return e.lastIndex=2,null!=e.exec("str")}))},function(e,t,n){"use strict";var r=n(205),A=n(116),o=n(11),i=n(29),a=n(26),u=n(206),c=n(6),s=n(207),f=n(70),g=n(2),l=[].push,d=Math.min,p=!g((function(){return!RegExp(4294967295,"y")}));r("split",2,(function(e,t,n){var r;return r="c"=="abbc".split(/(b)*/)[1]||4!="test".split(/(?:)/,-1).length||2!="ab".split(/(?:ab)*/).length||4!=".".split(/(.?)(.?)/).length||".".split(/()()/).length>1||"".split(/.?/).length?function(e,n){var r=String(i(this)),o=n===undefined?4294967295:n>>>0;if(0===o)return[];if(e===undefined)return[r];if(!A(e))return t.call(r,e,o);for(var a,u,c,s=[],g=(e.ignoreCase?"i":"")+(e.multiline?"m":"")+(e.unicode?"u":"")+(e.sticky?"y":""),d=0,p=new RegExp(e.source,g+"g");(a=f.call(p,r))&&!((u=p.lastIndex)>d&&(s.push(r.slice(d,a.index)),a.length>1&&a.index<r.length&&l.apply(s,a.slice(1)),c=a[0].length,d=u,s.length>=o));)p.lastIndex===a.index&&p.lastIndex++;return d===r.length?!c&&p.test("")||s.push(""):s.push(r.slice(d)),s.length>o?s.slice(0,o):s}:"0".split(undefined,0).length?function(e,n){return e===undefined&&0===n?[]:t.call(this,e,n)}:t,[function(t,n){var A=i(this),o=t==undefined?undefined:t[e];return o!==undefined?o.call(t,A,n):r.call(String(A),t,n)},function(e,A){var i=n(r,e,this,A,r!==t);if(i.done)return i.value;var f=o(e),g=String(this),l=a(f,RegExp),y=f.unicode,h=(f.ignoreCase?"i":"")+(f.multiline?"m":"")+(f.unicode?"u":"")+(p?"y":"g"),I=new l(p?f:"^(?:"+f.source+")",h),C=A===undefined?4294967295:A>>>0;if(0===C)return[];if(0===g.length)return null===s(I,g)?[g]:[];for(var B=0,E=0,v=[];E<g.length;){I.lastIndex=p?E:0;var Q,w=s(I,p?g:g.slice(E));if(null===w||(Q=d(c(I.lastIndex+(p?0:E)),g.length))===B)E=u(g,E,y);else{if(v.push(g.slice(B,E)),v.length===C)return v;for(var m=1;m<=w.length-1;m++)if(v.push(w[m]),v.length===C)return v;E=B=Q}}return v.push(g.slice(B)),v}]}),!p)},function(e,t,n){n(0)({target:"Array",stat:!0},{isArray:n(41)})},function(e,t,n){var r=n(50),A=n(8),o=n(10),i=n(9).f,a=n(49),u=n(212),c=a("meta"),s=0,f=Object.isExtensible||function(){return!0},g=function(e){i(e,c,{value:{objectID:"O"+ ++s,weakData:{}}})},l=e.exports={REQUIRED:!1,fastKey:function(e,t){if(!A(e))return"symbol"==typeof e?e:("string"==typeof e?"S":"P")+e;if(!o(e,c)){if(!f(e))return"F";if(!t)return"E";g(e)}return e[c].objectID},getWeakData:function(e,t){if(!o(e,c)){if(!f(e))return!0;if(!t)return!1;g(e)}return e[c].weakData},onFreeze:function(e){return u&&l.REQUIRED&&f(e)&&!o(e,c)&&g(e),e}};r[c]=!0},function(e,t,n){"use strict";n(35),n(7),n(12),n(45),Object.defineProperty(t,"__esModule",{value:!0}),t.exportCryptoKey=function(e){return u.apply(this,arguments)},t.generateUid=function(){return Math.random().toString(16).substring(2,8)},t.encryptPayloadWithActiveKey=function(e){return c.apply(this,arguments)},n(18);var r=n(127),A=n(46),o=n(124);function i(e,t,n,r,A,o,i){try{var a=e[o](i),u=a.value}catch(c){return void n(c)}a.done?t(u):Promise.resolve(u).then(r,A)}function a(e){return function(){var t=this,n=arguments;return new Promise((function(r,A){var o=e.apply(t,n);function a(e){i(o,r,A,a,u,"next",e)}function u(e){i(o,r,A,a,u,"throw",e)}a(undefined)}))}}function u(){return(u=a(regeneratorRuntime.mark((function e(t){return regeneratorRuntime.wrap((function(e){for(;;)switch(e.prev=e.next){case 0:return e.abrupt("return",crypto.subtle.exportKey("jwk",t));case 1:case"end":return e.stop()}}),e)})))).apply(this,arguments)}function c(){return(c=a(regeneratorRuntime.mark((function e(t){var n,i,a,u,c;return regeneratorRuntime.wrap((function(e){for(;;)switch(e.prev=e.next){case 0:return n=new o.KeyManager,i=n.getKeyCache(),a=(0,A.cookieManagerGet)().kid,u=new r.AesWasmCrypto(i),e.next=6,u.encrypt(a,t);case 6:return c=e.sent,e.abrupt("return",c);case 8:case"end":return e.stop()}}),e)})))).apply(this,arguments)}},function(e,t,n){var r=n(24),A=n(6);e.exports=function(e){if(e===undefined)return 0;var t=r(e),n=A(t);if(t!==n)throw RangeError("Wrong length or index");return n}},function(e,t,n){"use strict";var r=n(13),A=n(32),o=n(6);e.exports=function(e){for(var t=r(this),n=o(t.length),i=arguments.length,a=A(i>1?arguments[1]:undefined,n),u=i>2?arguments[2]:undefined,c=u===undefined?n:A(u,n);c>a;)t[a++]=e;return t}},function(e,t,n){var r=n(217);e.exports=function(e,t){var n=r(e);if(n%t)throw RangeError("Wrong offset");return n}},function(e,t,n){var r=n(54),A=n(13),o=n(47),i=n(6),a=function(e){return function(t,n,a,u){r(n);var c=A(t),s=o(c),f=i(c.length),g=e?f-1:0,l=e?-1:1;if(a<2)for(;;){if(g in s){u=s[g],g+=l;break}if(g+=l,e?g<0:f<=g)throw TypeError("Reduce of empty array with no initial value")}for(;e?g>=0:f>g;g+=l)g in s&&(u=n(u,s[g],g,c));return u}};e.exports={left:a(!1),right:a(!0)}},function(e,t,n){"use strict";var r,A=n(0),o=n(22).f,i=n(6),a=n(152),u=n(29),c=n(153),s=n(30),f="".startsWith,g=Math.min,l=c("startsWith");A({target:"String",proto:!0,forced:!!(s||l||(r=o(String.prototype,"startsWith"),!r||r.writable))&&!l},{startsWith:function(e){var t=String(u(this));a(e);var n=i(g(arguments.length>1?arguments[1]:undefined,t.length)),r=String(e);return f?f.call(t,r,n):t.slice(n,n+r.length)===r}})},function(e,t,n){"use strict";n(16),n(125),n(17),n(7),n(12),n(36),n(27),Object.defineProperty(t,"__esModule",{value:!0}),t.KeyCache=void 0,n(18);var r=n(28);function A(e,t,n,r,A,o,i){try{var a=e[o](i),u=a.value}catch(c){return void n(c)}a.done?t(u):Promise.resolve(u).then(r,A)}function o(e,t){for(var n=0;n<t.length;n++){var r=t[n];r.enumerable=r.enumerable||!1,r.configurable=!0,"value"in r&&(r.writable=!0),Object.defineProperty(e,r.key,r)}}function i(e,t,n){return t in e?Object.defineProperty(e,t,{value:n,enumerable:!0,configurable:!0,writable:!0}):e[t]=n,e}var a=function(){function e(t){!function(e,t){if(!(e instanceof t))throw new TypeError("Cannot call a class as a function")}(this,e),i(this,"keys",new Map),i(this,"storage",void 0),i(this,"logger",new r.Logger),i(this,"isFirstLogKeyCacheStatus",!0),this.storage=t}var t,n,a,u,c;return t=e,(n=[{key:"getCryptoKey",value:function(e){return this.get(e).key}},{key:"cacheKey",value:function(e){var t=this.storage.get(e);this.keys.set(e,t)}},{key:"cacheAllKeys",value:(u=regeneratorRuntime.mark((function s(){return regeneratorRuntime.wrap((function(e){for(;;)switch(e.prev=e.next){case 0:this.keys=this.storage.getAll();case 1:case"end":return e.stop()}}),s,this)})),c=function(){var e=this,t=arguments;return new Promise((function(n,r){var o=u.apply(e,t);function i(e){A(o,n,r,i,a,"next",e)}function a(e){A(o,n,r,i,a,"throw",e)}i(undefined)}))},function(){return c.apply(this,arguments)})},{key:"get",value:function(e){this.keys.has(e)&&this.keys.get(e)||this.cacheKey(e);var t=this.keys.get(e);if(!t)throw this.logKeyCacheStatus(e),new Error("Expecting a key with id '".concat(e,"' but got none"));return t}},{key:"logKeyCacheStatus",value:function(e){if(this.isFirstLogKeyCacheStatus){this.isFirstLogKeyCacheStatus=!1;var t=this.storage.getAll();this.logger.updateCounter("Siege:Csd:KeyCache:TotalKeysInCache",t.size),t.has(e)?this.logger.updateCounter("Siege:Csd:KeyCache:RequiredKeyAppearedLate",1):this.logger.updateCounter("Siege:Csd:KeyCache:IsMissingRequiredKey",1)}}}])&&o(t.prototype,n),a&&o(t,a),e}();t.KeyCache=a},function(e,t,n){"use strict";n(34),n(42),n(43),n(99),n(66),n(16),n(35),n(125),n(129),n(17),n(130),n(131),n(73),n(7),n(12),n(36),n(173),n(68),n(27),Object.defineProperty(t,"__esModule",{value:!0}),t.LocalStorage=void 0,n(18);var r=n(28),A=n(98);function o(e,t,n,r,A,o,i){try{var a=e[o](i),u=a.value}catch(c){return void n(c)}a.done?t(u):Promise.resolve(u).then(r,A)}function i(e,t){var n=Object.keys(e);if(Object.getOwnPropertySymbols){var r=Object.getOwnPropertySymbols(e);t&&(r=r.filter((function(t){return Object.getOwnPropertyDescriptor(e,t).enumerable}))),n.push.apply(n,r)}return n}function a(e){for(var t=1;t<arguments.length;t++){var n=null!=arguments[t]?arguments[t]:{};t%2?i(Object(n),!0).forEach((function(t){c(e,t,n[t])})):Object.getOwnPropertyDescriptors?Object.defineProperties(e,Object.getOwnPropertyDescriptors(n)):i(Object(n)).forEach((function(t){Object.defineProperty(e,t,Object.getOwnPropertyDescriptor(n,t))}))}return e}function u(e,t){for(var n=0;n<t.length;n++){var r=t[n];r.enumerable=r.enumerable||!1,r.configurable=!0,"value"in r&&(r.writable=!0),Object.defineProperty(e,r.key,r)}}function c(e,t,n){return t in e?Object.defineProperty(e,t,{value:n,enumerable:!0,configurable:!0,writable:!0}):e[t]=n,e}var s=function(){function e(){!function(e,t){if(!(e instanceof t))throw new TypeError("Cannot call a class as a function")}(this,e),c(this,"logger",new r.Logger),c(this,"encoder",new A.Encoder)}var t,n,i,s,f;return t=e,(n=[{key:"put",value:function(e,t){var n=arguments.length>2&&arguments[2]!==undefined?arguments[2]:new Date;localStorage.setItem("SIEGE_CSD_"+e,JSON.stringify({key:this.encoder.encode(t),issuedDate:n}))}},{key:"getAll",value:function(){var e=new Map,t=!0,n=!1,r=undefined;try{for(var A,o=this.getAllKeys()[Symbol.iterator]();!(t=(A=o.next()).done);t=!0){var i=A.value;e.set(i,this.get(i,!1))}}catch(err){n=!0,r=err}finally{try{t||null==o["return"]||o["return"]()}finally{if(n)throw r}}return e}},{key:"get",value:function(e){var t=!(arguments.length>1&&arguments[1]!==undefined)||arguments[1],n=localStorage.getItem("SIEGE_CSD_"+e);if(null===n)return undefined;var r=new Date,A=JSON.parse(n);return(t||A.lastUsedDate===undefined)&&localStorage.setItem("SIEGE_CSD_"+e,JSON.stringify(a({},A,{lastUsedDate:r}))),{key:this.encoder.decode(A.key),issuedDate:new Date(A.issuedDate),lastUsedDate:A.lastUsedDate!==undefined?new Date(A.lastUsedDate):r}}},{key:"removeKeys",value:function(e){var t=!0,n=!1,r=undefined;try{for(var A,o=e[Symbol.iterator]();!(t=(A=o.next()).done);t=!0){var i=A.value;localStorage.removeItem("SIEGE_CSD_"+i)}}catch(err){n=!0,r=err}finally{try{t||null==o["return"]||o["return"]()}finally{if(n)throw r}}}},{key:"getAllKeys",value:function(){for(var e=[],t=0;t<localStorage.length;t++){var n=localStorage.key(t);n.startsWith("SIEGE_CSD_")&&e.push(n.substr("SIEGE_CSD_".length))}return e}},{key:"clear",value:(s=regeneratorRuntime.mark((function g(){return regeneratorRuntime.wrap((function(e){for(;;)switch(e.prev=e.next){case 0:this.logger.incrementCounter("Siege:Csd:LocalStorage:Clearing",1),this.removeKeys(this.getAllKeys());case 2:case"end":return e.stop()}}),g,this)})),f=function(){var e=this,t=arguments;return new Promise((function(n,r){var A=s.apply(e,t);function i(e){o(A,n,r,i,a,"next",e)}function a(e){o(A,n,r,i,a,"throw",e)}i(undefined)}))},function(){return f.apply(this,arguments)})}])&&u(t.prototype,n),i&&u(t,i),e}();t.LocalStorage=s},function(e,t,n){"use strict";n(160),n(7),n(12),Object.defineProperty(t,"__esModule",{value:!0}),t.csdBootstrap=function(){return g.apply(this,arguments)},t.csdUninstall=l,t.csdDisable=function(){c.disable(),u.updateCounter("Siege:Csd:Bootstrap:Disable",1)},t.csdIsInstalled=p,t.csdIsDisabled=h,n(18);var r=n(46),A=n(124),o=n(231);function i(e,t,n,r,A,o,i){try{var a=e[o](i),u=a.value}catch(c){return void n(c)}a.done?t(u):Promise.resolve(u).then(r,A)}function a(e){return function(){var t=this,n=arguments;return new Promise((function(r,A){var o=e.apply(t,n);function a(e){i(o,r,A,a,u,"next",e)}function u(e){i(o,r,A,a,u,"throw",e)}a(undefined)}))}}var u=new(n(28).Logger),c=new A.KeyManager;function s(){return f.apply(this,arguments)}function f(){return(f=a(regeneratorRuntime.mark((function e(){var t,n;return regeneratorRuntime.wrap((function(e){for(;;)switch(e.prev=e.next){case 0:return e.next=2,l();case 2:return t=new o.CompatibilityValidator,e.next=5,t.validateBeforeInstall();case 5:return e.next=7,c.createKey();case 7:if((n=e.sent)===(0,r.cookieManagerGet)().kid){e.next=10;break}throw new Error("Cookie Manager does not return the new key after creation (expected ".concat(n,", got ").concat((0,r.cookieManagerGet)().kid,")"));case 10:return e.next=12,t.validateAfterInstall();case 12:case"end":return e.stop()}}),e)})))).apply(this,arguments)}function g(){return(g=a(regeneratorRuntime.mark((function e(){return regeneratorRuntime.wrap((function(e){for(;;)switch(e.prev=e.next){case 0:return e.next=2,p();case 2:if(e.t0=e.sent,!e.t0){e.next=5;break}e.t0=(0,r.cookieManagerGet)().wasmTested;case 5:if(!e.t0){e.next=13;break}return u.updateCounter("Siege:Csd:Bootstrap:Skip:AlreadyInstalled",1),u.updateCounter("Siege:Csd:Bootstrap:Success",1),e.next=10,c.rotateKeyIfNeeded();case 10:return e.sent?u.updateCounter("Siege:Csd:Bootstrap:KeyRotated",1):u.updateCounter("Siege:Csd:Bootstrap:KeyRotated",0),e.abrupt("return");case 13:return e.next=15,h();case 15:if(!e.sent){e.next=18;break}return u.updateCounter("Siege:Csd:Bootstrap:Skip:Disabled",1),e.abrupt("return");case 18:return e.next=20,s();case 20:u.updateCounter("Siege:Csd:Bootstrap:Success",1),u.updateCounter("Siege:Csd:Bootstrap:NewUser",1);case 22:case"end":return e.stop()}}),e)})))).apply(this,arguments)}function l(){return d.apply(this,arguments)}function d(){return(d=a(regeneratorRuntime.mark((function e(){var t,n=arguments;return regeneratorRuntime.wrap((function(e){for(;;)switch(e.prev=e.next){case 0:return t=n.length>0&&n[0]!==undefined&&n[0],e.next=3,c["delete"](t);case 3:return e.next=5,p();case 5:if(!e.sent){e.next=7;break}throw new Error("csdIsInstalled still returned true after uninstall");case 7:case"end":return e.stop()}}),e)})))).apply(this,arguments)}function p(){return y.apply(this,arguments)}function y(){return(y=a(regeneratorRuntime.mark((function e(){return regeneratorRuntime.wrap((function(e){for(;;)switch(e.prev=e.next){case 0:return e.abrupt("return",c.isInitialized());case 1:case"end":return e.stop()}}),e)})))).apply(this,arguments)}function h(){return I.apply(this,arguments)}function I(){return(I=a(regeneratorRuntime.mark((function e(){return regeneratorRuntime.wrap((function(e){for(;;)switch(e.prev=e.next){case 0:return e.abrupt("return",c.isDisabled());case 1:case"end":return e.stop()}}),e)})))).apply(this,arguments)}},function(e,t,n){"use strict";n(17),n(7),n(12),Object.defineProperty(t,"__esModule",{value:!0}),t.reqResHandler=function(e){return e instanceof Request||e instanceof Response?function(e){return{getHeader:function(t){return e.headers.get(t)},setHeader:function(t,n){e.headers.set(t,n)},csdStatusHeader:function(){var t=e.headers.get(r.Header.Status);return null!==t?JSON.parse(atob(t)):{payloadEncrypted:!1}},retrievePayload:function(){return i(regeneratorRuntime.mark((function t(){var n;return regeneratorRuntime.wrap((function(t){for(;;)switch(t.prev=t.next){case 0:return n=e.clone(),t.abrupt("return",n.text());case 2:case"end":return t.stop()}}),t)})))()},successResponse:function(t){return new Response(t,{headers:e.headers,status:e.status,statusText:e.statusText})},errorResponse:function(t){return new Response(e.body,{status:491,statusText:"SIEGE Client Side Decryption error, check x-csd-error header",headers:A({},r.Header.Error,t.message!==undefined?t.message:t)})}}}(e):function(e){return{getHeader:function(t){return e.headers[t]},setHeader:function(t,n){e.headers[t]=n},csdStatusHeader:function(){var t=e.headers[r.Header.Status];return t!==undefined?JSON.parse(atob(t)):{payloadEncrypted:!1}},successResponse:function(t){return e.data=t,e.text=e.data,e},retrievePayload:function(){return i(regeneratorRuntime.mark((function t(){return regeneratorRuntime.wrap((function(t){for(;;)switch(t.prev=t.next){case 0:return t.abrupt("return",e.data);case 1:case"end":return t.stop()}}),t)})))()},errorResponse:function(t){return e.status=491,e.statusText="SIEGE Client Side Decryption error, check x-csd-error header",e.headers[r.Header.Error]=t.message!==undefined?t.message:t,e}}}(e)},n(18);var r=n(178);function A(e,t,n){return t in e?Object.defineProperty(e,t,{value:n,enumerable:!0,configurable:!0,writable:!0}):e[t]=n,e}function o(e,t,n,r,A,o,i){try{var a=e[o](i),u=a.value}catch(c){return void n(c)}a.done?t(u):Promise.resolve(u).then(r,A)}function i(e){return function(){var t=this,n=arguments;return new Promise((function(r,A){var i=e.apply(t,n);function a(e){o(i,r,A,a,u,"next",e)}function u(e){o(i,r,A,a,u,"throw",e)}a(undefined)}))}}},function(e,t,n){"use strict";n(7),n(12),Object.defineProperty(t,"__esModule",{value:!0}),t.resetBootstrapPromise=function(){t.bootstrapPromise=s=undefined},t.beforeHandler=function(e){return d.apply(this,arguments)},t.afterHandler=function(e,t){return p.apply(this,arguments)},t.cryptoEngine=t.Header=t.bootstrapPromise=void 0,n(18);var r=n(123),A=n(46),o=n(176),i=n(28),a=n(177);function u(e,t,n,r,A,o,i){try{var a=e[o](i),u=a.value}catch(c){return void n(c)}a.done?t(u):Promise.resolve(u).then(r,A)}function c(e){return function(){var t=this,n=arguments;return new Promise((function(r,A){var o=e.apply(t,n);function i(e){u(o,r,A,i,a,"next",e)}function a(e){u(o,r,A,i,a,"throw",e)}i(undefined)}))}}var s,f,g=new i.Logger;t.bootstrapPromise=s,t.Header=f,function(e){e.Enable="x-csd-enable",e.Status="x-csd-status",e.Key="x-csd-key",e.Error="x-csd-error"}(f||(t.Header=f={}));var l=(0,r.getCryptoEngineSingleton)();function d(){return(d=c(regeneratorRuntime.mark((function e(n){var r;return regeneratorRuntime.wrap((function(e){for(;;)switch(e.prev=e.next){case 0:if("true"===(0,a.reqResHandler)(n).getHeader(f.Enable)){e.next=2;break}return e.abrupt("return");case 2:if(!(0,A.cookieManagerIsEnabled)()){e.next=6;break}r=(0,A.cookieManagerGetRaw)(),e.next=10;break;case 6:return s||(t.bootstrapPromise=s=(0,o.csdBootstrap)()),e.next=9,s;case 9:r=(0,A.cookieManagerGetRaw)();case 10:(0,a.reqResHandler)(n).setHeader(f.Key,r);case 11:case"end":return e.stop()}}),e)})))).apply(this,arguments)}function p(){return(p=c(regeneratorRuntime.mark((function e(t,n){var r,A,o;return regeneratorRuntime.wrap((function(e){for(;;)switch(e.prev=e.next){case 0:if((0,a.reqResHandler)(n).csdStatusHeader().payloadEncrypted){e.next=2;break}return e.abrupt("return",n);case 2:return e.next=4,(0,a.reqResHandler)(n).retrievePayload();case 4:if(r=e.sent,null==(A=JSON.parse(r)).error){e.next=8;break}throw new Error("Server-side CSD error: ".concat(A.error));case 8:return g.incrementCounter("Siege:Csd:decryptAJAX"),o=l.decrypt(A),g.updateCounter("Siege:Csd:Decrypt:Success",1),e.abrupt("return",(0,a.reqResHandler)(n).successResponse(o));case 12:case"end":return e.stop()}}),e)})))).apply(this,arguments)}t.cryptoEngine=l},function(e,t,n){e.exports=n(180)},function(e,t,n){"use strict";n(132);var r=n(139);setTimeout((function(){(0,r.bootstrap)()}),1e4),e.exports=n(139)},function(e,t,n){var r=n(1),A=n(104),o=r.WeakMap;e.exports="function"==typeof o&&/native code/.test(A(o))},function(e,t,n){var r=n(5),A=n(2),o=n(10),i=Object.defineProperty,a={},u=function(e){throw e};e.exports=function(e,t){if(o(a,e))return a[e];t||(t={});var n=[][e],c=!!o(t,"ACCESSORS")&&t.ACCESSORS,s=o(t,0)?t[0]:u,f=o(t,1)?t[1]:undefined;return a[e]=!!n&&!A((function(){if(c&&!r)return!0;var e={length:-1};c?i(e,1,{enumerable:!0,get:u}):e[1]=1,n.call(e,s,f)}))}},function(e,t,n){"use strict";var r=n(110),A=n(63);e.exports=r?{}.toString:function(){return"[object "+A(this)+"]"}},function(e,t,n){var r,A,o,i,a,u,c,s,f=n(1),g=n(22).f,l=n(23),d=n(147).set,p=n(148),y=f.MutationObserver||f.WebKitMutationObserver,h=f.process,I=f.Promise,C="process"==l(h),B=g(f,"queueMicrotask"),E=B&&B.value;E||(r=function(){var e,t;for(C&&(e=h.domain)&&e.exit();A;){t=A.fn,A=A.next;try{t()}catch(n){throw A?i():o=undefined,n}}o=undefined,e&&e.enter()},C?i=function(){h.nextTick(r)}:y&&!p?(a=!0,u=document.createTextNode(""),new y(r).observe(u,{characterData:!0}),i=function(){u.data=a=!a}):I&&I.resolve?(c=I.resolve(undefined),s=c.then,i=function(){s.call(c,r)}):i=function(){d.call(f,r)}),e.exports=E||function(e){var t={fn:e,next:undefined};o&&(o.next=t),A||(A=t,i()),o=t}},function(e,t,n){var r=n(1);e.exports=function(e,t){var n=r.console;n&&n.error&&(1===arguments.length?n.error(e):n.error(e,t))}},function(e,t){e.exports=function(e){try{return{error:!1,value:e()}}catch(t){return{error:!0,value:t}}}},function(e,t,n){"use strict";var r=n(0),A=n(30),o=n(145),i=n(2),a=n(31),u=n(26),c=n(149),s=n(15);r({target:"Promise",proto:!0,real:!0,forced:!!o&&i((function(){o.prototype["finally"].call({then:function(){}},(function(){}))}))},{"finally":function(e){var t=u(this,a("Promise")),n="function"==typeof e;return this.then(n?function(n){return c(t,e()).then((function(){return n}))}:e,n?function(n){return c(t,e()).then((function(){throw n}))}:e)}}),A||"function"!=typeof o||o.prototype["finally"]||s(o.prototype,"finally",a("Promise").prototype["finally"])},function(e,t){e.exports=function(e){return e.webpackPolyfill||(e.deprecate=function(){},e.paths=[],e.children||(e.children=[]),Object.defineProperty(e,"loaded",{enumerable:!0,get:function(){return e.l}}),Object.defineProperty(e,"id",{enumerable:!0,get:function(){return e.i}}),e.webpackPolyfill=1),e}},function(e,t,n){var r=n(19),A=n(38).f,o={}.toString,i="object"==typeof window&&window&&Object.getOwnPropertyNames?Object.getOwnPropertyNames(window):[];e.exports.f=function(e){return i&&"[object Window]"==o.call(e)?function(e){try{return A(e)}catch(t){return i.slice()}}(e):A(r(e))}},function(e,t,n){n(65)("asyncIterator")},function(e,t,n){n(65)("toStringTag")},function(e,t,n){"use strict";var r=n(156).IteratorPrototype,A=n(39),o=n(37),i=n(25),a=n(56),u=function(){return this};e.exports=function(e,t,n){var c=t+" Iterator";return e.prototype=A(r,{next:o(1,n)}),i(e,c,!1,!0),a[c]=u,e}},function(e,t,n){var r=n(8);e.exports=function(e){if(!r(e)&&null!==e)throw TypeError("Can't set "+String(e)+" as a prototype");return e}},function(e,t,n){"use strict";var r=n(0),A=n(41),o=[].reverse,i=[1,2];r({target:"Array",proto:!0,forced:String(i)===String(i.reverse())},{reverse:function(){return A(this)&&(this.length=this.length),o.call(this)}})},function(e,t,n){var r=n(1);n(25)(r.JSON,"JSON",!0)},function(e,t,n){n(25)(Math,"Math",!0)},function(e,t,n){n(0)({target:"Object",stat:!0,sham:!n(5)},{create:n(39)})},function(e,t,n){var r=n(0),A=n(2),o=n(13),i=n(57),a=n(157);r({target:"Object",stat:!0,forced:A((function(){i(1)})),sham:!a},{getPrototypeOf:function(e){return i(o(e))}})},function(e,t,n){n(0)({target:"Object",stat:!0},{setPrototypeOf:n(44)})},function(e,t,n){"use strict";(function(r){var A;function o(e){return(o="function"==typeof Symbol&&"symbol"==typeof Symbol.iterator?function(e){return typeof e}:function(e){return e&&"function"==typeof Symbol&&e.constructor===Symbol&&e!==Symbol.prototype?"symbol":typeof e})(e)}
+// Copyright © 2022 Jaime Pillora <dev@example.com>
+n(34),n(42),n(43),n(160),n(69),n(16),n(161),n(58),n(162),n(7),n(201),n(12),n(204),n(122),n(45),n(36),n(165),n(27),n(132);var i,a,u,c,s,f,g,l,d,p,y,h,I,C,B,E,v,Q,w,m,b,x,S,D,k=[].indexOf;d=null,d="undefined"!=typeof WorkerGlobalScope&&self instanceof WorkerGlobalScope?self:void 0!==r?r:window,E=d.document,g="addEventListener",f="removeEventListener",u="dispatchEvent",h="XMLHttpRequest",l=["load","loadend","loadstart"],i=["progress","abort","error","timeout"],S="undefined"!=typeof navigator&&navigator.useragent?navigator.userAgent:"",w=parseInt((/msie (\d+)/.exec(S.toLowerCase())||[])[1]),isNaN(w)&&(w=parseInt((/trident\/.*; rv:(\d+)/.exec(S.toLowerCase())||[])[1])),(I=Array.prototype).indexOf||(I.indexOf=function(e){var t,n,r;for(this,t=n=0,r=this.length;n<r;t=++n)if(this[t]===e)return t;return-1}),x=function(e,t){return Array.prototype.slice.call(e,t)},B=function(e){return"returnValue"===e||"totalSize"===e||"position"===e},Q=function(e,t){var n;for(n in e)if(e[n],!B(n))try{t[n]=e[n]}catch(r){}return t},m=function(e){return void 0===e?null:e},b=function(e,t,n){var r,A,o,i;for(i=function(e){return function(r){var A,o,i;for(o in A={},r)B(o)||(i=r[o],A[o]=i===t?n:i);return n[u](e,A)}},A=0,o=e.length;A<o;A++)r=e[A],n._has(r)&&(t["on".concat(r)]=i(r))},v=function(e){var t;if(E&&null!=E.createEventObject)return(t=E.createEventObject()).type=e,t;try{return new Event(e)}catch(n){return{type:e}}},(D=(a=function(e){var t,n,r;return n={},r=function(e){return n[e]||[]},(t={})[g]=function(e,t,A){n[e]=r(e),n[e].indexOf(t)>=0||(A=A===undefined?n[e].length:A,n[e].splice(A,0,t))},t[f]=function(e,t){var A;e!==undefined?(t===undefined&&(n[e]=[]),-1!==(A=r(e).indexOf(t))&&r(e).splice(A,1)):n={}},t[u]=function(){var n,A,o,i,a,u,c;for(A=(n=x(arguments)).shift(),e||(n[0]=Q(n[0],v(A))),(a=t["on".concat(A)])&&a.apply(t,n),o=i=0,u=(c=r(A).concat(r("*"))).length;i<u;o=++i)c[o].apply(t,n)},t._has=function(e){return!(!n[e]&&!t["on".concat(e)])},e&&(t.listeners=function(e){return x(r(e))},t.on=t[g],t.off=t[f],t.fire=t[u],t.once=function(e,n){var r;return r=function(){return t.off(e,r),n.apply(null,arguments)},t.on(e,r)},t.destroy=function(){return n={}}),t})(!0)).EventEmitter=a,D.before=function(e,t){if(e.length<1||e.length>2)throw"invalid hook";return D[g]("before",e,t)},D.after=function(e,t){if(e.length<2||e.length>3)throw"invalid hook";return D[g]("after",e,t)},D.enable=function(){d[h]=y,"function"==typeof p&&(d.fetch=p)},D.disable=function(){d[h]=D[h],d.fetch=D.fetch},C=D.headers=function(e,t){var n,r,A,i,a,u,c,s,f;switch(void 0===t&&(t={}),o(e)){case"object":for(i in r=[],e)s=e[i],u=i.toLowerCase(),r.push("".concat(u,":\t").concat(s));return r.join("\n")+"\n";case"string":for(A=0,a=(r=e.split("\n")).length;A<a;A++)n=r[A],/([^:]+):\s*(.+)/.test(n)&&(u=null!=(c=RegExp.$1)?c.toLowerCase():void 0,f=RegExp.$2,null==t[u]&&(t[u]=f));return t}},s=d[h],D[h]=s,y=d[h]=function(){var e,t,n,r,A,c,s,f,d,p,y,I,B,E,v,x,S,R,F,O;O=new D[h],x=null,c=void 0,S=void 0,E=void 0,y=function(){var e,t,n,r;if(E.status=x||O.status,-1===x&&w<10||(E.statusText=O.statusText),-1!==x)for(e in n=C(O.getAllResponseHeaders()))r=n[e],E.headers[e]||(t=e.toLowerCase(),E.headers[t]=r)},p=function(){if(O.responseType&&"text"!==O.responseType)"document"===O.responseType?(E.xml=O.responseXML,E.data=O.responseXML):E.data=O.response;else{E.text=O.responseText,E.data=O.responseText;try{E.xml=O.responseXML}catch(e){}}"responseURL"in O&&(E.finalUrl=O.responseURL)},F=function(){A.status=E.status,A.statusText=E.statusText},R=function(){"text"in E&&(A.responseText=E.text),"xml"in E&&(A.responseXML=E.xml),"data"in E&&(A.response=E.data),"finalUrl"in E&&(A.responseURL=E.finalUrl)},n=function(n){for(;n>e&&e<4;)A.readyState=++e,1===e&&A[u]("loadstart",{}),2===e&&F(),4===e&&(F(),R()),A[u]("readystatechange",{}),4===e&&(!1===B.async?t():setTimeout(t,0))},t=function(){c||A[u]("load",{}),A[u]("loadend",{}),c&&(A.readyState=0)},e=0,v=function(e){var t,r;4===e?(t=D.listeners("after"),(r=function(){var e;return t.length?2===(e=t.shift()).length?(e(B,E),r()):3===e.length&&B.async?e(B,E,r):r():n(4)})()):n(e)},A=(B={}).xhr=a(),O.onreadystatechange=function(e){try{2===O.readyState&&y()}catch(t){}4===O.readyState&&(S=!1,y(),p()),v(O.readyState)},s=function(){c=!0},A[g]("error",s),A[g]("timeout",s),A[g]("abort",s),A[g]("progress",(function(){e<3?v(3):A[u]("readystatechange",{})})),("withCredentials"in O||D.addWithCredentials)&&(A.withCredentials=!1),A.status=0;for(f=0,d=(I=i.concat(l)).length;f<d;f++)r=I[f],A["on".concat(r)]=null;return A.open=function(t,n,r,A,o){e=0,c=!1,S=!1,B.headers={},B.headerNames={},B.status=0,(E={}).headers={},B.method=t,B.url=n,B.async=!1!==r,B.user=A,B.pass=o,v(1)},A.send=function(e){var t,n,r,a,u,c,s,f;for(r=0,a=(s=["type","timeout","withCredentials"]).length;r<a;r++)(u="type"===(n=s[r])?"responseType":n)in A&&(B[n]=A[u]);B.body=e,f=function(){var e,t,r,o,a,c;for(b(i,O,A),A.upload&&b(i.concat(l),O.upload,A.upload),S=!0,O.open(B.method,B.url,B.async,B.user,B.pass),r=0,t=(o=["type","timeout","withCredentials"]).length;r<t;r++)u="type"===(n=o[r])?"responseType":n,n in B&&(O[u]=B[n]);for(e in a=B.headers)c=a[e],e&&O.setRequestHeader(e,c);O.send(B.body)},t=D.listeners("before"),(c=function(){var e,n;return t.length?((e=function(e){if("object"===o(e)&&("number"==typeof e.status||"number"==typeof E.status))return Q(e,E),k.call(e,"data")<0&&(e.data=e.response||e.text),void v(4);c()}).head=function(e){return Q(e,E),v(2)},e.progress=function(e){return Q(e,E),v(3)},1===(n=t.shift()).length?e(n(B)):2===n.length&&B.async?n(B,e):e()):f()})()},A.abort=function(){x=-1,S?O.abort():A[u]("abort",{})},A.setRequestHeader=function(e,t){var n,r;n=null!=e?e.toLowerCase():void 0,r=B.headerNames[n]=B.headerNames[n]||e,B.headers[r]&&(t=B.headers[r]+", "+t),B.headers[r]=t},A.getResponseHeader=function(e){var t;return t=null!=e?e.toLowerCase():void 0,m(E.headers[t])},A.getAllResponseHeaders=function(){return m(C(E.headers))},O.overrideMimeType&&(A.overrideMimeType=function(){return O.overrideMimeType.apply(O,arguments)}),O.upload&&(A.upload=B.upload=a()),A.UNSENT=0,A.OPENED=1,A.HEADERS_RECEIVED=2,A.LOADING=3,A.DONE=4,A.response="",A.responseText="",A.responseXML=null,A.readyState=0,A.statusText="",A},"function"==typeof d.fetch&&(c=d.fetch,D.fetch=c,p=d.fetch=function(e,t){var n,r,A;return void 0===t&&(t={headers:{}}),t.url=e,A=null,r=D.listeners("before"),n=D.listeners("after"),new Promise((function(e,o){var i,a,u,s,f;a=function(){return t.headers&&(t.headers=new Headers(t.headers)),A||(A=new Request(t.url,t)),Q(t,A)},u=function(t){var r;return n.length?2===(r=n.shift()).length?(r(a(),t),u(t)):3===r.length?r(a(),t,u):u(t):e(t)},i=function(t){var n;if(void 0!==t)return n=new Response(t.body||t.text,t),e(n),void u(n);s()},s=function(){var e;if(r.length)return 1===(e=r.shift()).length?i(e(t)):2===e.length?e(a(),i):void 0;f()},f=function(){return c(a()).then((function(e){return u(e)}))["catch"]((function(e){}),u(err),o(err))},s()}))}),y.UNSENT=0,y.OPENED=1,y.HEADERS_RECEIVED=2,y.LOADING=3,y.DONE=4,(A=function(){return D}.apply(t,[]))===undefined||(e.exports=A)}).call(this,n(100))},function(e,t,n){var r=n(0),A=n(202);r({global:!0,forced:parseInt!=A},{parseInt:A})},function(e,t,n){var r=n(1),A=n(203).trim,o=n(163),i=r.parseInt,a=/^[+-]?0[Xx]/,u=8!==i(o+"08")||22!==i(o+"0x16");e.exports=u?function(e,t){var n=A(String(e));return i(n,t>>>0||(a.test(n)?16:10))}:i},function(e,t,n){var r=n(29),A="["+n(163)+"]",o=RegExp("^"+A+A+"*"),i=RegExp(A+A+"*$"),a=function(e){return function(t){var n=String(r(t));return 1&e&&(n=n.replace(o,"")),2&e&&(n=n.replace(i,"")),n}};e.exports={start:a(1),end:a(2),trim:a(3)}},function(e,t,n){var r=n(5),A=n(1),o=n(61),i=n(121),a=n(9).f,u=n(38).f,c=n(116),s=n(120),f=n(164),g=n(15),l=n(2),d=n(21).set,p=n(53),y=n(4)("match"),h=A.RegExp,I=h.prototype,C=/a/g,B=/a/g,E=new h(C)!==C,v=f.UNSUPPORTED_Y;if(r&&o("RegExp",!E||v||l((function(){return B[y]=!1,h(C)!=C||h(B)==B||"/a/i"!=h(C,"i")})))){for(var Q=function(e,t){var n,r=this instanceof Q,A=c(e),o=t===undefined;if(!r&&A&&e.constructor===Q&&o)return e;E?A&&!o&&(e=e.source):e instanceof Q&&(o&&(t=s.call(e)),e=e.source),v&&(n=!!t&&t.indexOf("y")>-1)&&(t=t.replace(/y/g,""));var a=i(E?new h(e,t):h(e,t),r?this:I,Q);return v&&n&&d(a,{sticky:n}),a},w=function(e){e in Q||a(Q,e,{configurable:!0,get:function(){return h[e]},set:function(t){h[e]=t}})},m=u(h),b=0;m.length>b;)w(m[b++]);I.constructor=Q,Q.prototype=I,g(A,"RegExp",Q)}p("RegExp")},function(e,t,n){"use strict";n(122);var r=n(15),A=n(2),o=n(4),i=n(70),a=n(14),u=o("species"),c=!A((function(){var e=/./;return e.exec=function(){var e=[];return e.groups={a:"7"},e},"7"!=="".replace(e,"$<a>")})),s="$0"==="a".replace(/./,"$0"),f=o("replace"),g=!!/./[f]&&""===/./[f]("a","$0"),l=!A((function(){var e=/(?:)/,t=e.exec;e.exec=function(){return t.apply(this,arguments)};var n="ab".split(e);return 2!==n.length||"a"!==n[0]||"b"!==n[1]}));e.exports=function(e,t,n,f){var d=o(e),p=!A((function(){var t={};return t[d]=function(){return 7},7!=""[e](t)})),y=p&&!A((function(){var t=!1,n=/a/;return"split"===e&&((n={}).constructor={},n.constructor[u]=function(){return n},n.flags="",n[d]=/./[d]),n.exec=function(){return t=!0,null},n[d](""),!t}));if(!p||!y||"replace"===e&&(!c||!s||g)||"split"===e&&!l){var h=/./[d],I=n(d,""[e],(function(e,t,n,r,A){return t.exec===i?p&&!A?{done:!0,value:h.call(t,n,r)}:{done:!0,value:e.call(n,t,r)}:{done:!1}}),{REPLACE_KEEPS_$0:s,REGEXP_REPLACE_SUBSTITUTES_UNDEFINED_CAPTURE:g}),C=I[0],B=I[1];r(String.prototype,e,C),r(RegExp.prototype,d,2==t?function(e,t){return B.call(e,this,t)}:function(e){return B.call(e,this)})}f&&a(RegExp.prototype[d],"sham",!0)}},function(e,t,n){"use strict";var r=n(158).charAt;e.exports=function(e,t,n){return t+(n?r(e,t).length:1)}},function(e,t,n){var r=n(23),A=n(70);e.exports=function(e,t){var n=e.exec;if("function"==typeof n){var o=n.call(e,t);if("object"!=typeof o)throw TypeError("RegExp exec method returned something other than an Object or null");return o}if("RegExp"!==r(e))throw TypeError("RegExp#exec called on incompatible receiver");return A.call(e,t)}},function(e,t,n){var r=n(0),A=n(209);r({target:"Array",stat:!0,forced:!n(64)((function(e){Array.from(e)}))},{from:A})},function(e,t,n){"use strict";var r=n(40),A=n(13),o=n(146),i=n(113),a=n(6),u=n(59),c=n(114);e.exports=function(e){var t,n,s,f,g,l,d=A(e),p="function"==typeof this?this:Array,y=arguments.length,h=y>1?arguments[1]:undefined,I=h!==undefined,C=c(d),B=0;if(I&&(h=r(h,y>2?arguments[2]:undefined,2)),C==undefined||p==Array&&i(C))for(n=new p(t=a(d.length));t>B;B++)l=I?h(d[B],B):d[B],u(n,B,l);else for(g=(f=C.call(d)).next,n=new p;!(s=g.call(f)).done;B++)l=I?o(f,h,[s.value,B],!0):s.value,u(n,B,l);return n.length=B,n}},function(e,t,n){n(0)({target:"Date",stat:!0},{now:function(){return(new Date).getTime()}})},function(e,t,n){"use strict";var r=n(0),A=n(1),o=n(61),i=n(15),a=n(167),u=n(112),c=n(55),s=n(8),f=n(2),g=n(64),l=n(25),d=n(121);e.exports=function(e,t,n){var p=-1!==e.indexOf("Map"),y=-1!==e.indexOf("Weak"),h=p?"set":"add",I=A[e],C=I&&I.prototype,B=I,E={},v=function(e){var t=C[e];i(C,e,"add"==e?function(e){return t.call(this,0===e?0:e),this}:"delete"==e?function(e){return!(y&&!s(e))&&t.call(this,0===e?0:e)}:"get"==e?function(e){return y&&!s(e)?undefined:t.call(this,0===e?0:e)}:"has"==e?function(e){return!(y&&!s(e))&&t.call(this,0===e?0:e)}:function(e,n){return t.call(this,0===e?0:e,n),this})};if(o(e,"function"!=typeof I||!(y||C.forEach&&!f((function(){(new I).entries().next()})))))B=n.getConstructor(t,e,p,h),a.REQUIRED=!0;else if(o(e,!0)){var Q=new B,w=Q[h](y?{}:-0,1)!=Q,m=f((function(){Q.has(1)})),b=g((function(e){new I(e)})),x=!y&&f((function(){for(var e=new I,t=5;t--;)e[h](t,t);return!e.has(-0)}));b||((B=t((function(t,n){c(t,B,e);var r=d(new I,t,B);return n!=undefined&&u(n,r[h],r,p),r}))).prototype=C,C.constructor=B),(m||x)&&(v("delete"),v("has"),p&&v("get")),(x||w)&&v(h),y&&C.clear&&delete C.clear}return E[e]=B,r({global:!0,forced:B!=I},E),l(B,e),y||n.setStrong(B,e,p),B}},function(e,t,n){var r=n(2);e.exports=!r((function(){return Object.isExtensible(Object.preventExtensions({}))}))},function(e,t,n){"use strict";var r=n(9).f,A=n(39),o=n(111),i=n(40),a=n(55),u=n(112),c=n(118),s=n(53),f=n(5),g=n(167).fastKey,l=n(21),d=l.set,p=l.getterFor;e.exports={getConstructor:function(e,t,n,c){var s=e((function(e,r){a(e,s,t),d(e,{type:t,index:A(null),first:undefined,last:undefined,size:0}),f||(e.size=0),r!=undefined&&u(r,e[c],e,n)})),l=p(t),y=function(e,t,n){var r,A,o=l(e),i=h(e,t);return i?i.value=n:(o.last=i={index:A=g(t,!0),key:t,value:n,previous:r=o.last,next:undefined,removed:!1},o.first||(o.first=i),r&&(r.next=i),f?o.size++:e.size++,"F"!==A&&(o.index[A]=i)),e},h=function(e,t){var n,r=l(e),A=g(t);if("F"!==A)return r.index[A];for(n=r.first;n;n=n.next)if(n.key==t)return n};return o(s.prototype,{clear:function(){for(var e=l(this),t=e.index,n=e.first;n;)n.removed=!0,n.previous&&(n.previous=n.previous.next=undefined),delete t[n.index],n=n.next;e.first=e.last=undefined,f?e.size=0:this.size=0},"delete":function(e){var t=l(this),n=h(this,e);if(n){var r=n.next,A=n.previous;delete t.index[n.index],n.removed=!0,A&&(A.next=r),r&&(r.previous=A),t.first==n&&(t.first=r),t.last==n&&(t.last=A),f?t.size--:this.size--}return!!n},forEach:function(e){for(var t,n=l(this),r=i(e,arguments.length>1?arguments[1]:undefined,3);t=t?t.next:n.first;)for(r(t.value,t.key,this);t&&t.removed;)t=t.previous},has:function(e){return!!h(this,e)}}),o(s.prototype,n?{get:function(e){var t=h(this,e);return t&&t.value},set:function(e,t){return y(this,0===e?0:e,t)}}:{add:function(e){return y(this,e=0===e?0:e,e)}}),f&&r(s.prototype,"size",{get:function(){return l(this).size}}),s},setStrong:function(e,t,n){var r=t+" Iterator",A=p(t),o=p(r);c(e,t,(function(e,t){d(this,{type:r,target:e,state:A(e),kind:t,last:undefined})}),(function(){for(var e=o(this),t=e.kind,n=e.last;n&&n.removed;)n=n.previous;return e.target&&(e.last=n=n?n.next:e.state.first)?"keys"==t?{value:n.key,done:!1}:"values"==t?{value:n.value,done:!1}:{value:[n.key,n.value],done:!1}:(e.target=undefined,{value:undefined,done:!0})}),n?"entries":"values",!n,!0),s(t)}}},function(e,t){var n=Math.abs,r=Math.pow,A=Math.floor,o=Math.log,i=Math.LN2;e.exports={pack:function(e,t,a){var u,c,s,f=new Array(a),g=8*a-t-1,l=(1<<g)-1,d=l>>1,p=23===t?r(2,-24)-r(2,-77):0,y=e<0||0===e&&1/e<0?1:0,h=0;for((e=n(e))!=e||e===1/0?(c=e!=e?1:0,u=l):(u=A(o(e)/i),e*(s=r(2,-u))<1&&(u--,s*=2),(e+=u+d>=1?p/s:p*r(2,1-d))*s>=2&&(u++,s/=2),u+d>=l?(c=0,u=l):u+d>=1?(c=(e*s-1)*r(2,t),u+=d):(c=e*r(2,d-1)*r(2,t),u=0));t>=8;f[h++]=255&c,c/=256,t-=8);for(u=u<<t|c,g+=t;g>0;f[h++]=255&u,u/=256,g-=8);return f[--h]|=128*y,f},unpack:function(e,t){var n,A=e.length,o=8*A-t-1,i=(1<<o)-1,a=i>>1,u=o-7,c=A-1,s=e[c--],f=127&s;for(s>>=7;u>0;f=256*f+e[c],c--,u-=8);for(n=f&(1<<-u)-1,f>>=-u,u+=t;u>0;n=256*n+e[c],c--,u-=8);if(0===f)f=1-a;else{if(f===i)return n?NaN:s?-1/0:1/0;n+=r(2,t),f-=a}return(s?-1:1)*n*r(2,f-t)}}},function(e,t,n){"use strict";var r=n(0),A=n(1),o=n(5),i=n(216),a=n(3),u=n(72),c=n(55),s=n(37),f=n(14),g=n(6),l=n(169),d=n(171),p=n(48),y=n(10),h=n(63),I=n(8),C=n(39),B=n(44),E=n(38).f,v=n(218),Q=n(20).forEach,w=n(53),m=n(9),b=n(22),x=n(21),S=n(121),D=x.get,k=x.set,R=m.f,F=b.f,O=Math.round,M=A.RangeError,G=u.ArrayBuffer,N=u.DataView,T=a.NATIVE_ARRAY_BUFFER_VIEWS,L=a.TYPED_ARRAY_TAG,H=a.TypedArray,j=a.TypedArrayPrototype,Y=a.aTypedArrayConstructor,U=a.isTypedArray,P=function(e,t){for(var n=0,r=t.length,A=new(Y(e))(r);r>n;)A[n]=t[n++];return A},K=function(e,t){R(e,t,{get:function(){return D(this)[t]}})},_=function(e){var t;return e instanceof G||"ArrayBuffer"==(t=h(e))||"SharedArrayBuffer"==t},X=function(e,t){return U(e)&&"symbol"!=typeof t&&t in e&&String(+t)==String(t)},J=function(e,t){return X(e,t=p(t,!0))?s(2,e[t]):F(e,t)},q=function(e,t,n){return!(X(e,t=p(t,!0))&&I(n)&&y(n,"value"))||y(n,"get")||y(n,"set")||n.configurable||y(n,"writable")&&!n.writable||y(n,"enumerable")&&!n.enumerable?R(e,t,n):(e[t]=n.value,e)};o?(T||(b.f=J,m.f=q,K(j,"buffer"),K(j,"byteOffset"),K(j,"byteLength"),K(j,"length")),r({target:"Object",stat:!0,forced:!T},{getOwnPropertyDescriptor:J,defineProperty:q}),e.exports=function(e,t,n){var o=e.match(/\d+$/)[0]/8,a=e+(n?"Clamped":"")+"Array",u="get"+e,s="set"+e,p=A[a],y=p,h=y&&y.prototype,m={},b=function(e,t){R(e,t,{get:function(){return function(e,t){var n=D(e);return n.view[u](t*o+n.byteOffset,!0)}(this,t)},set:function(e){return function(e,t,r){var A=D(e);n&&(r=(r=O(r))<0?0:r>255?255:255&r),A.view[s](t*o+A.byteOffset,r,!0)}(this,t,e)},enumerable:!0})};T?i&&(y=t((function(e,t,n,r){return c(e,y,a),S(I(t)?_(t)?r!==undefined?new p(t,d(n,o),r):n!==undefined?new p(t,d(n,o)):new p(t):U(t)?P(y,t):v.call(y,t):new p(l(t)),e,y)})),B&&B(y,H),Q(E(p),(function(e){e in y||f(y,e,p[e])})),y.prototype=h):(y=t((function(e,t,n,r){c(e,y,a);var A,i,u,s=0,f=0;if(I(t)){if(!_(t))return U(t)?P(y,t):v.call(y,t);A=t,f=d(n,o);var p=t.byteLength;if(r===undefined){if(p%o)throw M("Wrong length");if((i=p-f)<0)throw M("Wrong length")}else if((i=g(r)*o)+f>p)throw M("Wrong length");u=i/o}else u=l(t),A=new G(i=u*o);for(k(e,{buffer:A,byteOffset:f,byteLength:i,length:u,view:new N(A)});s<u;)b(e,s++)})),B&&B(y,H),h=y.prototype=C(j)),h.constructor!==y&&f(h,"constructor",y),L&&f(h,L,a),m[a]=y,r({global:!0,forced:y!=p,sham:!T},m),"BYTES_PER_ELEMENT"in y||f(y,"BYTES_PER_ELEMENT",o),"BYTES_PER_ELEMENT"in h||f(h,"BYTES_PER_ELEMENT",o),w(a)}):e.exports=function(){}},function(e,t,n){var r=n(1),A=n(2),o=n(64),i=n(3).NATIVE_ARRAY_BUFFER_VIEWS,a=r.ArrayBuffer,u=r.Int8Array;e.exports=!i||!A((function(){u(1)}))||!A((function(){new u(-1)}))||!o((function(e){new u,new u(null),new u(1.5),new u(e)}),!0)||A((function(){return 1!==new u(new a(2),1,undefined).length}))},function(e,t,n){var r=n(24);e.exports=function(e){var t=r(e);if(t<0)throw RangeError("The argument can't be less than 0");return t}},function(e,t,n){var r=n(13),A=n(6),o=n(114),i=n(113),a=n(40),u=n(3).aTypedArrayConstructor;e.exports=function(e){var t,n,c,s,f,g,l=r(e),d=arguments.length,p=d>1?arguments[1]:undefined,y=p!==undefined,h=o(l);if(h!=undefined&&!i(h))for(g=(f=h.call(l)).next,l=[];!(s=g.call(f)).done;)l.push(s.value);for(y&&d>2&&(p=a(p,arguments[2],2)),n=A(l.length),c=new(u(this))(n),t=0;n>t;t++)c[t]=y?p(l[t],t):l[t];return c}},function(e,t,n){"use strict";var r=n(13),A=n(32),o=n(6),i=Math.min;e.exports=[].copyWithin||function(e,t){var n=r(this),a=o(n.length),u=A(e,a),c=A(t,a),s=arguments.length>2?arguments[2]:undefined,f=i((s===undefined?a:A(s,a))-c,a-u),g=1;for(c<u&&u<c+f&&(g=-1,c+=f-1,u+=f-1);f-- >0;)c in n?n[u]=n[c]:delete n[u],u+=g,c+=g;return n}},function(e,t,n){"use strict";var r=n(19),A=n(24),o=n(6),i=n(52),a=n(33),u=Math.min,c=[].lastIndexOf,s=!!c&&1/[1].lastIndexOf(1,-0)<0,f=i("lastIndexOf"),g=a("indexOf",{ACCESSORS:!0,1:0}),l=s||!f||!g;e.exports=l?function(e){if(s)return c.apply(this,arguments)||0;var t=r(this),n=o(t.length),i=n-1;for(arguments.length>1&&(i=u(i,A(arguments[1]))),i<0&&(i=n+i);i>=0;i--)if(i in t&&t[i]===e)return i||0;return-1}:c},function(e,t,n){"use strict";(function(e){n(69),n(16),n(161),n(58),n(222),n(71),n(17),n(7),n(74),n(75),n(76),n(77),n(78),n(79),n(80),n(81),n(82),n(83),n(84),n(85),n(86),n(87),n(88),n(89),n(90),n(91),n(92),n(93),n(94),n(95),n(96),n(97),function(e){function t(){}function n(e,t){if(e=void 0===e?"utf-8":e,t=void 0===t?{fatal:!1}:t,-1===r.indexOf(e.toLowerCase()))throw new RangeError("Failed to construct 'TextDecoder': The encoding label provided ('"+e+"') is invalid.");if(t.fatal)throw Error("Failed to construct 'TextDecoder': the 'fatal' option is unsupported.")}if(e.TextEncoder&&e.TextDecoder)return!1;var r=["utf-8","utf8","unicode-1-1-utf-8"];Object.defineProperty(t.prototype,"encoding",{value:"utf-8"}),t.prototype.encode=function(e,t){if((t=void 0===t?{stream:!1}:t).stream)throw Error("Failed to encode: the 'stream' option is unsupported.");t=0;for(var n=e.length,r=0,A=Math.max(32,n+(n>>1)+7),o=new Uint8Array(A>>3<<3);t<n;){var i=e.charCodeAt(t++);if(55296<=i&&56319>=i){if(t<n){var a=e.charCodeAt(t);56320==(64512&a)&&(++t,i=((1023&i)<<10)+(1023&a)+65536)}if(55296<=i&&56319>=i)continue}if(r+4>o.length&&(A+=8,A=(A*=1+t/e.length*2)>>3<<3,(a=new Uint8Array(A)).set(o),o=a),0==(4294967168&i))o[r++]=i;else{if(0==(4294965248&i))o[r++]=i>>6&31|192;else if(0==(4294901760&i))o[r++]=i>>12&15|224,o[r++]=i>>6&63|128;else{if(0!=(4292870144&i))continue;o[r++]=i>>18&7|240,o[r++]=i>>12&63|128,o[r++]=i>>6&63|128}o[r++]=63&i|128}}return o.slice?o.slice(0,r):o.subarray(0,r)},Object.defineProperty(n.prototype,"encoding",{value:"utf-8"}),Object.defineProperty(n.prototype,"fatal",{value:!1}),Object.defineProperty(n.prototype,"ignoreBOM",{value:!1}),n.prototype.decode=function(e,t){if((t=void 0===t?{stream:!1}:t).stream)throw Error("Failed to decode: the 'stream' option is unsupported.");!((t=e)instanceof Uint8Array)&&t.buffer instanceof ArrayBuffer&&(t=new Uint8Array(e.buffer)),e=0;for(var n=[],r=[];;){var A=e<t.length;if(!A||65536&e){if(r.push(String.fromCharCode.apply(null,n)),!A)return r.join("");n=[],t=t.subarray(e),e=0}if(0===(A=t[e++]))n.push(0);else if(0==(128&A))n.push(A);else if(192==(224&A)){var o=63&t[e++];n.push((31&A)<<6|o)}else if(224==(240&A)){o=63&t[e++];var i=63&t[e++];n.push((31&A)<<12|o<<6|i)}else if(240==(248&A)){65535<(A=(7&A)<<18|(o=63&t[e++])<<12|(i=63&t[e++])<<6|63&t[e++])&&(A-=65536,n.push(A>>>10&1023|55296),A=56320|1023&A),n.push(A)}}},e.TextEncoder=t,e.TextDecoder=n}("undefined"!=typeof window?window:void 0!==e?e:void 0)}).call(this,n(100))},function(e,t,n){"use strict";var r=n(0),A=n(1),o=n(72),i=n(53),a=o.ArrayBuffer;r({global:!0,forced:A.ArrayBuffer!==a},{ArrayBuffer:a}),i("ArrayBuffer")},function(e,t,n){var r=n(0),A=n(72);r({global:!0,forced:!n(128)},{DataView:A.DataView})},function(e,t,n){"use strict";n(34),n(42),n(43),n(99),n(66),n(16),n(58),n(225),n(129),n(17),n(130),n(131),n(73),n(7),n(36),n(173),n(68),n(27),Object.defineProperty(t,"__esModule",{value:!0}),t.loadCondensedWasm=function(e){var t=arguments.length>1&&arguments[1]!==undefined?arguments[1]:{},n="_wasm_dep",A=o({},t,i({},n,{})),a={},u=new r.Encoder,c=!0,s=!1,f=undefined;try{for(var g,l=e[Symbol.iterator]();!(c=(g=l.next()).done);c=!0){var d=g.value,p=new WebAssembly.Module(u.decode(d)),y=new WebAssembly.Instance(p,A);Object.assign(a,y.exports);for(var h=0,I=Object.keys(a);h<I.length;h++){var C=I[h];C.startsWith(n)&&(A[n][C.slice(n.length)]=a[C],delete a[C])}}}catch(err){s=!0,f=err}finally{try{c||null==l["return"]||l["return"]()}finally{if(s)throw f}}return a};var r=n(98);function A(e,t){var n=Object.keys(e);if(Object.getOwnPropertySymbols){var r=Object.getOwnPropertySymbols(e);t&&(r=r.filter((function(t){return Object.getOwnPropertyDescriptor(e,t).enumerable}))),n.push.apply(n,r)}return n}function o(e){for(var t=1;t<arguments.length;t++){var n=null!=arguments[t]?arguments[t]:{};t%2?A(Object(n),!0).forEach((function(t){i(e,t,n[t])})):Object.getOwnPropertyDescriptors?Object.defineProperties(e,Object.getOwnPropertyDescriptors(n)):A(Object(n)).forEach((function(t){Object.defineProperty(e,t,Object.getOwnPropertyDescriptor(n,t))}))}return e}function i(e,t,n){return t in e?Object.defineProperty(e,t,{value:n,enumerable:!0,configurable:!0,writable:!0}):e[t]=n,e}},function(e,t,n){var r=n(0),A=n(226);r({target:"Object",stat:!0,forced:Object.assign!==A},{assign:A})},function(e,t,n){"use strict";var r=n(5),A=n(2),o=n(62),i=n(107),a=n(101),u=n(13),c=n(47),s=Object.assign,f=Object.defineProperty;e.exports=!s||A((function(){if(r&&1!==s({b:1},s(f({},"a",{enumerable:!0,get:function(){f(this,"b",{value:3,enumerable:!1})}}),{b:2})).b)return!0;var e={},t={},n=Symbol();return e[n]=7,"abcdefghijklmnopqrst".split("").forEach((function(e){t[e]=e})),7!=s({},e)[n]||"abcdefghijklmnopqrst"!=o(s({},t)).join("")}))?function(e,t){for(var n=u(e),A=arguments.length,s=1,f=i.f,g=a.f;A>s;)for(var l,d=c(arguments[s++]),p=f?o(d).concat(f(d)):o(d),y=p.length,h=0;y>h;)l=p[h++],r&&!g.call(d,l)||(n[l]=d[l]);return n}:s},function(e){e.exports=JSON.parse('{"program":["AGFzbQEAAAABw4CAgACJgICAAGADf39/AX9gAX8AYAABf2ABfwF/YAR/f39/AX9gA39/fwBgAn9/AGAFf39/f38Bf2AKf39/f39/f39/fwF/AoWAgIAAgICAgAADlICAgACPgICAAAICAgAFBgQHBQQACAIBAwSJgICAAIGAgIAAcAELCwWLgICAAIGAgIAAAYACgIACBpCAgIAAgoCAgAB/AUEAC38AQZAMCwfqgYCAAIyAgIAABm1lbW9yeQIAGnNpemVvZl9tYmVkdGxzX2djbV9jb250ZXh0AAAVbWJlZHRsc19jaXBoZXJfaWRfYWVzAAEYbWJlZHRsc19nY21fYXV0aF9kZWNyeXB0AAsQX19lcnJub19sb2NhdGlvbgACCXN0YWNrU2F2ZQAMDHN0YWNrUmVzdG9yZQANCnN0YWNrQWxsb2MADhFfd2FzbV9kZXBfZnVuY18xOAAFEV93YXNtX2RlcF9mdW5jXzM2AAYSX3dhc21fZGVwX21lbW9yeV8wAgARX3dhc21fZGVwX3RhYmxlXzABAAmFgICAAICAgIAACriWgIAAj4CAgACFgICAAABBgAMLhICAgAAAQQILhYCAgAAAQaAMC4GEgIAAAQN/IAJBgARPBEAgACABIAIQBCAADwsgACACaiEDAkAgACABc0EDcUUEQAJAIAJBAUgEQCAAIQIMAQsgAEEDcUUEQCAAIQIMAQsgACECA0AgAiABLQAAOgAAIAFBAWohASACQQFqIgIgA08NASACQQNxDQALCwJAIANBfHEiBEHAAEkNACACIARBQGoiBUsNAANAIAIgASgCADYCACACIAEoAgQ2AgQgAiABKAIINgIIIAIgASgCDDYCDCACIAEoAhA2AhAgAiABKAIUNgIUIAIgASgCGDYCGCACIAEoAhw2AhwgAiABKAIgNgIgIAIgASgCJDYCJCACIAEoAig2AiggAiABKAIsNgIsIAIgASgCMDYCMCACIAEoAjQ2AjQgAiABKAI4NgI4IAIgASgCPDYCPCABQUBrIQEgAkFAayICIAVNDQALCyACIARPDQEDQCACIAEoAgA2AgAgAUEEaiEBIAJBBGoiAiAESQ0ACwwBCyADQQRJBEAgACECDAELIANBfGoiBCAASQRAIAAhAgwBCyAAIQIDQCACIAEtAAA6AAAgAiABLQABOgABIAIgAS0AAjoAAiACIAEtAAM6AAMgAUEEaiEBIAJBBGoiAiAETQ0ACwsgAiADSQRAA0AgAiABLQAAOgAAIAFBAWohASACQQFqIgIgA0cNAAsLIAALu4CAgAABAX8gAgRAA0AgACABIAJB/AMgAkH8A0kbIgMQAyEAIAFB/ANqIQEgAEH8A2ohACACIANrIgINAAsLC5eAgIAAACABBEAgAEEAIAFBgAgoAgARAAAaCwurgYCAAAEDf0GAvn4hBAJAIAAoAgAiBUUNACADQQA2AgAgBSgCGCEGAkACQAJAIAUoAgRBf2oOBgACAgICAQILQYC7fiEEIAZBEEcNAiADQRA2AgAgACgCNCAAKAIIIAEgAiAFKAIcKAIEEQQADwsgA0EQNgIAIAAoAjRBECABIAIQCQ8LIAZFBEBBgLl+DwsgASACRgRAIAAoAhwNAUEQIAZwDQELQYC/fiEECyAEC4iEgIAAAQt/IwEoAgBBEGsiCCQAIwEjADYCACAIQQA2AgwCQCACRQRAQWwhBQwBCyAAQoAANwPYAiAAQQA2AvgCIABCgAA3A7gCIABCgAA3A/ACIABB6AJqIgtCgAA3AwAgAEKAADcD4AIgAEKAADcDwAIgAEHYAmohBgJAIAJBDEYEQCAGIAEpAAA3AAAgBiABKAAINgAIIABBAToA5wIMAQsgAkEDdCEMIAJBBXYhDSACQQ12IQ4gAkEVdiEPA0AgAkEQIAJBEEkbIglBASAJQQFLGyEHQQAhBQNAIAAgBWpB2AJqIgogCi0AACABIAVqLQAAczoAACAFQQFqIgUgB0cNAAsgACAGIAYQCCABIAlqIQEgAiAJayICDQALIABB5wJqIgUgBS0AACAMczoAACAAQeYCaiIFIAUtAAAgDXM6AAAgAEHlAmoiBSAFLQAAIA5zOgAAIABB5AJqIgUgBS0AACAPczoAACAAIAYgBhAICyAAIAYgAEHIAmogCEEMahAGIgUNACAAIAStNwPAAiAEBEADQCAEQRAgBEEQSRsiB0EBIAdBAUsbIQFBACEFA0AgACAFakHoAmoiCiAKLQAAIAMgBWotAABzOgAAIAVBAWoiBSABRw0ACyAAIAsgCxAIIAMgB2ohAyAEIAdrIgQNAAsLQQAhBQsgCEEQaiQAIwEjADYCACAFC4uDgIAAAgN/A34gACABLQAPIgNBD3FBA3RqIgQpAzghByAEKQO4ASEGQQ8hBANAIANB8AFxQQR2IQUCQCAEQQ9GBEAgByEIDAELIAAgA0EPcUEDdGoiAykDOCAGQrwAhiAHQoQAiISFIQggAykDuAEgB6dBD3FBA3RBgAtqKQMAQrAAhiAGQoQAiIWFIQYLIAAgBUEDdGoiAykDOCAGQrwAhiAIQoQAiISFIQcgAykDuAEgCKdBD3FBA3RBgAtqKQMAQrAAhiAGQoQAiIWFIQYgBARAIAEgBEF/aiIEai0AACEDDAELCyACIAc8AA8gAiAGPAAHIAIgB0KIAIg8AA4gAiAHQpAAiDwADSACIAdCmACIPAAMIAIgB0KgAIg8AAsgAiAHQqgAiDwACiACIAdCsACIPAAJIAIgB0K4AIg8AAggAiAGQogAiDwABiACIAZCkACIPAAFIAIgBkKYAIg8AAQgAiAGQqAAiDwAAyACIAZCqACIPAACIAIgBkKwAIg8AAEgAiAGQrgAiDwAAAuJg4CAAAIIfwJ+IwEoAgBBIGsiBiQAIwEjADYCACAGQQA2AgwCQCADIAJLBEBBbCEEIAMgAmsgAUkNAQtBbCEEIAApA7gCIg0gAa18IgwgDVQNACAMQuD/////AVYNACAAIAw3A7gCIAEEQCAAQegCaiEIIABB2AJqIQkDQEEQIQQDQCAEQQ1PBEAgACAEQX9qIgRqQdgCaiIFIAUtAABBAWoiBToAACAFQf8BcSAFRw0BCwsgACAJIAZBEGogBkEMahAGIgQNAiABQRAgAUEQSRsiB0EBIAdBAUsbIQpBACEEA0AgACgC+AJFBEAgACAEakHoAmoiBSAFLQAAIAIgBGotAABzOgAACyADIARqIAIgBGotAAAgBkEQaiAEai0AAHMiBToAACAAKAL4AkEBRgRAIAAgBGpB6AJqIgsgCy0AACAFczoAAAsgBEEBaiIEIApHDQALIAAgCCAIEAggAyAHaiEDIAIgB2ohAiABIAdrIgENAAsLQQAhBAsgBkEgaiQAIwEjADYCACAEC/mDgIAAAgN/BH5BbCEEIAJBfGpBDE0EQCAAKQPAAiEGIAApA7gCIQcgASAAQcgCaiACEAMhBSAGQoMAhiIIIAdCgwCGIgmEUARAQQAPCyAAIAAtAOgCIAZCtQCIp3M6AOgCIABB6QJqIgEgAS0AACAGQq0AiKdzOgAAIABB6gJqIgEgAS0AACAGQqUAiKdzOgAAIABB6wJqIgEgAS0AACAGQp0AiKdzOgAAIABB7AJqIgEgAS0AACAGpyIBQRV2czoAACAAQe0CaiIDIAMtAAAgAUENdnM6AAAgAEHuAmoiAyADLQAAIAFBBXZzOgAAIABB7wJqIgEgAS0AACAIp3M6AAAgAEHwAmoiASABLQAAIAdCtQCIp3M6AAAgAEHxAmoiASABLQAAIAdCrQCIp3M6AAAgAEHyAmoiASABLQAAIAdCpQCIp3M6AAAgAEHzAmoiASABLQAAIAdCnQCIp3M6AAAgAEH0AmoiASABLQAAIAenIgFBFXZzOgAAIABB9QJqIgMgAy0AACABQQ12czoAACAAQfYCaiIDIAMtAAAgAUEFdnM6AAAgAEH3AmoiASABLQAAIAmnczoAACAAIABB6AJqIgEgARAIQQAhBEEAIQEDQCABIAVqIgMgAy0AACAAIAFqLQDoAnM6AAAgAUEBaiIBIAJHDQALCyAEC5mBgIAAAQF/IwEoAgBBEGsiCiQAIwEjADYCAAJAIAAgAiADIAQgBRAHIgINACAAIAEgCCAJEAkiAg0AIAAgCiAHEAoiAg0AQQAhAiAHRQ0AQQAhA0EAIQADQCADIAAgCmotAAAgACAGai0AAHNyIQMgAEEBaiIAIAdHDQALIANFDQAgCSABEAVBbiECCyAKQRBqJAAjASMANgIAIAILh4CAgAAAIwEoAgALjYCAgAAAIAAkACMBIwA2AgALmoCAgAAAIwEoAgAgAGtBcHEiACQAIwEjADYCACAACwvzg4CAAIiAgIAAAEGACAsSAgAAAAIAAAABAAAAgAAAAAgFAEGcCAsWEAAAABQFAAADAAAAAQAAAMAAAAAsBQBBvAgLFhAAAAAUBQAABAAAAAEAAAAAAQAAOAUAQdwIC2YQAAAAFAUAAA4AAAAGAAAAgAAAAEQFAAAMAAAAAQAAABAAAABQBQAADwAAAAYAAADAAAAAaAUAAAwAAAABAAAAEAAAAFAFAAAQAAAABgAAAAABAAB0BQAADAAAAAEAAAAQAAAAUAUAQdAJCy4CAAAABAQAAAMAAAAkBAAABAAAAEQEAAAOAAAAZAQAAA8AAACEBAAAEAAAAKQEAEGICgt3QUVTLTEyOC1FQ0IAAgAAAAMAAAAEAAAABQAAAAYAAAAHAAAAQUVTLTE5Mi1FQ0IAQUVTLTI1Ni1FQ0IAQUVTLTEyOC1HQ00AAgAAAAAAAAAIAAAACAAAAAkAAAAKAAAAQUVTLTE5Mi1HQ00AQUVTLTI1Ni1HQ00AQYgLC3IgHAAAAAAAAEA4AAAAAAAAYCQAAAAAAACAcAAAAAAAAKBsAAAAAAAAwEgAAAAAAADgVAAAAAAAAADhAAAAAAAAIP0AAAAAAABA2QAAAAAAAGDFAAAAAAAAgJEAAAAAAACgjQAAAAAAAMCpAAAAAAAA4LUAQYAMCwOALFA=","AGFzbQEAAAABmICAgACEgICAAGADf39/AX9gAX8AYAF/AX9gAAACxoCAgACCgICAAANlbnYfZW1zY3JpcHRlbl9ub3RpZnlfbWVtb3J5X2dyb3d0aAABCV93YXNtX2RlcAlfbWVtb3J5XzACAYACgIACA5GAgIAAjICAgAADAAICAwICAAIBAQIEhYCAgACAgICAAAWFgICAAICAgIAABpeAgIAAg4CAgAB/AUEAC38AQZAMC38AQYDZAAsH94CAgACIgICAAAZtYWxsb2MACQRmcmVlAAsEc2JyawAECl9fZGF0YV9lbmQDAhBfd2FzbV9kZXBfZnVuY18xAAEQX3dhc21fZGVwX2Z1bmNfNAACEV93YXNtX2RlcF9mdW5jXzE1AAoRX3dhc21fZGVwX2Z1bmNfMTcADAmFgICAAICAgIAACsaTgIAAjICAgACSgICAAABBgNnAAiQAIwEjADYCABAFC/SCgIAAAgJ/AX4CQCACRQ0AIAAgAmoiA0F/aiABOgAAIAAgAToAACACQQNJDQAgA0F+aiABOgAAIAAgAToAASADQX1qIAE6AAAgACABOgACIAJBB0kNACADQXxqIAE6AAAgACABOgADIAJBCUkNACAAQQAgAGtBA3EiBGoiAyABQf8BcUGBgoQIbCIBNgIAIAMgAiAEa0F8cSIEaiICQXxqIAE2AgAgBEEJSQ0AIAMgATYCCCADIAE2AgQgAkF4aiABNgIAIAJBdGogATYCACAEQRlJDQAgAyABNgIYIAMgATYCFCADIAE2AhAgAyABNgIMIAJBcGogATYCACACQWxqIAE2AgAgAkFoaiABNgIAIAJBZGogATYCACAEIANBBHFBGHIiBGsiAkEgSQ0AIAGtIgVCoACGIAWEIQUgAyAEaiEBA0AgASAFNwMYIAEgBTcDECABIAU3AwggASAFNwMAIAFBIGohASACQWBqIgJBH0sNAAsLIAALo4CAgAAAIAA/AEEQdGtB//8DakEQdkAAQX9GBEBBAA8LQQAQAEEBC9KAgIAAAQJ/QYAMKAIAIgEgAEEDakF8cSICaiEAAkAgAkEBTkEAIAAgAU0bDQAgAD8AQRB0SwRAIAAQA0UNAQtBgAwgADYCACABDwtBoAxBMDYCAEF/C7qAgIAAAQN/A0AgAEEEdCIBQbQMaiABQbAMaiICNgIAIAFBuAxqIAI2AgAgAEEBaiIAQcAARw0AC0EwEAYaC7yEgIAAAQZ/IAAQBCIDQQFOBEBBECECIAAgA2oiBEFwaiIBQRA2AgwgAUEQNgIAAkACQAJAQbAUKAIAIgBFDQAgAyAAKAIIRw0AIAMgA0F8aigCACICQR91IAJzayIGQXxqKAIAIQUgACAENgIIQXAhAiAGIAUgBUEfdXNrIgAgACgCAGpBfGooAgBBf0oNASAAKAIEIgIgACgCCDYCCCAAKAIIIAI2AgQgACABIABrIgE2AgAgAUF8cSAAakF8aiABQX9zNgIAIAACfyAAKAIAQXhqIgFB/wBNBEAgAUEDdkF/agwBCyABZyECIAFBHSACa3ZBBHMgAkECdGtB7gBqIAFB/x9NDQAaIAFBHiACa3ZBAnMgAkEBdGtBxwBqIgFBPyABQT9JGwsiAUEEdCICQbAMajYCBCAAIAJBuAxqIgIoAgA2AggMAgsgA0EQNgIMIANBEDYCACADIAQ2AgggAyAANgIEQbAUIAM2AgALIAIgA2oiACABIABrIgE2AgAgAUF8cSAAakF8aiABQX9zNgIAIAACfyAAKAIAQXhqIgFB/wBNBEAgAUEDdkF/agwBCyABZyECIAFBHSACa3ZBBHMgAkECdGtB7gBqIAFB/x9NDQAaIAFBHiACa3ZBAnMgAkEBdGtBxwBqIgFBPyABQT9JGwsiAUEEdCICQbAMajYCBCAAIAJBuAxqIgIoAgA2AggLIAIgADYCACAAKAIIIAA2AgRBuBRBuBQpAwBCgQAgAa2GhDcDAAsgA0EASgvtg4CAAAIGfwJ+QQghBAJAAkADQCAEIARBf2pxDQEgBEEIIARBCEsbIQRBuBQpAwAiCAJ/IABBA2pBfHFBCCAAQQhLGyIAQf8ATQRAIABBA3ZBf2oMAQsgAEEdIABnIgJrdkEEcyACQQJ0a0HuAGogAEH/H00NABogAEEeIAJrdkECcyACQQF0a0HHAGoiAkE/IAJBP0kbCyICrYgiB1BFBEADQCAHIAd6IgiIIQcCfiACIAinaiICQQR0IgNBuAxqKAIAIgEgA0GwDGoiBkcEQCABIAQgABAIIgUNBiABKAIEIgUgASgCCDYCCCABKAIIIAU2AgQgASAGNgIIIAEgA0G0DGoiAygCADYCBCADIAE2AgAgASgCBCABNgIIIAJBAWohAiAHQoEAiAwBC0G4FEG4FCkDAEL+fyACrYmDNwMAIAdCgQCFCyIHQoAAUg0AC0G4FCkDACEIC0E/IAh5p2tBBHQiAUGwDGohAyABQbgMaigCACEBAkAgCEKAgICABFQNAEHjACECIAEgA0YNAANAIAJFDQEgASAEIAAQCCIFDQQgAkF/aiECIAEoAggiASADRw0ACyADIQELIABBMGoQBg0ACyABIANGDQADQCABIAQgABAIIgUNAiABKAIIIgEgA0cNAAsLQQAhBQsgBQuog4CAAAEDfyABIABBBGoiBGpBf2pBACABa3EiBSACaiAAIAAoAgAiAWpBfGpNBH8gACgCBCIDIAAoAgg2AgggACgCCCADNgIEIAQgBUcEQCAAIABBfGooAgAiA0EfdSADc2siAyAFIARrIgQgAygCAGoiBTYCACAFQXxxIANqQXxqIAU2AgAgACAEaiIAIAEgBGsiATYCAAsCQCACQRhqIAFNBEAgACACakEIaiIDIAEgAmsiAUF4aiIENgIAIARBfHEgA2pBfGpBByABazYCACADAn8gAygCAEF4aiIBQf8ATQRAIAFBA3ZBf2oMAQsgAWchBCABQR0gBGt2QQRzIARBAnRrQe4AaiABQf8fTQ0AGiABQR4gBGt2QQJzIARBAXRrQccAaiIBQT8gAUE/SRsLIgFBBHQiBEGwDGo2AgQgAyAEQbgMaiIEKAIANgIIIAQgAzYCACADKAIIIAM2AgRBuBRBuBQpAwBCgQAgAa2GhDcDACAAIAJBCGoiAjYCACACQXxxIABqQXxqIAI2AgAMAQsgACABakF8aiABNgIACyAAQQRqBSADCwuGgICAAAAgABAHC9mCgIAAAQV/IAAEQCAAQXxqIgMoAgAiBCEBIAMhAiAAQXhqKAIAIgBBf0wEQCAAIANqIgIoAgUiASACQQlqIgUoAgA2AgggBSgCACABNgIEIAQgAEF/c2ohASACQQFqIQILIAMgBGoiACgCACIDIAAgA2pBfGooAgBHBEAgACgCBCIEIAAoAgg2AgggACgCCCAENgIEIAEgA2ohAQsgAiABNgIAIAFBfHEgAmpBfGogAUF/czYCACACAn8gAigCAEF4aiIBQf8ATQRAIAFBA3ZBf2oMAQsgAWchACABQR0gAGt2QQRzIABBAnRrQe4AaiABQf8fTQ0AGiABQR4gAGt2QQJzIABBAXRrQccAaiIBQT8gAUE/SRsLIgFBBHQiAEGwDGo2AgQgAiAAQbgMaiIAKAIANgIIIAAgAjYCACACKAIIIAI2AgRBuBRBuBQpAwBCgQAgAa2GhDcDAAsLhoCAgAAAIAAQCguagICAAAEBfyAAIgEQByIABEAgAEEAIAEQAhoLIAALC4WAgIAAgICAgAA=","AGFzbQEAAAABmICAgACDgICAAGAEf39/fwF/YAN/f38AYAJ/fwACtYCAgACCgICAAAlfd2FzbV9kZXAIX2Z1bmNfMTgAAglfd2FzbV9kZXAJX21lbW9yeV8wAgGAAoCAAgOJgICAAISAgIAAAQEAAASFgICAAICAgIAABYWAgIAAgICAgAAGkICAgACCgICAAH8BQQALfwBBkAwLB5mAgIAAgYCAgAARX3dhc21fZGVwX2Z1bmNfMjQABAmFgICAAICAgIAACsqcgIAAhICAgACHjoCAAAERfyMBKAIAQTBrIgMkACMBIwA2AgAgACgCBCEFIAMgASgAACIENgIoIAMgBCAFKAIAcyIENgIoIAMgASgABCAFKAIEcyIHNgIkIAMgASgACCAFKAIIcyIINgIgIAEoAAwhBiADIAVBEGoiATYCLCADIAYgBSgCDHMiBTYCHCAAKAIAIgBBBE4EQCAAQQF2IQsDQCAHQRZ2QfwHcUGAzwBqKAIAIARBDnZB/AdxQYDHAGooAgAgBUEGdkH8B3FBgD9qKAIAIAhB/wFxQQJ0QYA3aigCACABKAIIc3NzcyIKQRZ2QfwHcUGAzwBqKAIAIARBFnZB/AdxQYDPAGooAgAgBUEOdkH8B3FBgMcAaigCACAIQQZ2QfwHcUGAP2ooAgAgB0H/AXFBAnRBgDdqKAIAIAEoAgRzc3NzIglBDnZB/AdxQYDHAGooAgAgBUEWdkH8B3FBgM8AaigCACAIQQ52QfwHcUGAxwBqKAIAIAdBBnZB/AdxQYA/aigCACAEQf8BcUECdEGAN2ooAgAgASgCAHNzc3MiBkEGdkH8B3FBgD9qKAIAIAhBFnZB/AdxQYDPAGooAgAgB0EOdkH8B3FBgMcAaigCACAEQQZ2QfwHcUGAP2ooAgAgBUH/AXFBAnRBgDdqKAIAIAEoAgxzc3NzIgBB/wFxQQJ0QYA3aigCACABKAIcc3NzcyEFIAlBFnZB/AdxQYDPAGooAgAgBkEOdkH8B3FBgMcAaigCACAAQQZ2QfwHcUGAP2ooAgAgCkH/AXFBAnRBgDdqKAIAIAEoAhhzc3NzIQggBkEWdkH8B3FBgM8AaigCACAAQQ52QfwHcUGAxwBqKAIAIApBBnZB/AdxQYA/aigCACAJQf8BcUECdEGAN2ooAgAgASgCFHNzc3MhByAAQRZ2QfwHcUGAzwBqKAIAIApBDnZB/AdxQYDHAGooAgAgCUEGdkH8B3FBgD9qKAIAIAZB/wFxQQJ0QYA3aigCACABKAIQc3NzcyEEIAFBIGohASALQQJKIQwgC0F/aiELIAwNAAsgAyAJNgIUIAMgBjYCGCADIAo2AhAgAyAANgIMIAMgBDYCKCADIAc2AiQgAyAINgIgIAMgBTYCHCADIAE2AiwLIAMgBUEWdkH8B3FBgM8AaigCACAIQQ52QfwHcUGAxwBqKAIAIAdBBnZB/AdxQYA/aigCACAEQf8BcUECdEGAN2ooAgAgASgCAHNzc3MiADYCGCADIARBFnZB/AdxQYDPAGooAgAgBUEOdkH8B3FBgMcAaigCACAIQQZ2QfwHcUGAP2ooAgAgB0H/AXFBAnRBgDdqKAIAIAEoAgRzc3NzIgY2AhQgAyAHQRZ2QfwHcUGAzwBqKAIAIARBDnZB/AdxQYDHAGooAgAgBUEGdkH8B3FBgD9qKAIAIAhB/wFxQQJ0QYA3aigCACABKAIIc3NzcyIJNgIQIAMgCEEWdkH8B3FBgM8AaigCACAHQQ52QfwHcUGAxwBqKAIAIARBBnZB/AdxQYA/aigCACAFQf8BcUECdEGAN2ooAgAgASgCDHNzc3MiBDYCDCADIAEoAhAgAEH/AXFBgBVqLQAAcyIHIAZBCHZB/wFxQYAVai0AAEEIdHMiCCAJQRB2Qf8BcUGAFWotAABBEHRzIgUgBEEYdkGAFWotAABBGHRzIgo2AiggAyABKAIUIAZB/wFxQYAVai0AAHMiCyAJQQh2Qf8BcUGAFWotAABBCHRzIgwgBEEQdkH/AXFBgBVqLQAAQRB0cyIRIABBGHZBgBVqLQAAQRh0cyISNgIkIAZBGHZBgBVqLQAAIQ0gAEEQdkH/AXFBgBVqLQAAIQ4gBEEIdkH/AXFBgBVqLQAAIQ8gCUH/AXFBgBVqLQAAIRAgASgCGCETIAMgAUEgajYCLCADIA9BCHQgECATcyIPcyIQIA5BEHRzIg4gDUEYdHMiDTYCICADIAEoAhwgBEH/AXFBgBVqLQAAcyIBIABBCHZB/wFxQYAVai0AAEEIdHMiBCAGQRB2Qf8BcUGAFWotAABBEHRzIgAgCUEYdkGAFWotAABBGHRzIgY2AhwgAiAAQRB2OgAOIAIgBEEIdjoADSACIAE6AAwgAiANQRh2OgALIAIgDkEQdjoACiACIBBBCHY6AAkgAiAPOgAIIAIgEkEYdjoAByACIBFBEHY6AAYgAiAMQQh2OgAFIAIgCzoABCACIApBGHY6AAMgAiAFQRB2OgACIAIgCEEIdjoAASACIAc6AAAgAiAGQRh2OgAPIANBKGpBBBAAIANBJGpBBBAAIANBIGpBBBAAIANBHGpBBBAAIANBGGpBBBAAIANBFGpBBBAAIANBEGpBBBAAIANBDGpBBBAAIANBLGpBBBAAIANBMGokACMBIwA2AgAL/42AgAABEX8jASgCAEEwayIDJAAjASMANgIAIAAoAgQhBSADIAEoAAAiBDYCKCADIAQgBSgCAHMiBDYCKCADIAEoAAQgBSgCBHMiBzYCJCADIAEoAAggBSgCCHMiCDYCICABKAAMIQYgAyAFQRBqIgE2AiwgAyAGIAUoAgxzIgU2AhwgACgCACIAQQROBEAgAEEBdiELA0AgB0EWdkH8B3FBgC9qKAIAIAhBDnZB/AdxQYAnaigCACAFQQZ2QfwHcUGAH2ooAgAgBEH/AXFBAnRBgBdqKAIAIAEoAgBzc3NzIgpBFnZB/AdxQYAvaigCACAIQRZ2QfwHcUGAL2ooAgAgBUEOdkH8B3FBgCdqKAIAIARBBnZB/AdxQYAfaigCACAHQf8BcUECdEGAF2ooAgAgASgCBHNzc3MiCUEOdkH8B3FBgCdqKAIAIAVBFnZB/AdxQYAvaigCACAEQQ52QfwHcUGAJ2ooAgAgB0EGdkH8B3FBgB9qKAIAIAhB/wFxQQJ0QYAXaigCACABKAIIc3NzcyIGQQZ2QfwHcUGAH2ooAgAgBEEWdkH8B3FBgC9qKAIAIAdBDnZB/AdxQYAnaigCACAIQQZ2QfwHcUGAH2ooAgAgBUH/AXFBAnRBgBdqKAIAIAEoAgxzc3NzIgBB/wFxQQJ0QYAXaigCACABKAIcc3NzcyEFIABBFnZB/AdxQYAvaigCACAKQQ52QfwHcUGAJ2ooAgAgCUEGdkH8B3FBgB9qKAIAIAZB/wFxQQJ0QYAXaigCACABKAIYc3NzcyEIIAZBFnZB/AdxQYAvaigCACAAQQ52QfwHcUGAJ2ooAgAgCkEGdkH8B3FBgB9qKAIAIAlB/wFxQQJ0QYAXaigCACABKAIUc3NzcyEHIAlBFnZB/AdxQYAvaigCACAGQQ52QfwHcUGAJ2ooAgAgAEEGdkH8B3FBgB9qKAIAIApB/wFxQQJ0QYAXaigCACABKAIQc3NzcyEEIAFBIGohASALQQJKIQwgC0F/aiELIAwNAAsgAyAJNgIUIAMgCjYCGCADIAY2AhAgAyAANgIMIAMgBDYCKCADIAc2AiQgAyAINgIgIAMgBTYCHCADIAE2AiwLIAMgB0EWdkH8B3FBgC9qKAIAIAhBDnZB/AdxQYAnaigCACAFQQZ2QfwHcUGAH2ooAgAgBEH/AXFBAnRBgBdqKAIAIAEoAgBzc3NzIgA2AhggAyAIQRZ2QfwHcUGAL2ooAgAgBUEOdkH8B3FBgCdqKAIAIARBBnZB/AdxQYAfaigCACAHQf8BcUECdEGAF2ooAgAgASgCBHNzc3MiBjYCFCADIAVBFnZB/AdxQYAvaigCACAEQQ52QfwHcUGAJ2ooAgAgB0EGdkH8B3FBgB9qKAIAIAhB/wFxQQJ0QYAXaigCACABKAIIc3NzcyIJNgIQIAMgBEEWdkH8B3FBgC9qKAIAIAdBDnZB/AdxQYAnaigCACAIQQZ2QfwHcUGAH2ooAgAgBUH/AXFBAnRBgBdqKAIAIAEoAgxzc3NzIgQ2AgwgAyABKAIQIABB/wFxQYDXAGotAABzIgcgBEEIdkH/AXFBgNcAai0AAEEIdHMiCCAJQRB2Qf8BcUGA1wBqLQAAQRB0cyIFIAZBGHZBgNcAai0AAEEYdHMiCjYCKCADIAEoAhQgBkH/AXFBgNcAai0AAHMiCyAAQQh2Qf8BcUGA1wBqLQAAQQh0cyIMIARBEHZB/wFxQYDXAGotAABBEHRzIhEgCUEYdkGA1wBqLQAAQRh0cyISNgIkIARBGHZBgNcAai0AACENIABBEHZB/wFxQYDXAGotAAAhDiAGQQh2Qf8BcUGA1wBqLQAAIQ8gCUH/AXFBgNcAai0AACEQIAEoAhghEyADIAFBIGo2AiwgAyAPQQh0IBAgE3MiD3MiECAOQRB0cyIOIA1BGHRzIg02AiAgAyABKAIcIARB/wFxQYDXAGotAABzIgEgCUEIdkH/AXFBgNcAai0AAEEIdHMiBCAGQRB2Qf8BcUGA1wBqLQAAQRB0cyIGIABBGHZBgNcAai0AAEEYdHMiADYCHCACIAZBEHY6AA4gAiAEQQh2OgANIAIgAToADCACIA1BGHY6AAsgAiAOQRB2OgAKIAIgEEEIdjoACSACIA86AAggAiASQRh2OgAHIAIgEUEQdjoABiACIAxBCHY6AAUgAiALOgAEIAIgCkEYdjoAAyACIAVBEHY6AAIgAiAIQQh2OgABIAIgBzoAACACIABBGHY6AA8gA0EoakEEEAAgA0EkakEEEAAgA0EgakEEEAAgA0EcakEEEAAgA0EYakEEEAAgA0EUakEEEAAgA0EQakEEEAAgA0EMakEEEAAgA0EsakEEEAAgA0EwaiQAIwEjADYCAAufgICAAAAgAUEBRgRAIAAgAiADEAFBAA8LIAAgAiADEAJBAAuMgICAAAAgACABIAIgAxADCwuFgICAAICAgIAA","AGFzbQEAAAABrICAgACHgICAAGADf39/AX9gAX8AYAABf2ABfwF/YAR/f39/AX9gAn9/AX9gAn9/AAKggYCAAIeAgIAACV93YXNtX2RlcAdfZnVuY180AAAJX3dhc21fZGVwCF9mdW5jXzE1AAEJX3dhc21fZGVwCF9mdW5jXzE3AAMJX3dhc21fZGVwCF9mdW5jXzE4AAYJX3dhc21fZGVwCF9mdW5jXzM2AAQJX3dhc21fZGVwCV9tZW1vcnlfMAIBgAKAgAIJX3dhc21fZGVwCF90YWJsZV8wAXABCwsDkYCAgACMgICAAAAAAAACAQAFAQUABASFgICAAICAgIAABYWAgIAAgICAgAAGkICAgACCgICAAH8BQQALfwBBkAwLB5GBgIAAh4CAgAARX3dhc21fZGVwX2Z1bmNfMjUABxFfd2FzbV9kZXBfZnVuY18yNgAIEV93YXNtX2RlcF9mdW5jXzI3AAkRX3dhc21fZGVwX2Z1bmNfMjgAChFfd2FzbV9kZXBfZnVuY18yOQALEV93YXNtX2RlcF9mdW5jXzMzAA0RX3dhc21fZGVwX2Z1bmNfMzgAEAmFgICAAICAgIAACpacgIAAjICAgADCjICAAAEMfyMBKAIAQYAQayIHJAAjASMANgIAAkAgAAJ/QQogAkGAAUYNABogAkGAAkcEQEFgIQggAkHAAUcNAkEMDAELQQ4LIgk2AgBBwBQtAABFBEBBASEDA0AgByADQQJ0aiAENgIAIAdBgAhqIARBAnRqIAM2AgAgA0EYdEEfdUEbcSADQQF0Qf4BcSADc3MhAyAEQQFqIgRBgAJHDQALQfAUQpuAgIDgBjcDAEHoFELAgICAgBA3AwBB4BRCkICAgIAENwMAQdgUQoSAgICAATcDAEHQFEKBgICAoAA3AwBBgBVB4wA6AABB49cAQQA6AABBASEDA0AgA0GAFWpBACAHIANBAnRqKAIAa0ECdCAHakH8D2ooAgAiBCAEQQF0IARBB3ZyQf8BcSIEcyAEQQF0Qf4BcSIGIARBB3ZyIgRzIARBAXRB/gFxIgQgBkEHdnIiBnMgBkEBdEH+AXEgBEEHdnJzQeMAcyIEOgAAIARBgNcAaiADOgAAIANBAWoiA0GAAkcNAAtBACEGIAcoAiwhCiAHKAI0IQsgBygCJCEMIAcoAjghDQNAIAZBAnQiA0GAP2ogBkGAFWotAAAiBEEQdCAEQQh0ciAEQRh0QR91QRtxIARBAXRB/gFxcyIFciIIQQh0IAQgBXMiBXIiDjYCACADQYA3aiAFQRh0IAhyNgIAIANBgMcAaiAEIA5BCHRyIgU2AgAgA0GAzwBqIAQgBUEIdHI2AgBBACEEQQAhBSAGQYDXAGotAAAiCARAIAdBgAhqIAcgCEECdGooAgAiBSAMakH/AW9BAnRqKAIAQQh0IAdBgAhqIAUgDWpB/wFvQQJ0aigCAHMgB0GACGogBSALakH/AW9BAnRqKAIAQRB0cyEEIAdBgAhqIAUgCmpB/wFvQQJ0aigCACEFCyADQYAXaiAFQRh0IARzIgU2AgAgA0GAH2ogBEEIdCAFQRh2ciIENgIAIANBgCdqIARBCHc2AgAgA0GAL2ogBEEQdzYCACAGQQFqIgZBgAJHDQALQcAUQQE6AAALIAAgAEEIaiIDNgIEIAJBBXYiBQRAQQAhBgNAIAAgBkECdCIEaiABIARqLQAAIAEgBEEBcmotAABBCHRyIAEgBEECcmotAABBEHRyIAEgBEEDcmotAABBGHRyNgIIIAZBAWoiBiAFRw0ACwtBACEIAkACQAJAIAlBdmoOBQADAQMCAwsgAygCACEBQQAhBgNAIAMgAygCDCIEQQh2Qf8BcUGAFWotAAAgBkECdEHQFGooAgAgAXNzIARBEHZB/wFxQYAVai0AAEEIdHMgBEEYdkGAFWotAABBEHRzIARB/wFxQYAVai0AAEEYdHMiATYCECADIAEgAygCBHMiBTYCFCADIAMoAgggBXMiBTYCGCADIAQgBXM2AhwgA0EQaiEDIAZBAWoiBkEKRw0ACwwCCyADKAIAIQFBACEGA0AgAyADKAIUIgRBCHZB/wFxQYAVai0AACAGQQJ0QdAUaigCACABc3MgBEEQdkH/AXFBgBVqLQAAQQh0cyAEQRh2QYAVai0AAEEQdHMgBEH/AXFBgBVqLQAAQRh0cyIBNgIYIAMgASADKAIEcyIFNgIcIAMgAygCCCAFcyIFNgIgIAMgAygCDCAFcyIFNgIkIAMgAygCECAFcyIFNgIoIAMgBCAFczYCLCADQRhqIQMgBkEBaiIGQQhHDQALDAELIAMoAgAhBkEAIQUDQCADIAMoAhwiBEEIdkH/AXFBgBVqLQAAIAVBAnRB0BRqKAIAIAZzcyAEQRB2Qf8BcUGAFWotAABBCHRzIARBGHZBgBVqLQAAQRB0cyAEQf8BcUGAFWotAABBGHRzIgY2AiAgAyAGIAMoAgRzIgE2AiQgAyADKAIIIAFzIgE2AiggAyADKAIMIAFzIgE2AiwgAyADKAIQIAFB/wFxQYAVai0AAHMgAUEIdkH/AXFBgBVqLQAAQQh0cyABQRB2Qf8BcUGAFWotAABBEHRzIAFBGHZBgBVqLQAAQRh0cyIBNgIwIAMgASADKAIUcyIBNgI0IAMgAygCGCABcyIBNgI4IAMgASAEczYCPCADQSBqIQMgBUEBaiIFQQdHDQALCyAHQYAQaiQAIwEjADYCACAIC82FgIAAAQR/IwEoAgBBoAJrIgMkACMBIwA2AgAgA0EIakEAQZgCEAAaIAAgAEEIajYCBCADQQhqIAEgAhAFIgVFBEAgACADKAIIIgQ2AgAgACADKAIMIgYgBEEEdGoiAigCADYCCCAAIAIoAgQ2AgwgACACKAIINgIQIAAgAigCDDYCFCAAQRhqIQAgAkFwaiEBIARBAkgEfyACQRBqBQNAIAAgASgCACICQQh2Qf8BcUGAFWotAABBAnRBgB9qKAIAIAJB/wFxQYAVai0AAEECdEGAF2ooAgBzIAJBEHZB/wFxQYAVai0AAEECdEGAJ2ooAgBzIAJBGHZBgBVqLQAAQQJ0QYAvaigCAHM2AgAgACABKAIEIgJBCHZB/wFxQYAVai0AAEECdEGAH2ooAgAgAkH/AXFBgBVqLQAAQQJ0QYAXaigCAHMgAkEQdkH/AXFBgBVqLQAAQQJ0QYAnaigCAHMgAkEYdkGAFWotAABBAnRBgC9qKAIAczYCBCAAIAEoAggiAkEIdkH/AXFBgBVqLQAAQQJ0QYAfaigCACACQf8BcUGAFWotAABBAnRBgBdqKAIAcyACQRB2Qf8BcUGAFWotAABBAnRBgCdqKAIAcyACQRh2QYAVai0AAEECdEGAL2ooAgBzNgIIIAAgASgCDCICQQh2Qf8BcUGAFWotAABBAnRBgB9qKAIAIAJB/wFxQYAVai0AAEECdEGAF2ooAgBzIAJBEHZB/wFxQYAVai0AAEECdEGAJ2ooAgBzIAJBGHZBgBVqLQAAQQJ0QYAvaigCAHM2AgwgAUFwaiEBIABBEGohACAEQQJKIQIgBEF/aiEEIAINAAsgBiIBQSBqCyECIAAgASgCADYCACAAIAJBZGooAgA2AgQgACACQWhqKAIANgIIIAAgAkFsaigCADYCDAsgA0EIakGYAhADIANBoAJqJAAjASMANgIAIAULioCAgAAAIAAgASACEAULioCAgAAAIAAgASACEAYLmoCAgAABAX9BmAIQAiIABEAgAEEAQZgCEAAaCyAAC5aAgIAAAQF/IAAiAQRAIAFBmAIQAwsgABABC4yAgIAAACAAQQIgASACEBAL2ICAgAABA38CQEHUCSgCACICBEBB0AkhAwNAIAMhBAJAIAIoAhwoAgAgAEcNACACKAIIIAFHDQAgAigCBEEBRg0DCyAEQQhqIQMgBCgCDCICDQALC0EAIQILIAILqYCAgAABAX8gAARAIAAoAjQiAQRAIAEgACgCACgCHCgCFBEBAAsgAEE4EAMLC+2AgIAAAQF/IAFFBEBBgL5+DwsgAEKAADcCACAAQoAANwIwIABCgAA3AiggAEKAADcCICAAQoAANwIYIABCgAA3AhAgAEKAADcCCCAAIAEoAhwoAhARAgAiAjYCNCACRQRAQYC9fg8LIAAgATYCAEEAC86AgIAAAQF/AkAgACgCACIDRQ0AIAMtABRBAnFFBEAgAygCCCACRw0BCyAAQQE2AgggACACNgIEIAAoAjQgASACIAMoAhwoAggRAAAPC0GAvn4LuoaAgAACAn8QfiMBKAIAQSBrIgQkACMBIwA2AgBBbCEFAkAgASADEAwiAUUNACABKAIYQRBHDQAgABANIAAgARAOIgUNACAAIAIgAxAPIgUNACAEQoAANwMQIARCgAA3AxggBEEANgIMIAAgBEEQaiAEQRBqIARBDGoQBCIFRQRAIAQxAB8hCCAEMQAeIQYgBDEAGyELIAQxABohCSAEMQAZIQwgBDEAGCENIAQxAB0hDiAEMQAcIQ8gBDEAFyEKIAQxABYhByAEMQATIRAgBDEAEiERIAQxABEhEiAEMQAQIRMgBDEAFSEUIAQxABQhFSAAQoAANwO4ASAAQoAANwM4IAAgCiAUQpAAhiAVQpgAhoQgECASQpAAhiATQpgAhoQgEUKIAIaEhEKgAIaEIAdCiACGhIQiBzcD+AEgACAIIA5CkACGIA9CmACGhCALIAxCkACGIA1CmACGhCAJQogAhoSEQqAAhoQgBkKIAIaEhCIGNwN4IAAgB0KBAIgiCSAIQoEAg0KAgICAgICAgOF/foUiCzcD2AEgACAKQr8AhiAGQoEAiIQiCDcDWCAAIAlCvwCGIAhCgQCIhCIKNwNIIAAgC0KBAIgiDCAIQoEAg0KAgICAgICAgOF/foUiCTcDyAEgACAIIAqFIhA3A2ggAEFAayAMQr8AhiAKQoEAiIQiDDcDACAAIAkgC4UiETcD6AEgACAKQoEAg0KAgICAgICAgOF/fiAJQoEAiIUiDTcDwAEgACAKIAyFIg43A1AgACAIIAyFIhI3A2AgACAJIA2FIg83A9ABIAAgCyANhSITNwPgASAAIAcgDYU3A4ACIAAgCCAOhSINNwNwIAAgCyAPhSIUNwPwASAAIAcgCYU3A4gCIAAgBiAMhTcDgAEgACAGIAqFNwOIASAAIAcgD4U3A5ACIAAgBiAOhTcDkAEgACAHIAuFNwOYAiAAIAYgCIU3A5gBIAAgByAThTcDoAIgACAGIBKFNwOgASAAIAcgEYU3A6gCIAAgBiAQhTcDqAEgACAHIBSFNwOwAiAAIAYgDYU3A7ABCyAEQSBqJAAjASMANgIAIAUPCyAEQSBqJAAjASMANgIAIAULC4WAgIAAgICAgAA=","AGFzbQEAAAABqYCAgACHgICAAGADf39/AX9gAX8AYAABf2ABfwF/YAR/f39/AX9gAABgAn9/AAKsgoCAAI6AgIAACV93YXNtX2RlcAdfZnVuY18xAAUJX3dhc21fZGVwB19mdW5jXzQAAAlfd2FzbV9kZXAIX2Z1bmNfMTUAAQlfd2FzbV9kZXAIX2Z1bmNfMTcAAwlfd2FzbV9kZXAIX2Z1bmNfMTgABglfd2FzbV9kZXAIX2Z1bmNfMjQABAlfd2FzbV9kZXAIX2Z1bmNfMjUAAAlfd2FzbV9kZXAIX2Z1bmNfMjYAAAlfd2FzbV9kZXAIX2Z1bmNfMjcAAglfd2FzbV9kZXAIX2Z1bmNfMjgAAQlfd2FzbV9kZXAIX2Z1bmNfMjkAAAlfd2FzbV9kZXAIX2Z1bmNfMzMAAQlfd2FzbV9kZXAIX2Z1bmNfMzgABAlfd2FzbV9kZXAIX3RhYmxlXzABcAELCwOJgICAAISAgIAAAgEBAQSFgICAAICAgIAABYWAgIAAgICAgAAGhYCAgACAgICAAAfqgICAAIWAgIAAGV9faW5kaXJlY3RfZnVuY3Rpb25fdGFibGUBABBtYmVkdGxzX2djbV9pbml0AA8SbWJlZHRsc19nY21fc2V0a2V5AAwQbWJlZHRsc19nY21fZnJlZQAQC19pbml0aWFsaXplAAAJlICAgACBgICAAABBAQsKAAEFBgcICQoNDgrVgICAAISAgIAAlICAgAABAX9BgAMQAyIABEAgABAPCyAAC4qAgIAAACAAEBAgABACC4yAgIAAACAAQQBBgAMQARoLkoCAgAAAIAAEQCAAEAsgAEGAAxAECwsLhYCAgACAgICAAA=="]}')},function(e,t,n){"use strict";n(69),n(35),n(122),n(165),Object.defineProperty(t,"__esModule",{value:!0}),t.cookieSet=function(e,t,n){o(e);var r=new Date;r.setTime(r.getTime()+24*n*60*60*1e3);var i="expires="+r.toUTCString();document.cookie=e+"="+t+"; "+i+A},t.cookieGet=function(e){for(var t=e+"=",n="",A=0,o=document.cookie.split(";"),i=0;i<o.length;i++){for(var a=o[i];" "===a.charAt(0);)a=a.substring(1);0===a.indexOf(t)&&(n=a.substring(t.length,a.length),A++)}A>1&&r.updateCounter("Siege:Csd:DuplicateCookieDetected",1);return n},t.cookieDelete=o;var r=new(n(28).Logger),A="; path=/"+("https:"===window.location.protocol?"; secure":"");function o(e){document.cookie=e+"=; expires=Thu, 01 Jan 1970 00:00:01 GMT"+A,document.cookie=e+"=; expires=Thu, 01 Jan 1970 00:00:01 GMT; domain="+location.hostname+A}},function(e,t,n){"use strict";function r(e,t,n,r,A,o,i){try{var a=e[o](i),u=a.value}catch(c){return void n(c)}a.done?t(u):Promise.resolve(u).then(r,A)}function A(e){return function(){var t=this,n=arguments;return new Promise((function(A,o){var i=e.apply(t,n);function a(e){r(i,A,o,a,u,"next",e)}function u(e){r(i,A,o,a,u,"throw",e)}a(undefined)}))}}n(16),n(71),n(7),n(12),n(74),n(75),n(76),n(77),n(78),n(79),n(80),n(81),n(82),n(83),n(84),n(85),n(86),n(87),n(88),n(89),n(90),n(91),n(92),n(93),n(94),n(95),n(96),n(97),Object.defineProperty(t,"__esModule",{value:!0}),t.rsaGenerateKey=function(){return u.apply(this,arguments)},t.rsaImportKey=function(e){return c.apply(this,arguments)},t.rsaWrap=function(e,t){return s.apply(this,arguments)},t.rsaUnwrap=function(e,t,n,r,A){return f.apply(this,arguments)},n(18);var o="RSA-OAEP",i=new Uint8Array([1,0,1]),a=["encrypt","decrypt"];function u(){return(u=A(regeneratorRuntime.mark((function e(){var t,n,r=arguments;return regeneratorRuntime.wrap((function(e){for(;;)switch(e.prev=e.next){case 0:return t=r.length>0&&r[0]!==undefined&&r[0],n=r.length>1&&r[1]!==undefined?r[1]:a,e.abrupt("return",crypto.subtle.generateKey({name:o,modulusLength:2048,publicExponent:i,hash:"SHA-256"},t,n));case 3:case"end":return e.stop()}}),e)})))).apply(this,arguments)}function c(){return(c=A(regeneratorRuntime.mark((function e(t){var n,r,A=arguments;return regeneratorRuntime.wrap((function(e){for(;;)switch(e.prev=e.next){case 0:return n=A.length>1&&A[1]!==undefined&&A[1],r=A.length>2&&A[2]!==undefined?A[2]:a,e.abrupt("return",crypto.subtle.importKey("jwk",t,{name:o,hash:"SHA-256"},n,r));case 3:case"end":return e.stop()}}),e)})))).apply(this,arguments)}function s(){return(s=A(regeneratorRuntime.mark((function e(t,n){var r;return regeneratorRuntime.wrap((function(e){for(;;)switch(e.prev=e.next){case 0:return r={name:o,hash:{name:"SHA-256"}},e.abrupt("return",crypto.subtle.wrapKey("raw",n,t,r));case 2:case"end":return e.stop()}}),e)})))).apply(this,arguments)}function f(){return(f=A(regeneratorRuntime.mark((function e(t,n,r,A,i){var a;return regeneratorRuntime.wrap((function(e){for(;;)switch(e.prev=e.next){case 0:return a={name:o,hash:{name:"SHA-256"}},e.abrupt("return",crypto.subtle.unwrapKey("raw",n,t,a,r,i,A));case 2:case"end":return e.stop()}}),e)})))).apply(this,arguments)}},function(e,t,n){"use strict";function r(e,t){for(var n=0;n<t.length;n++){var r=t[n];r.enumerable=r.enumerable||!1,r.configurable=!0,"value"in r&&(r.writable=!0),Object.defineProperty(e,r.key,r)}}function A(e){if(function(e){if(o(e))return"SCRIPT"===e.tagName;return!1}(e)){if(!e.parentNode)throw new Error("Script element has no parent node");e.parentNode.replaceChild(function(e){var t=document.createElement("script");t.text=e.innerHTML;for(var n=e.attributes.length-1;n>=0;n--)t.setAttribute(e.attributes[n].name,e.attributes[n].value);return t}(e),e)}else for(var t=0,n=e.childNodes;t<n.length;)A(n[t++]);return e}function o(e){return e.nodeType===e.ELEMENT_NODE}n(119),n(17),Object.defineProperty(t,"__esModule",{value:!0}),t.NodeDisplay=void 0;var i=function(){function e(){!function(e,t){if(!(e instanceof t))throw new TypeError("Cannot call a class as a function")}(this,e)}var t,n,i;return t=e,(n=[{key:"display",value:function(e,t){var n='<span id="siege-csd-replacement-start"></span>'.concat(t,'<span id="siege-csd-replacement-end"></span>'),r=e.parentNode;if(!r)throw new Error("Element to be replaced does not have parent node");e.outerHTML=n;for(var i=r.childNodes,a=[],u=!1,c=[],s=0;s<i.length;s++){var f=i[s];if(o(f))if(u){if("siege-csd-replacement-end"===f.id){c.push(f);break}a.push(f)}else"siege-csd-replacement-start"===f.id&&(c.push(f),u=!0)}for(var g=0,l=c;g<l.length;g++){var d=l[g];d.parentNode.removeChild(d)}for(var p=0,y=a;p<y.length;p++)A(y[p])}}])&&r(t.prototype,n),i&&r(t,i),e}();t.NodeDisplay=i},function(e,t,n){"use strict";n(17),n(7),n(12),Object.defineProperty(t,"__esModule",{value:!0}),t.CompatibilityValidator=void 0,n(18);var r=n(126),A=n(127),o=n(123),i=n(174),a=n(175),u=n(168);function c(e,t,n,r,A,o,i){try{var a=e[o](i),u=a.value}catch(c){return void n(c)}a.done?t(u):Promise.resolve(u).then(r,A)}function s(e){return function(){var t=this,n=arguments;return new Promise((function(r,A){var o=e.apply(t,n);function i(e){c(o,r,A,i,a,"next",e)}function a(e){c(o,r,A,i,a,"throw",e)}i(undefined)}))}}function f(e,t){for(var n=0;n<t.length;n++){var r=t[n];r.enumerable=r.enumerable||!1,r.configurable=!0,"value"in r&&(r.writable=!0),Object.defineProperty(e,r.key,r)}}function g(e,t,n){return t in e?Object.defineProperty(e,t,{value:n,enumerable:!0,configurable:!0,writable:!0}):e[t]=n,e}var l=function(){function e(){!function(e,t){if(!(e instanceof t))throw new TypeError("Cannot call a class as a function")}(this,e),g(this,"TEST_TEXT","Test crypto capabilites"),g(this,"KEY_ID_PREFIX","TEST_KEY"),g(this,"storage",new a.LocalStorage),g(this,"keyCache",new i.KeyCache(this.storage))}var t,n,c,l,d,p,y,h;return t=e,(n=[{key:"assertEncryptDecrypt",value:(h=s(regeneratorRuntime.mark((function I(e){var t,n,r;return regeneratorRuntime.wrap((function(o){for(;;)switch(o.prev=o.next){case 0:return t=new A.AesWasmCrypto(this.keyCache),o.next=3,t.encrypt(e,this.TEST_TEXT);case 3:if(n=o.sent,r=t.decrypt(n),n){o.next=7;break}throw new Error("Browser could not encrypt the payload");case 7:if(r===this.TEST_TEXT){o.next=9;break}throw new Error("Decryption payload does not match the original text when encrypting with a random key");case 9:case"end":return o.stop()}}),I,this)}))),function(e){return h.apply(this,arguments)})},{key:"validateAesCrypto",value:(y=s(regeneratorRuntime.mark((function C(){var e,t;return regeneratorRuntime.wrap((function(n){for(;;)switch(n.prev=n.next){case 0:return e=this.KEY_ID_PREFIX+(0,u.generateUid)(),n.next=3,(0,r.aesGenerateKey)();case 3:return t=n.sent,this.storage.put(e,t),n.prev=5,n.next=8,this.assertEncryptDecrypt(e);case 8:return n.prev=8,this.storage.removeKeys([e]),n.finish(8);case 11:case"end":return n.stop()}}),C,this,[[5,,8,11]])}))),function(){return y.apply(this,arguments)})},{key:"validateLibUsageUsingCryptoEngine",value:(p=s(regeneratorRuntime.mark((function B(){var e;return regeneratorRuntime.wrap((function(t){for(;;)switch(t.prev=t.next){case 0:return t.next=2,(0,u.encryptPayloadWithActiveKey)(this.TEST_TEXT);case 2:if(e=t.sent,(0,o.getCryptoEngineSingleton)().decrypt(e)===this.TEST_TEXT){t.next=7;break}throw new Error("Decryption payload doesn't match the original text");case 7:case"end":return t.stop()}}),B,this)}))),function(){return p.apply(this,arguments)})},{key:"validateBeforeInstall",value:(d=s(regeneratorRuntime.mark((function E(){return regeneratorRuntime.wrap((function(e){for(;;)switch(e.prev=e.next){case 0:return e.next=2,this.validateAesCrypto();case 2:case"end":return e.stop()}}),E,this)}))),function(){return d.apply(this,arguments)})},{key:"validateAfterInstall",value:(l=s(regeneratorRuntime.mark((function v(){return regeneratorRuntime.wrap((function(e){for(;;)switch(e.prev=e.next){case 0:return e.next=2,this.validateLibUsageUsingCryptoEngine();case 2:case"end":return e.stop()}}),v,this)}))),function(){return l.apply(this,arguments)})}])&&f(t.prototype,n),c&&f(t,c),e}();t.CompatibilityValidator=l},function(e,t,n){"use strict";Object.defineProperty(t,"__esModule",{value:!0}),t.reloadPage=function(){window.location.reload()}},function(e,t,n){"use strict";n(35),n(7),n(45),Object.defineProperty(t,"__esModule",{value:!0}),t.resetDecryptionCounter=function(){A=1},t.decryptInPlace=function(e,t,n,o,i,a){1===A&&(n.startTimer("Decrypt:Overall"),n.startTimer("Decrypt:FromStartToSecondPayload"));if(n.startTimer("Decrypt:Payload:"+A.toString()),n.incrementCounter("Siege:Csd:Decrypt:Payloads"),1===A)try{(0,r.cookieManagerGet)().kid!==t.kid&&n.incrementCounter("Siege:Csd:Decrypt:UsingNonActiveKey",1)}catch(f){n.incrementCounter("Siege:Csd:Decrypt:BadKeyCookie",1)}var u=i.decrypt(t),c=document.getElementById(e);if(null===c)throw new Error("Can't find element to insert the decrypt result");o.display(c,u),n.stopAndSendTimer("Decrypt:Payload:"+A.toString()),n.stopAndSendTimer("Decrypt:Overall"),2===A&&n.stopAndSendTimer("Decrypt:FromStartToSecondPayload");A++;var s=null==a?void 0:a.callSource;s!==undefined&&""!==s&&n.incrementCounter("Siege:Csd:Decrypt:CallSource:".concat(s))};var r=n(46),A=1}])}));
+});
+try {
+  window.uet('cf', 'Siege:Csd:LibraryEval', {wb: 1});
+  window.uex('ld', 'Siege:Csd:LibraryEval', {wb: 1});
+  window.uet('bb', 'Siege:Csd:LibLoadToDecrypt1Start', {wb: 1});
+} catch (e) {}
+
+</script>
+
+<div class="csd-encrypted-sensitive" id="aee06297-3b79-4ddf-ac17-455981f842a5">
+	<script type="text/javascript">
+		(function(payload) {
+			var elementId = "aee06297-3b79-4ddf-ac17-455981f842a5";
+			
+				try {
+					window.uet("cf", "Siege:Csd:LibLoadToDecrypt1Start", {wb: 1});
+					window.uex("ld", "Siege:Csd:LibLoadToDecrypt1Start", {wb: 1});
+				} catch (e) {}
+			
+			if (!window.SiegeClientSideDecryption) {
+				if (!window.csdFallbackDone) {
+					try {
+						ue.count("Siege:Csd:SafeFallback:missing-library", 1);
+					} catch (e) {}
+					window.location.href = "?disableCsd\u003Dmissing-library\u0026orderID\u003D113-4055495-4107437\u0026ref_\u003Dppx_hzsearch_conn_dt_b_fed_wwgs_wfm_ATVPDKIKX0DER_3";
+					window.csdFallbackDone = true;
+				}
+				return;
+			}
+			SiegeClientSideDecryption.decryptInElementWithId(elementId, payload, {callSource: "now"});
+		})({"ct":"XNiZSnnn/WLXd+smVoH/NJX5QeWf6d4A9oY2moLIBVEW8y9MH09p2aQWK2anXe7Y+2zG0g==","iv":"vGquywGq9tm/Cgdl","kid":"bb4a41"})
+	</script>
+	<noscript><meta http-equiv="refresh" content="0;url=?disableCsd=no-js&amp;orderID=113-4055495-4107437&amp;ref_=ppx_hzsearch_conn_dt_b_fed_wwgs_wfm_ATVPDKIKX0DER_3" /></noscript>
+</div>
+
+        <br/>
+        
+<div class="csd-encrypted-sensitive" id="5731bfdb-30f7-4755-a28e-fa76998432f6">
+	<script type="text/javascript">
+		(function(payload) {
+			var elementId = "5731bfdb-30f7-4755-a28e-fa76998432f6";
+			
+			if (!window.SiegeClientSideDecryption) {
+				if (!window.csdFallbackDone) {
+					try {
+						ue.count("Siege:Csd:SafeFallback:missing-library", 1);
+					} catch (e) {}
+					window.location.href = "?disableCsd\u003Dmissing-library\u0026orderID\u003D113-4055495-4107437\u0026ref_\u003Dppx_hzsearch_conn_dt_b_fed_wwgs_wfm_ATVPDKIKX0DER_3";
+					window.csdFallbackDone = true;
+				}
+				return;
+			}
+			SiegeClientSideDecryption.decryptInElementWithId(elementId, payload, {callSource: "now"});
+		})({"ct":"PFpcq+/jPhqT2tS7P+TKId/xD2yebwRofAOVUCI54fXLeImq4Oe5+Tept/jHDlaTniXBJqeLaWk+748hxVO5Z5tkG/Yuj9URvvI=","iv":"1MuSjWo25agaqxTQ","kid":"bb4a41"})
+	</script>
+	<noscript><meta http-equiv="refresh" content="0;url=?disableCsd=no-js&amp;orderID=113-4055495-4107437&amp;ref_=ppx_hzsearch_conn_dt_b_fed_wwgs_wfm_ATVPDKIKX0DER_3" /></noscript>
+</div>
+
+    </span>
+</div>
+
+
+<script type="a-state" data-a-state="{&quot;key&quot;:&quot;delivery-instructions-data-map&quot;}">{"orderId":"113-4055495-4107437","isDeliveryInstructionsEditable":false,"isUpdateDeliveryInstructionsEnabled":false}</script>
+
+</div>
+
+        
+            <div id="f3_food_WfmInStoreOrderSummary" class="odp-widget-wrapper celwidget" cel_widget_id="f3_food_WfmInStoreOrderSummary">
+
+
+
+
+
+<!-- WFM Color Palette: https://design.amazon.com/styleguide/B4997FAE703u/whole-foods-market/visual-guidelines/colors/ -->
+
+<style type="text/css">
+    #provide_feedback_button {
+        border-radius: 3px;
+    }
+</style>
+
+<!-- Order Totals -->
+<div class="a-row a-spacing-base">
+    <span class="a-size-medium a-text-bold">
+        Purchase Summary
+    </span>
+</div>
+<div class="a-row a-spacing-base">
+    <span class="a-size-small a-color-tertiary">
+        Order #: 113-4055495-4107437
+    </span>
+    <br/>
+    
+        <span class="a-size-small a-color-tertiary">
+            Purchased Sunday, October 5, 2025
+        </span>
+    
+</div>
+<div class="a-row a-spacing-medium">
+    <table class="a-normal">
+        <tr class="ufpo-order-totals-padding-row"></tr>
+
+        <!-- subtotal -->
+        <tr id="wfm-subtotal-row">
+            <td class="a-span9">
+                <span id="wfm-subtotal-label" class="a-text-bold">
+                    Item Subtotal
+                </span>
+            </td>
+            <td class="a-span3 a-text-right a-align-center">
+                <span id="wfm-subtotal-amount" class="a-text-bold">
+                    $27.96
+                </span>
+            </td>
+        </tr>
+
+        <!-- total savings -->
+        <tr id="wfm-total-savings-row">
+            <td class="a-span9">
+                <span id="wfm-total-savings-label" class="a-color-success a-text-bold">
+                    Total Savings
+                </span>
+            </td>
+            <td class="a-span3 a-text-right a-align-center">
+                <span id="wfm-total-savings-amount" class="a-color-success a-text-bold">
+                    -$2.79
+                </span>
+            </td>
+        </tr>
+
+        <!-- total taxes -->
+        
+            <tr id="wfm-tax-total-row">
+                <td class="a-span9 a-align-center">
+                    <span id="wfm-tax-total-label" class="a-text-bold">
+                        Tax and Fees
+                    </span>
+                </td>
+                <td class="a-span3 a-text-right a-align-center a-text-bold">
+                    <span id="wfm-tax-total-amount">
+                        $0.54
+                    </span>
+                </td>
+            </tr>
+        
+
+
+        <!-- taxes list -->
+        
+            
+            <tr id="wfm-AUSTIN, CITY OF-row" class="wfm-tax-breakout-row">
+                <td class="a-span9 a-align-center">
+                    <ul class="a-unordered-list a-vertical">
+                        <li id="wfm-AUSTIN, CITY OF-label" class="a-list-more a-align-center"><span class="a-list-item a-size-mini a-color-tertiary">
+                            AUSTIN, CITY OF
+                        </span></li>
+                    </ul>
+                </td>
+                <td class="a-span3 a-color-tertiary a-text-right a-align-center">
+                    <span id="wfm-AUSTIN, CITY OF-amount">
+                        $0.54
+                    </span>
+                </td>
+            </tr>
+        
+
+        <!-- grand total -->
+        <tr id="wfm-grand-total-row">
+            <td class="a-span9 a-align-center">
+                <span id="wfm-grand-total-label" class="a-text-bold">
+                    Grand Total
+                </span>
+            </td>
+            <td class="a-span3 a-text-right a-align-center a-text-bold">
+                <span id="wfm-grand-total-amount">
+                    $25.71
+                </span>
+            </td>
+        </tr>
+    </table>
+</div>
+
+<!-- Payment Method - Conditionally render the section if the card tail is available -->
+
+    <hr aria-hidden="true" class="a-divider-normal"/>
+
+    <div class="a-row a-spacing-base">
+        <span class="a-size-medium a-text-bold">
+            Payment Methods
+        </span>
+    </div>
+
+
+    <div class="a-row a-spacing-medium">
+        <table class="a-normal">
+            
+                
+                
+                
+                <tr id="wfm-payment-info-0-row">
+                    <td class="a-span6 a-color-information a-text-left a-align-center">
+                        <span id="wfm-0-card-brand">
+                            Visa
+                        </span>
+                    </td>
+                    <td class="a-span2 a-color-information a-text-left a-align-center">
+                        <span id="wfm-0-card-tail">
+                            *9790
+                        </span>
+                    </td>
+                    <td class="a-span2 a-color-information a-text-right a-align-center">
+                        <span id="wfm-0-amount-charged">
+                            $25.71
+                        </span>
+                    </td>
+                </tr>
+            
+        </table>
+    </div>
+
+
+<!-- Provide Feedback -->
+<hr aria-hidden="true" class="a-divider-normal"/>
+
+<table class="a-normal">
+    <tr id="wfm-feedback">
+        <td class="a-span7 a-align-center">
+            <span id="wfm-feedback-label">
+                How was your trip?
+            </span>
+        </td>
+        <td class="a-span5 a-text-right a-align-center a-text-bold">
+            
+            
+                
+                
+                    
+                
+            
+            
+                
+            
+            
+                
+            
+            
+                
+            
+            
+                
+            
+            
+                
+            
+            <span id="provide_feedback_button" class="a-button a-button-base"><span class="a-button-inner"><a href="https://wholefoods.co1.qualtrics.com/jfe/form/SV_daIhabGWWMKDaZM?Country=US&amp;Q_Language=EN&amp;VERSION=WFUS&amp;WFDIGR=1&amp;TransactionID=IL3FX5JRL8&amp;StoreNumber=10316&amp;TimeShopped=3&amp;CheckoutType=1&amp;DateShopped=2025-10-05" target="_blank" rel="noopener" class="a-button-text">
+                Provide Feedback
+            </a></span></span>
+        </td>
+    </tr>
+</table>
+
+</div>
+
+        
+         <div class="odp-widget-wrapper hidden"></div> 
+    </div>
+
+    <div id="od-ad-container">
+        
+            <div id="f3_food_OrderIdBarcode" class="odp-widget-wrapper celwidget" cel_widget_id="f3_food_OrderIdBarcode">
+
+
+<div>
+    <div>
+        
+            
+
+            
+            
+
+            
+            <div id="wfm-groceries-banner" class="a-image-container a-dynamic-image-container" style="width:100%; height:190px;">
+                <a class="a-link-normal" href="/wfm?_ref=dr_wfm_ad_banner">
+                    <img alt="" src="https://m.media-amazon.com/images/G/01/WholeFoodsMarket/NewGroceryImage0522.jpg"/>
+                </a>
+            </div>
+        
+        
+            <div id="itemized-receipt-barcode-image-container" class="a-image-container a-dynamic-image-container" style="width:100%; height:70px;">
+                <img alt="" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAW4AAAAtCAIAAAABexauAAAMJklEQVR4XpXQMY7FMAwD0X//S+9WBsacUJBZJY9Uivz+lB9CaZvW+pliZ9rGbtk4pbm/EK/MMI7kZf9dmz2lOYXudha39LkNYeXEONzy6hQ6Q2/LvVuYtmx+HZ+42p+z5cbPlMiH+sb33LTWzxQ70zZ2y8Ypzf2FeGWGcSQv++/a7CnNKXS3s7ilz20IKyfG4ZZXp9AZelvu3cK0ZfPr+MTV/pwtN36mRD7UN77nprV+ptiZtrFbNk5p7i/EKzOMI3nZf9dmT2lOobudxS19bkNYOTEOt7w6hc7Q23LvFqYtm1/HJ67252y58TMl8qG+8T03rfUzxc60jd2ycUpzfyFemWEcycv+uzZ7SnMK3e0sbulzG8LKiXG45dUpdIbelnu3MG3Z/Do+cbU/Z8uNnymRD/WN77lprZ8pdqZt7JaNU5r7C/HKDONIXvbftdlTmlPobmdxS5/bEFZOjMMtr06hM/S23LuFacvm1/GJq/05W278TIl8qG98z01r/UyxM21jt2yc0txfiFdmGEfysv+uzZ7SnEJ3O4tb+tyGsHJiHG55dQqdobfl3i1MWza/jk9c7c/ZcuNnSuRDfeN7blrrZ4qdaRu7ZeOU5v5CvDLDOJKX/Xdt9pTmFLrbWdzS5zaElRPjcMurU+gMvS33bmHasvl1fOJqf86WGz9TIh/qG99z01o/U+xM29gtG6c09xfilRnGkbzsv2uzpzSn0N3O4pY+tyGsnBiHW16dQmfobbl3C9OWza/jE1f7c7bc+JkS+VDf+J6b1vqZYmfaxm7ZOKW5vxCvzDCO5GX/XZs9pTmF7nYWt/S5DWHlxDjc8uoUOkNvy71bmLZsfh2fuNqfs+XGz5TIh/rG99y01s8UO9M2dsvGKc39hXhlhnEkL/vv2uwpzSl0t7O4pc9tCCsnxuGWV6fQGXpb7t3CtGXz6/jE1f6cLTd+pkQ+1De+56a1fqbYmbaxWzZOae4vxCszjCN52X/XZk9pTqG7ncUtfW5DWDkxDre8OoXO0Nty7xamLZtfxyeu9udsufEzJfKhvvE9N631M8XOtI3dsnFKc38hXplhHMnL/rs2e0pzCt3tLG7pcxvCyolxuOXVKXSG3pZ7tzBt2fw6PnG1P2fLjZ8pkQ/1je+5aa2fKXambeyWjVOa+wvxygzjSF7237XZU5pT6G5ncUuf2xBWTozDLa9OoTP0tty7hWnL5tfxiav9OVtu/EyJfKhvfM9Na/1MsTNtY7dsnNLcX4hXZhhH8rL/rs2e0pxCdzuLW/rchrByYhxueXUKnaG35d4tTFs2v45PXO3P2XLjZ0rkQ33je25a62eKnWkbu2XjlOb+QrwywziSl/13bfaU5hS621nc0uc2hJUT43DLq1PoDL0t925h2rL5dXzian/Olhs/UyIf6hvfc9NaP1PsTNvYLRunNPcX4pUZxpG87L9rs6c0p9DdzuKWPrchrJwYh1tenUJn6G25dwvTls2v4xNX+3O23PiZEvlQ3/iem9b6mWJn2sZu2Tilub8Qr8wwjuRl/12bPaU5he52Frf0uQ1h5cQ43PLqFDpDb8u9W5i2bH4dn7jan7Plxs+UyIf6xvfctNbPFDvTNnbLxinN/YV4ZYZxJC/779rsKc0pdLezuKXPbQgrJ8bhllen0Bl6W+7dwrRl8+v4xNX+nC03fqZEPtQ3vuemtX6m2Jm2sVs2TmnuL8QrM4wjedl/12ZPaU6hu53FLX1uQ1g5MQ63vDqFztDbcu8Wpi2bX8cnrvbnbLnxMyXyob7xPTet9TPFzrSN3bJxSnN/IV6ZYRzJy/67NntKcwrd7Sxu6XMbwsqJcbjl1Sl0ht6We7cwbdn8Oj5xtT9ny42fKZEP9Y3vuWmtnyl2pm3slo1TmvsL8coM40he9t+12VOaU+huZ3FLn9sQVk6Mwy2vTqEz9Lbcu4Vpy+bX8Ymr/TlbbvxMiXyob3zPTWv9TLEzbWO3bJzS3F+IV2YYR/Ky/67NntKcQnc7i1v63IawcmIcbnl1Cp2ht+XeLUxbNr+OT1ztz9ly42dK5EN943tuWutnip1pG7tl45Tm/kK8MsM4kpf9d232lOYUuttZ3NLnNoSVE+Nwy6tT6Ay9LfduYdqy+XV84mp/zpYbP1MiH+ob33PTWj9T7Ezb2C0bpzT3F+KVGcaRvOy/a7OnNKfQ3c7ilj63IaycGIdbXp1CZ+htuXcL05bNr+MTV/tzttz4mRL5UN/4npvW+pliZ9rGbtk4pbm/EK/MMI7kZf9dmz2lOYXudha39LkNYeXEONzy6hQ6Q2/LvVuYtmx+HZ+42p+z5cbPlMiH+sb33LTWzxQ70zZ2y8Ypzf2FeGWGcSQv++/a7CnNKXS3s7ilz20IKyfG4ZZXp9AZelvu3cK0ZfPr+MTV/pwtN36mRD7UN77nprV+ptiZtrFbNk5p7i/EKzOMI3nZf9dmT2lOobudxS19bkNYOTEOt7w6hc7Q23LvFqYtm1/HJ67252y58TMl8qG+8T03rfUzxc60jd2ycUpzfyFemWEcycv+uzZ7SnMK3e0sbulzG8LKiXG45dUpdIbelnu3MG3Z/Do+cbU/Z8uNnymRD/WN77lprZ8pdqZt7JaNU5r7C/HKDONIXvbftdlTmlPobmdxS5/bEFZOjMMtr06hM/S23LuFacvm1/GJq/05W278TIl8qG98z01r/UyxM21jt2yc0txfiFdmGEfysv+uzZ7SnEJ3O4tb+tyGsHJiHG55dQqdobfl3i1MWza/jk9c7c/ZcuNnSuRDfeN7blrrZ4qdaRu7ZeOU5v5CvDLDOJKX/Xdt9pTmFLrbWdzS5zaElRPjcMurU+gMvS33bmHasvl1fOJqf86WGz9TIh/qG99z01o/U+xM29gtG6c09xfilRnGkbzsv2uzpzSn0N3O4pY+tyGsnBiHW16dQmfobbl3C9OWza/jE1f7c7bc+JkS+VDf+J6b1vqZYmfaxm7ZOKW5vxCvzDCO5GX/XZs9pTmF7nYWt/S5DWHlxDjc8uoUOkNvy71bmLZsfh2fuNqfs+XGz5TIh/rG99y01s8UO9M2dsvGKc39hXhlhnEkL/vv2uwpzSl0t7O4pc9tCCsnxuGWV6fQGXpb7t3CtGXz6/jE1f6cLTd+pkQ+1De+56a1fqbYmbaxWzZOae4vxCszjCN52X/XZk9pTqG7ncUtfW5DWDkxDre8OoXO0Nty7xamLZtfxyeu9udsufEzJfKhvvE9N631M8XOtI3dsnFKc38hXplhHMnL/rs2e0pzCt3tLG7pcxvCyolxuOXVKXSG3pZ7tzBt2fw6PnG1P2fLjZ8pkQ/1je+5aa2fKXambeyWjVOa+wvxygzjSF7237XZU5pT6G5ncUuf2xBWTozDLa9OoTP0tty7hWnL5tfxiav9OVtu/EyJfKhvfM9Na/1MsTNtY7dsnNLcX4hXZhhH8rL/rs2e0pxCdzuLW/rchrByYhxueXUKnaG35d4tTFs2v45PXO3P2XLjZ0rkQ33je25a62eKnWkbu2XjlOb+QrwywziSl/13bfaU5hS621nc0uc2hJUT43DLq1PoDL0t925h2rL5dXzian/Olhs/UyIf6hvfc9NaP1PsTNvYLRunNPcX4pUZxpG87L9rs6c0p9DdzuKWPrchrJwYh1tenUJn6G25dwvTls2v4xNX+3O23PiZEvlQ3/iem9b6mWJn2sZu2Tilub8Qr8wwjuRl/12bPaU5he52Frf0uQ1h5cQ43PLqFDpDb8u9W5i2bH4dn7jan7Plxs+UyIf6xvfctNbPFDvTNnbLxinN/YV4ZYZxJC/779rsKc0pdLezuKXPbQgrJ8bhllen0Bl6W+7dwrRl8+v4xNX+nC03fqZEPtQ3vuemtX6m2Jm2sVs2TmnuL8QrM4wjedl/12ZPaU6hu53FLX1uQ1g5MQ63vDqFztDbcu8Wpi2bX8cnrvbnbLnxMyXyob7xPTet9TPFzrSN3bJxSnN/IV6ZYRzJy/67NntKcwrd7Sxu6XMbwsqJcbjl1Sl0ht6We7cwbdn8Oj5xtT9ny42fKZEP9Y3vuWmtnyl2pm3slo1TmvsL8coM40he9t+12VOaU+huZ3FLn9sQVk6Mwy2vTqEz9Lbcu4Vpy+bX8Ymr/TlbbvxMifwDgML6n9aKiIsAAAAASUVORK5CYII="/>
+            </div>
+        
+        
+            <div id="barcodeId-text-container" style="width:100%; text-align:center">
+                <span id="barcode-text-label">
+                    63011031620508338100520250
+                </span>
+            </div>
+        
+        
+            <div id="transactionId-text-container" style="width:100%; text-align:center">
+                <span id="transactionId-text-label">
+                    IL3FX5JRL8
+                </span>
+            </div>
+        
+    </div>
+</div>
+
+
+</div>
+
+        
+    </div>
+</div>
+
+
+
+<script>
+    if (typeof uet == 'function')  { uet('af'); }
+</script>
+
+<!--&&&Portal&Delimiter&&&--><!-- sp:end-feature:host-atf -->
+<!-- sp:feature:nav-btf -->
+<!-- NAVYAAN BTF START -->
+
+
+
+
+
+
+  <script type='text/javascript'>(function ($Nav) {
+"use strict";
+
+if (typeof $Nav === 'undefined' || $Nav === null || typeof $Nav.when !== 'function') {
+    return;
+}
+
+$Nav.when('$', 'data', 'flyout.yourAccount', 'sidepanel.csYourAccount',
+          'config')
+    .run("BuyitAgain-YourAccount-SidePanel",
+    function ($, data, yaFlyout, csYourAccount, config) {
+        if (config.disableBuyItAgain) {
+            return;
+        }
+        var render = function (data) {
+            if (data.dramResult) {
+                var widgetHtml = data.dramResult;
+                navbar.sidePanel({
+                    flyoutName: 'yourAccount',
+                    data: {html: widgetHtml}
+                });
+            }
+        };
+
+        var renderBuyItAgain = function (biaData) {
+            if (csYourAccount) {
+                csYourAccount.register(render, biaData);
+            } else {
+                render(biaData);
+            }
+        };
+
+        var truncateAndRestructureYaFlyout = function() {
+            if (window.P) {
+                P.when('A', 'a-truncate').execute(function(A, truncate) {
+                    var truncateElements = A.$('.a-truncate');
+                    A.each(truncateElements, function(element) {
+                        truncate.get(element).update();
+                    });
+                    var recommendationsWidget = document.getElementById('bia-hcb-widget');
+                    if (recommendationsWidget) { 
+                        var navFlyout = recommendationsWidget.parentElement;
+                        var navFlyoutPaddingBottom = parseInt(window.getComputedStyle(navFlyout).getPropertyValue('padding-bottom'));
+                        var navFlyoutContentHeight = navFlyout.clientHeight - navFlyoutPaddingBottom;
+                        while (recommendationsWidget.offsetHeight > navFlyoutContentHeight && recommendationsWidget.offsetHeight > 0){
+                            var recommendations = recommendationsWidget.querySelectorAll('.biaNavFlyoutFaceout');
+                            if (recommendations.length <= 1) {
+                                break;
+                            }
+                            var lastRecommendation = recommendations[recommendations.length - 1];
+                            lastRecommendation.parentElement.removeChild(lastRecommendation);
+                        }
+                    }
+               });
+            }
+        };
+
+        yaFlyout.sidePanel.onData(truncateAndRestructureYaFlyout);
+        yaFlyout.onShow(truncateAndRestructureYaFlyout);
+
+    yaFlyout.onRender(function() {
+            $.ajax({
+                url: '/gp/bia/external/bia-hcb-ajax-handler.html',
+                data: {"biaHcbRid":"RBWFGARJB4TBW5KMJP91"},
+                dataType: 'json',
+                timeout: 4*1000,
+                success: renderBuyItAgain,
+                error: function (jqXHR, textStatus, errorThrown) {
+                }
+            });
+        });
+    });
+})(window.$Nav);</script>
+
+
+<script type="text/javascript">
+  window.$Nav && $Nav.when("data").run(function (data) {
+    data({
+      "accountListContent": { "html": "<div id='nav-al-container'><div id='nav-al-profile' class='nav-flyout-content nav-flyout-accessibility'></div><div id='nav-al-wishlist' class='nav-al-column nav-tpl-itemList nav-flyout-content nav-flyout-accessibility'><div class='nav-title' id='nav-al-title' role='heading' aria-level='6'>Your Lists</div><ul><li><a href='/hz/wishlist/ls?triggerElementID=createList&ref_=nav_ListFlyout_navFlyout_createList_lv_redirect' class='nav-link nav-item'><span class='nav-text'>Create a List</span></a></li><li><a href='/registries?ref_=nav_ListFlyout_find' class='nav-link nav-item'><span class='nav-text'>Find a List or Registry</span></a></li><li><a href='/your-books?ref=yb_ip_ysb_d&tabView=saved_books' class='nav-link nav-item'><span class='nav-text'>Your Saved Books</span></a></li></ul></div><div id='nav-al-your-account' class='nav-al-column nav-template nav-flyout-content nav-tpl-itemList nav-flyout-accessibility'><div class='nav-title' role='heading' aria-level='6'>Your Account</div><ul><li><a href='/gp/css/homepage.html?ref_=nav_AccountFlyout_ya' class='nav-link nav-item'><span class='nav-text'>Account</span></a></li><li><a id='nav_prefetch_yourorders' href='/gp/css/order-history?ref_=nav_AccountFlyout_orders' class='nav-link nav-item'><span class='nav-text'>Orders</span></a></li><li><a href='/hz/mobile/mission?ref_=nav_AccountFlyout_ci_mcx_mi_d_nf' class='nav-link nav-item'><span class='nav-text'>Keep Shopping For</span></a></li><li><a href='/gp/yourstore?ref_=nav_AccountFlyout_recs' class='nav-link nav-item'><span class='nav-text'>Recommendations</span></a></li><li><a href='/your-returns?ingress=navm_account_flyout&ref_=nav_AccountFlyout_returns' class='nav-link nav-item'><span class='nav-text'>Returns</span></a></li><li><a href='/gp/history?ref_=nav_AccountFlyout_browsinghistory' class='nav-link nav-item'><span class='nav-text'>Browsing History</span></a></li><li><a href='https://www.amazon.com/slc/hub?ref_=nav_AccountFlyout_sl_ph_navflyout' class='nav-link nav-item'><span class='nav-text'>Your Shopping preferences</span></a></li><li><a href='/b/?node=12766669011&ld=AZUSSOA-yaflyout&ref_=nav_AccountFlyout_cs_sell' class='nav-link nav-item'><span class='nav-text'>Start a Selling Account</span></a></li><li><a href='https://www.amazon.com/credit/landing?ref_=nav_AccountFlyout_ya_amazon_cc_landing_ms' class='nav-link nav-item'><span class='nav-text'>Amazon Credit Cards</span></a></li><li><a href='https://www.amazon.com/your-product-safety-alerts?ref_=nav_AccountFlyout_flyout_bsx_ypsa' class='nav-link nav-item'><span class='nav-text'>Recalls and Product Safety Alerts</span></a></li><li><a href='/gp/video/watchlist?ref_=nav_AccountFlyout_ywl' class='nav-link nav-item'><span class='nav-text'>Watchlist</span></a></li><li><a href='/gp/video/library?ref_=nav_AccountFlyout_yvl' class='nav-link nav-item'><span class='nav-text'>Video Purchases & Rentals</span></a></li><li><a href='/gp/kindle/ku/ku_central?ref_=nav_AccountFlyout_ku' class='nav-link nav-item'><span class='nav-text'>Kindle Unlimited</span></a></li><li><a href='/hz/mycd/myx?pageType=content&ref_=nav_AccountFlyout_myk' class='nav-link nav-item'><span class='nav-text'>Content Library</span></a></li><li><a href='https://www.amazon.com/hz/mycd/digital-console/alldevices?pageType=devices&ref_=nav_accountFlyOut_manage_devices' class='nav-link nav-item'><span class='nav-text'>Devices</span></a></li><li><a href='/gp/subscribe-and-save/manager/viewsubscriptions?ref_=nav_AccountFlyout_sns' class='nav-link nav-item'><span class='nav-text'>Subscribe & Save Items</span></a></li><li><a href='/hz5/yourmembershipsandsubscriptions?ref_=nav_AccountFlyout_digital_subscriptions' class='nav-link nav-item'><span class='nav-text'>Memberships & Subscriptions</span></a></li><li><a href='/gp/subs/primeclub/account/homepage.html?ref_=nav_AccountFlyout_prime' class='nav-link nav-item'><span class='nav-text'>Prime Membership</span></a></li><li><a href='https://health.amazon.com/?ref_=nav_yc_ahi_homepage' class='nav-link nav-item'><span class='nav-text'>Medical Care & Pharmacy</span></a></li><li><a href='https://music.amazon.com?ref=nav_youraccount_cldplyr' class='nav-link nav-item'><span class='nav-text'>Music Library</span></a></li><li><a href='/gp/browse.html?node=11261610011&ref_=nav_AccountFlyout_b2b_reg_bottom' class='nav-link nav-item'><span class='nav-text'>Create Your Free Business Account</span></a></li><li><a href='https://www.amazon.com/hz/contact-us?ref_=nav_AccountFlyout_CS' class='nav-link nav-item'><span class='nav-text'>Customer Service</span></a></li></ul></div></div>" },
+      "tooltipContent": { "html": "" },
+      "signinContent": { "html": "<div id='nav-signin-tooltip'><a href='https://www.amazon.com/ap/signin?openid.return_to=https%3A%2F%2Fwww.amazon.com%2Ffopo%2Forder-details%2F%3F_encoding%3DUTF8%26orderID%3D113-4055495-4107437%26ref_%3Dnav_custrec_signin&openid.identity=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0%2Fidentifier_select&openid.assoc_handle=usflex&openid.mode=checkid_setup&openid.claimed_id=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0%2Fidentifier_select&openid.ns=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0' class='nav-action-signin-button' data-nav-role='signin' data-nav-ref='nav_custrec_signin'><span class='nav-action-inner'>Sign in</span></a><div class='nav-signin-tooltip-footer'>New customer? <a href='https://www.amazon.com/ap/register?openid.return_to=https%3A%2F%2Fwww.amazon.com%2Ffopo%2Forder-details%2F%3F_encoding%3DUTF8%26orderID%3D113-4055495-4107437%26ref_%3Dnav_custrec_newcust&openid.identity=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0%2Fidentifier_select&openid.assoc_handle=usflex&openid.mode=checkid_setup&openid.claimed_id=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0%2Fidentifier_select&openid.ns=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0' class='nav-a' aria-label='New to Amazon? Start here to create an account'>Start here.</a></div></div>" },
+      "templates": {"itemList":"<# var hasColumns = (function () {  var checkColumns = function (_items) {    if (!_items) {      return false;    }    for (var i=0; i<_items.length; i++) {      if (_items[i].columnBreak || (_items[i].items && checkColumns(_items[i].items))) {        return true;      }    }    return false;  };  return checkColumns(items);}()); #><# if(hasColumns) { #>  <# if(items[0].image && items[0].image.src) { #>    <div class='nav-column nav-column-first nav-column-image'>  <# } else if (items[0].greeting) { #>    <div class='nav-column nav-column-first nav-column-greeting'>  <# } else { #>    <div class='nav-column nav-column-first'>  <# } #><# } #><# var renderItems = function(items) { #>  <# jQuery.each(items, function (i, item) { #>    <# if(hasColumns && item.columnBreak) { #>      <# if(item.image && item.image.src) { #>        </div><div class='nav-column nav-column-notfirst nav-column-break nav-column-image'>      <# } else if (item.greeting) { #>        </div><div class='nav-column nav-column-notfirst nav-column-break nav-column-greeting'>      <# } else { #>        </div><div class='nav-column nav-column-notfirst nav-column-break'>      <# } #>    <# } #>    <# if(item.dividerBefore) { #>      <div class='nav-divider'></div>    <# } #>    <# if(item.text || item.content) { #>      <# if(item.url) { #>        <a href='<#=item.url #>' class='nav-link      <# } else {#>        <span class='      <# } #>      <# if(item.panelKey) { #>        nav-hasPanel      <# } #>      <# if(item.items) { #>        nav-title      <# } #>      <# if(item.decorate == 'carat') { #>        nav-carat      <# } #>      <# if(item.decorate == 'nav-action-button') { #>        nav-action-button      <# } #>      nav-item'      <# if(item.extra) { #>        <#=item.extra #>      <# } #>      <# if(item.id) { #>        id='<#=item.id #>'      <# } #>      <# if(item.dataNavRole) { #>        data-nav-role='<#=item.dataNavRole #>'      <# } #>      <# if(item.dataNavRef) { #>        data-nav-ref='<#=item.dataNavRef #>'      <# } #>      <# if(item.panelKey) { #>        data-nav-panelkey='<#=item.panelKey #>'        role='navigation'        aria-label='<#=item.text#>'      <# } #>      <# if(item.subtextKey) { #>        data-nav-subtextkey='<#=item.subtextKey #>'      <# } #>      <# if(item.image && item.image.height > 16) { #>        style='line-height:<#=item.image.height #>px;'      <# } #>      >      <# if(item.decorate == 'carat') { #>        <i class='nav-icon'></i>      <# } #>      <# if(item.image && item.image.src) { #>        <img class='nav-image' src='<#=item.image.src #>' style='height:<#=item.image.height #>px; width:<#=item.image.width #>px;' />      <# } #>      <# if(item.text) { #>        <span class='nav-text<# if(item.classname) { #> <#=item.classname #><# } #>'><#=item.text#><# if(item.badgeText) { #>          <span class='nav-badge'><#=item.badgeText#></span>        <# } #></span>      <# } else if (item.content) { #>        <span class='nav-content'><# jQuery.each(item.content, function (j, cItem) { #><# if(cItem.url && cItem.text) { #><a href='<#=cItem.url #>' class='nav-a'><#=cItem.text #></a><# } else if (cItem.text) { #><#=cItem.text#><# } #><# }); #></span>      <# } #>      <# if(item.subtext) { #>        <span class='nav-subtext'><#=item.subtext #></span>      <# } #>      <# if(item.url) { #>        </a>      <# } else {#>        </span>      <# } #>    <# } #>    <# if(item.image && item.image.src) { #>      <# if(item.url) { #>        <a href='<#=item.url #>'>       <# } #>      <img class='nav-image'      <# if(item.id) { #>        id='<#=item.id #>'      <# } #>      src='<#=item.image.src #>' <# if (item.alt) { #> alt='<#= item.alt #>'<# } #>/>      <# if(item.url) { #>        </a>       <# } #>    <# } #>    <# if(item.items) { #>      <div class='nav-panel'> <# renderItems(item.items); #> </div>    <# } #>  <# }); #><# }; #><# renderItems(items); #><# if(hasColumns) { #>  </div><# } #>","subnav":"<# if (obj && obj.type === 'vertical') { #>  <# jQuery.each(obj.rows, function (i, row) { #>    <# if (row.flyoutElement === 'button') { #>      <div class='nav_sv_fo_v_button'        <# if (row.elementStyle) { #>          style='<#= row.elementStyle #>'        <# } #>      >        <a href='<#=row.url #>' class='nav-action-button nav-sprite'>          <#=row.text #>        </a>      </div>    <# } else if (row.flyoutElement === 'list' && row.list) { #>      <# jQuery.each(row.list, function (j, list) { #>        <div class='nav_sv_fo_v_column <#=(j === 0) ? 'nav_sv_fo_v_first' : '' #>'>          <ul class='<#=list.elementClass #>'>          <# jQuery.each(list.linkList, function (k, link) { #>            <# if (k === 0) { link.elementClass += ' nav_sv_fo_v_first'; } #>            <li class='<#=link.elementClass #>'>              <# if (link.url) { #>                <a href='<#=link.url #>' class='nav_a'><#=link.text #></a>              <# } else { #>                <span class='nav_sv_fo_v_span'><#=link.text #></span>              <# } #>            </li>          <# }); #>          </ul>        </div>      <# }); #>    <# } else if (row.flyoutElement === 'link') { #>      <# if (row.topSpacer) { #>        <div class='nav_sv_fo_v_clear'></div>      <# } #>      <div class='<#=row.elementClass #>'>        <a href='<#=row.url #>' class='nav_sv_fo_v_lmargin nav_a'>          <#=row.text #>        </a>      </div>    <# } #>  <# }); #><# } else if (obj) { #>  <div class='nav_sv_fo_scheduled'>    <#= obj #>  </div><# } #>","htmlList":"<# jQuery.each(items, function (i, item) { #>  <div class='nav-item'>    <#=item #>  </div><# }); #>"}
+    })
+  })
+</script>
+
+<script type="text/javascript">
+  window.$Nav && $Nav.declare('config.flyoutURL', null);
+  window.$Nav && $Nav.declare('btf.lite');
+  window.$Nav && $Nav.declare('btf.full');
+  window.$Nav && $Nav.declare('btf.exists');
+  (window.AmazonUIPageJS ? AmazonUIPageJS : P).register('navCF');
+</script>
+
+<!-- NAVYAAN BTF END -->
+<!-- sp:end-feature:nav-btf -->
+<!-- sp:feature:host-btf -->
+
+
+<!-- Page BTF -->
+<!-- sp:end-feature:host-btf -->
+<!-- sp:feature:aui-preload -->
+<!-- sp:end-feature:aui-preload -->
+<!-- sp:feature:nav-footer -->
+
+  <!-- NAVYAAN FOOTER START -->
+  <!-- WITH MOZART -->
+
+<div id='rhf' class='copilot-secure-display' style='clear: both;' role='complementary' aria-label='Your recently viewed items and featured recommendations'> <div class='rhf-frame' style='display: none;'> <br> <div id='rhf-container'> <div class='rhf-loading-outer'> <table class='rhf-loading-middle'> <tr> <td class='rhf-loading-inner'> <img src='https://m.media-amazon.com/images/G/01/personalization/ybh/loading-4x-gray._CB485916920_.gif'> </td> </tr> </table> </div> <div id='rhf-context'> <script type='application/json'> { "rhfHandlerParams":{"currentPageType":"F3OmnichannelPostOrder","currentSubPageType":"OrderDetails","excludeAsin":"","fieldKeywords":"","k":"","keywords":"","search":"","auditEnabled":"","previewCampaigns":"","forceWidgets":"","searchAlias":""} } </script> </div> </div> <noscript> <div class='rhf-border'> <div class='rhf-header'> Your recently viewed items and featured recommendations </div> <div class='rhf-footer'> <div class='rvi-container'> <div class='ybh-edit'> <div class='ybh-edit-arrow'> &#8250; </div> <div class='ybh-edit-link'> <a href='/gp/history'> View or edit your browsing history </a> </div> </div> <span class='no-rvi-message'> After viewing product detail pages, look here to find an easy way to navigate back to pages you are interested in. </span> </div> </div> </div> </noscript> <div id='rhf-error' style='display: none;'> <div class='rhf-border'> <div class='rhf-header'> Your recently viewed items and featured recommendations </div> <div class='rhf-footer'> <div class='rvi-container'> <div class='ybh-edit'> <div class='ybh-edit-arrow'> &#8250; </div> <div class='ybh-edit-link'> <a href='/gp/history'> View or edit your browsing history </a> </div> </div> <span class='no-rvi-message'> After viewing product detail pages, look here to find an easy way to navigate back to pages you are interested in. </span> </div> </div> </div> </div> <br> </div> </div>
+<div class="navLeftFooter nav-sprite-v1" id="navFooter">
+  <button id="navBackToTop" class="navFooterBackToTopText" aria-label="Back to top"><div class="navFooterBackToTop">Back to top</div></button>
+  
+<div class="navFooterVerticalColumn navAccessibility" role="presentation">
+  <div class="navFooterVerticalRow navAccessibility">
+        <div class="navFooterLinkCol navAccessibility">
+          <div class="navFooterColHead" role="heading" aria-level="6">Get to Know Us</div>
+        <ul>
+            <li class="nav_first">
+              <a href="https://www.amazon.jobs" class="nav_a">Careers</a>
+            </li>
+            <li >
+              <a href="https://email.aboutamazon.com/l/637851/2020-10-29/pd87g?utm_source=gateway&utm_medium=amazonfooters&utm_campaign=newslettersubscribers&utm_content=amazonnewssignup" class="nav_a">Amazon Newsletter</a>
+            </li>
+            <li >
+              <a href="https://www.aboutamazon.com/?utm_source=gateway&utm_medium=footer&token=about" class="nav_a">About Amazon</a>
+            </li>
+            <li >
+              <a href="https://www.amazon.com/b?node=15701038011&ie=UTF8" class="nav_a">Accessibility</a>
+            </li>
+            <li >
+              <a href="https://sustainability.aboutamazon.com/?utm_source=gateway&utm_medium=footer&ref_=susty_footer" class="nav_a">Sustainability</a>
+            </li>
+            <li >
+              <a href="https://www.amazon.com/pr" class="nav_a">Press Center</a>
+            </li>
+            <li >
+              <a href="https://www.amazon.com/ir" class="nav_a">Investor Relations</a>
+            </li>
+            <li >
+              <a href="/gp/browse.html?node=2102313011&ref_=footer_devices" class="nav_a">Amazon Devices</a>
+            </li>
+            <li class="nav_last ">
+              <a href="https://www.amazon.science" class="nav_a">Amazon Science</a>
+            </li>
+        </ul>
+      </div>
+        <div class="navFooterColSpacerInner navAccessibility"></div>
+        <div class="navFooterLinkCol navAccessibility">
+          <div class="navFooterColHead" role="heading" aria-level="6">Make Money with Us</div>
+        <ul>
+            <li class="nav_first">
+              <a href="https://sell.amazon.com/?ld=AZFSSOA_FTSELL-C&ref_=footer_soa" class="nav_a">Sell on Amazon</a>
+            </li>
+            <li >
+              <a href="https://developer.amazon.com" class="nav_a">Sell apps on Amazon</a>
+            </li>
+            <li >
+              <a href="https://supply.amazon.com" class="nav_a">Supply to Amazon</a>
+            </li>
+            <li >
+              <a href="https://sell.amazon.com/brand-registry?ld=AZUSSOA_ABR-FT" class="nav_a">Protect & Build Your Brand</a>
+            </li>
+            <li >
+              <a href="https://affiliate-program.amazon.com/" class="nav_a">Become an Affiliate</a>
+            </li>
+            <li >
+              <a href="https://dspjobhub.com/" class="nav_a">Become a Delivery Driver</a>
+            </li>
+            <li >
+              <a href="https://logistics.amazon.com/marketing?utm_source=amzn&utm_medium=footer&utm_campaign=home" class="nav_a">Start a Package Delivery Business</a>
+            </li>
+            <li >
+              <a href="https://advertising.amazon.com/?ref=ext_amzn_ftr" class="nav_a">Advertise Your Products</a>
+            </li>
+            <li >
+              <a href="/gp/seller-account/mm-summary-page.html?ld=AZFooterSelfPublish&topic=200260520&ref_=footer_publishing" class="nav_a">Self-Publish with Us</a>
+            </li>
+            <li >
+              <a href="https://www.amazon.com/b?node=216188543011" class="nav_a">Become an Amazon Hub Partner</a>
+            </li>
+            <li class="nav_last nav_a_carat">
+              <span class="nav_a_carat" aria-hidden="true">›</span><a href="/b/?node=18190131011&ld=AZUSSOA-seemore&ref_=footer_seemore" class="nav_a">See More Ways to Make Money</a>
+            </li>
+        </ul>
+      </div>
+        <div class="navFooterColSpacerInner navAccessibility"></div>
+        <div class="navFooterLinkCol navAccessibility">
+          <div class="navFooterColHead" role="heading" aria-level="6">Amazon Payment Products</div>
+        <ul>
+            <li class="nav_first">
+              <a href="/iss/credit/rewardscardmember?plattr=CBFOOT&ref_=footer_cbcc" class="nav_a">Amazon Visa</a>
+            </li>
+            <li >
+              <a href="/credit/storecard/member?plattr=PLCCFOOT&ref_=footer_plcc" class="nav_a">Amazon Store Card</a>
+            </li>
+            <li >
+              <a href="/dp/product/B084KP3NG6?plattr=SCFOOT&ref_=footer_ACB" class="nav_a">Amazon Secured Card</a>
+            </li>
+            <li >
+              <a href="/dp/B0DVBL912R?plattr=ACOMFO&ie=UTF-8" class="nav_a">Amazon Business Card</a>
+            </li>
+            <li >
+              <a href="https://www.amazon.com/hp/shopwithpoints/servicing" class="nav_a">Shop with Points</a>
+            </li>
+            <li >
+              <a href="/gp/browse.html?node=3561432011&ref_=footer_ccmp" class="nav_a">Credit Card Marketplace</a>
+            </li>
+            <li >
+              <a href="/gp/browse.html?node=10232440011&ref_=footer_reload_us" class="nav_a">Reload Your Balance</a>
+            </li>
+            <li >
+              <a href="https://www.amazon.com/b/?node=2238192011&ref=shop_footer_payments_gc_desktop" class="nav_a">Gift Cards</a>
+            </li>
+            <li >
+              <a href="/gp/browse.html?node=388305011&ref_=footer_tfx" class="nav_a">Amazon Currency Converter</a>
+            </li>
+            <li class="nav_last ">
+              <a href="/gp/browse.html?node=20338459011&ref_=footer_cbcc_fin" class="nav_a">Promotional Financing</a>
+            </li>
+        </ul>
+      </div>
+        <div class="navFooterColSpacerInner navAccessibility"></div>
+        <div class="navFooterLinkCol navAccessibility">
+          <div class="navFooterColHead" role="heading" aria-level="6">Let Us Help You</div>
+        <ul>
+            <li class="nav_first">
+              <a href="https://www.amazon.com/gp/css/homepage.html?ref_=footer_ya" class="nav_a">Your Account</a>
+            </li>
+            <li >
+              <a href="https://www.amazon.com/gp/css/order-history?ref_=footer_yo" class="nav_a">Your Orders</a>
+            </li>
+            <li >
+              <a href="/gp/help/customer/display.html?nodeId=468520&ref_=footer_shiprates" class="nav_a">Shipping Rates & Policies</a>
+            </li>
+            <li >
+              <a href="/gp/prime?ref_=footer_prime" class="nav_a">Amazon Prime</a>
+            </li>
+            <li >
+              <a href="/gp/css/returns/homepage.html?ref_=footer_hy_f_4" class="nav_a">Returns & Replacements</a>
+            </li>
+            <li >
+              <a href="/hz/mycd/myx?ref_=footer_myk" class="nav_a">Manage Your Content and Devices</a>
+            </li>
+            <li >
+              <a href="https://www.amazon.com/product-safety-alerts?ref_=footer_bsx_ypsa" class="nav_a">Recalls and Product Safety Alerts</a>
+            </li>
+            <li >
+              <a href="/registries?ref_=nav_footer_registry_giftlist_desktop" class="nav_a">Registry & Gift List</a>
+            </li>
+            <li class="nav_last ">
+              <a href="/gp/help/customer/display.html?nodeId=508510&ref_=footer_gw_m_b_he" class="nav_a">Help</a>
+            </li>
+        </ul>
+      </div>
+  </div>
+</div>
+<div class="nav-footer-line"></div>
+
+  <div class="navFooterLine navFooterLinkLine navFooterPadItemLine">
+    <span>
+      <div class="navFooterLine navFooterLogoLine">
+        <a  aria-label="Amazon US Home"   lang="en"  href="/?ref_=footer_logo">
+        <div class="nav-logo-base nav-sprite"></div>
+        </a>
+      </div>
+</span>
+    
+      <span class="icp-container-desktop"><div
+          class="navFooterLine">
+<style type="text/css">
+  #icp-touch-link-language { display: none; }
+</style>
+
+
+<div class="icp-button" id="icp-touch-link-language" >
+<a href="/customer-preferences/edit?ie=UTF8&preferencesReturnUrl=%2F&ref_=footer_lang" class="icp-language-link" aria-label="Choose a language for shopping. Current selection is English. ">
+  <div class="icp-nav-globe-img-2 icp-button-globe-2"></div><span class="icp-color-base">English</span>
+</a>
+<button class="nav-arrow icp-up-down-arrow" aria-controls="nav-flyout-icp-footer-flyout" aria-label="Expand to Change Language or Country"></button>
+</div>
+
+<style type="text/css">
+#icp-touch-link-country { display: none; }
+</style>
+<a href="/customer-preferences/country?ie=UTF8&preferencesReturnUrl=%2F&ref_=footer_icp_cp" role="button" aria-label="Choose a country/region for shopping. The current selection is United States." class="icp-button" id="icp-touch-link-country">
+  <span class="icp-flag-3 icp-flag-3-us"></span><span class="icp-color-base">United States</span>
+</a>
+</div></span>
+    
+  </div>
+  
+  
+  <div class="navFooterLine navFooterLinkLine navFooterDescLine" role="navigation" aria-label="More on Amazon">
+    <div class="navFooterMoreOnAmazon navFooterMoreOnAmazonWrapper" aria-label="More on Amazon">
+      <ul>
+<li class="navFooterDescItem"><a href=https://music.amazon.com?ref=dm_aff_amz_com class="nav_a"><h5 class="navFooterDescItem_heading">Amazon Music</h5><span class="navFooterDescText">Stream millions<br>of songs</span></a></li><li class="navFooterDescSpacer" aria-hidden="true" style="width: 3%"></li>
+<li class="navFooterDescItem"><a href=https://advertising.amazon.com/?ref=footer_advtsing_amzn_com class="nav_a"><h5 class="navFooterDescItem_heading">Amazon Ads</h5><span class="navFooterDescText">Reach customers<br>wherever they<br>spend their time</span></a></li><li class="navFooterDescSpacer" aria-hidden="true" style="width: 3%"></li>
+<li class="navFooterDescItem"><a href=https://www.6pm.com class="nav_a"><h5 class="navFooterDescItem_heading">6pm</h5><span class="navFooterDescText">Score deals<br>on fashion brands</span></a></li><li class="navFooterDescSpacer" aria-hidden="true" style="width: 3%"></li>
+<li class="navFooterDescItem"><a href=https://www.abebooks.com class="nav_a"><h5 class="navFooterDescItem_heading">AbeBooks</h5><span class="navFooterDescText">Books, art<br>& collectibles</span></a></li><li class="navFooterDescSpacer" aria-hidden="true" style="width: 3%"></li>
+<li class="navFooterDescItem"><a href=https://www.acx.com/ class="nav_a"><h5 class="navFooterDescItem_heading">ACX </h5><span class="navFooterDescText">Audiobook Publishing<br>Made Easy</span></a></li><li class="navFooterDescSpacer" aria-hidden="true" style="width: 3%"></li>
+<li class="navFooterDescItem"><a href=https://sell.amazon.com/?ld=AZUSSOA-footer-aff&ref_=footer_sell class="nav_a"><h5 class="navFooterDescItem_heading">Sell on Amazon</h5><span class="navFooterDescText">Start a Selling Account</span></a></li><li class="navFooterDescSpacer" aria-hidden="true" style="width: 3%"></li>
+<li class="navFooterDescItem"><a href=https://www.veeqo.com/?utm_source=amazon&utm_medium=website&utm_campaign=footer class="nav_a"><h5 class="navFooterDescItem_heading">Veeqo</h5><span class="navFooterDescText">Shipping Software<br>Inventory Management</span></a></li></ul>
+
+<ul>
+<li class="navFooterDescItem"><a href=/business?ref_=footer_retail_b2b class="nav_a"><h5 class="navFooterDescItem_heading">Amazon Business</h5><span class="navFooterDescText">Everything For<br>Your Business</span></a></li><li class="navFooterDescSpacer" aria-hidden="true" style="width: 3%"></li>
+<li class="navFooterDescItem"><a href=/alm/storefront?almBrandId=QW1hem9uIEZyZXNo&ref_=footer_aff_fresh class="nav_a"><h5 class="navFooterDescItem_heading">Amazon Fresh</h5><span class="navFooterDescText">Groceries & More<br>Right To Your Door</span></a></li><li class="navFooterDescSpacer" aria-hidden="true" style="width: 3%"></li>
+<li class="navFooterDescItem"><a href=/gp/browse.html?node=20338496011&ref_=footer_amazonglobal class="nav_a"><h5 class="navFooterDescItem_heading">AmazonGlobal</h5><span class="navFooterDescText">Ship Orders<br>Internationally</span></a></li><li class="navFooterDescSpacer" aria-hidden="true" style="width: 3%"></li>
+<li class="navFooterDescItem"><a href=/services?ref_=footer_services class="nav_a"><h5 class="navFooterDescItem_heading">Home Services</h5><span class="navFooterDescText">Experienced Pros<br>Happiness Guarantee</span></a></li><li class="navFooterDescSpacer" aria-hidden="true" style="width: 3%"></li>
+<li class="navFooterDescItem"><a href=https://aws.amazon.com/what-is-cloud-computing/?sc_channel=EL&sc_campaign=amazonfooter class="nav_a"><h5 class="navFooterDescItem_heading">Amazon Web Services</h5><span class="navFooterDescText">Scalable Cloud<br>Computing Services</span></a></li><li class="navFooterDescSpacer" aria-hidden="true" style="width: 3%"></li>
+<li class="navFooterDescItem"><a href=https://www.audible.com class="nav_a"><h5 class="navFooterDescItem_heading">Audible</h5><span class="navFooterDescText">Listen to Books & Original<br>Audio Performances</span></a></li><li class="navFooterDescSpacer" aria-hidden="true" style="width: 3%"></li>
+<li class="navFooterDescItem"><a href=https://www.boxofficemojo.com/?ref_=amzn_nav_ftr class="nav_a"><h5 class="navFooterDescItem_heading">Box Office Mojo</h5><span class="navFooterDescText">Find Movie<br>Box Office Data</span></a></li></ul>
+
+<ul>
+<li class="navFooterDescItem"><a href=https://www.goodreads.com class="nav_a"><h5 class="navFooterDescItem_heading">Goodreads</h5><span class="navFooterDescText">Book reviews<br>& recommendations</span></a></li><li class="navFooterDescSpacer" aria-hidden="true" style="width: 3%"></li>
+<li class="navFooterDescItem"><a href=https://www.imdb.com class="nav_a"><h5 class="navFooterDescItem_heading">IMDb</h5><span class="navFooterDescText">Movies, TV<br>& Celebrities</span></a></li><li class="navFooterDescSpacer" aria-hidden="true" style="width: 3%"></li>
+<li class="navFooterDescItem"><a href=https://pro.imdb.com?ref_=amzn_nav_ftr class="nav_a"><h5 class="navFooterDescItem_heading">IMDbPro</h5><span class="navFooterDescText">Get Info Entertainment<br>Professionals Need</span></a></li><li class="navFooterDescSpacer" aria-hidden="true" style="width: 3%"></li>
+<li class="navFooterDescItem"><a href=https://kdp.amazon.com class="nav_a"><h5 class="navFooterDescItem_heading">Kindle Direct Publishing</h5><span class="navFooterDescText">Indie Digital & Print Publishing<br>Made Easy
+</span></a></li><li class="navFooterDescSpacer" aria-hidden="true" style="width: 3%"></li>
+<li class="navFooterDescItem"><a href=/gp/browse.html?node=13234696011&ref_=_gno_p_foot class="nav_a"><h5 class="navFooterDescItem_heading">Amazon Photos</h5><span class="navFooterDescText">Unlimited Photo Storage<br>Free With Prime</span></a></li><li class="navFooterDescSpacer" aria-hidden="true" style="width: 3%"></li>
+<li class="navFooterDescItem"><a href=https://videodirect.amazon.com/home/landing class="nav_a"><h5 class="navFooterDescItem_heading">Prime Video Direct</h5><span class="navFooterDescText">Video Distribution<br>Made Easy</span></a></li><li class="navFooterDescSpacer" aria-hidden="true" style="width: 3%"></li>
+<li class="navFooterDescItem"><a href=https://www.shopbop.com class="nav_a"><h5 class="navFooterDescItem_heading">Shopbop</h5><span class="navFooterDescText">Designer<br>Fashion Brands</span></a></li></ul>
+
+<ul>
+<li class="navFooterDescItem"><a href=/gp/browse.html?node=10158976011&ref_=footer_wrhsdls class="nav_a"><h5 class="navFooterDescItem_heading">Amazon Resale</h5><span class="navFooterDescText">Great Deals on<br>Quality Used Products </span></a></li><li class="navFooterDescSpacer" aria-hidden="true" style="width: 3%"></li>
+<li class="navFooterDescItem"><a href=https://www.wholefoodsmarket.com class="nav_a"><h5 class="navFooterDescItem_heading">Whole Foods Market</h5><span class="navFooterDescText">America’s Healthiest<br>Grocery Store</span></a></li><li class="navFooterDescSpacer" aria-hidden="true" style="width: 3%"></li>
+<li class="navFooterDescItem"><a href=https://www.woot.com/ class="nav_a"><h5 class="navFooterDescItem_heading">Woot!</h5><span class="navFooterDescText">Deals and <br>Shenanigans</span></a></li><li class="navFooterDescSpacer" aria-hidden="true" style="width: 3%"></li>
+<li class="navFooterDescItem"><a href=https://www.zappos.com class="nav_a"><h5 class="navFooterDescItem_heading">Zappos</h5><span class="navFooterDescText">Shoes &<br>Clothing</span></a></li><li class="navFooterDescSpacer" aria-hidden="true" style="width: 3%"></li>
+<li class="navFooterDescItem"><a href=https://ring.com class="nav_a"><h5 class="navFooterDescItem_heading">Ring</h5><span class="navFooterDescText">Smart Home<br>Security Systems
+</span></a></li><li class="navFooterDescSpacer" aria-hidden="true" style="width: 3%"></li>
+<li class="navFooterDescItem"><a href=https://eero.com/ class="nav_a"><h5 class="navFooterDescItem_heading">eero WiFi</h5><span class="navFooterDescText">Stream 4K Video<br>in Every Room</span></a></li><li class="navFooterDescSpacer" aria-hidden="true" style="width: 3%"></li>
+<li class="navFooterDescItem"><a href=https://blinkforhome.com/?ref=nav_footer class="nav_a"><h5 class="navFooterDescItem_heading">Blink</h5><span class="navFooterDescText">Smart Security<br>for Every Home
+</span></a></li></ul>
+
+<ul>
+<li class="navFooterDescItem" aria-hidden="true">&nbsp;</li>
+<li class="navFooterDescSpacer" aria-hidden="true" style="width: 3%"></li>
+<li class="navFooterDescItem"><a href=https://shop.ring.com/pages/neighbors-app class="nav_a"><h5 class="navFooterDescItem_heading">Neighbors App </h5><span class="navFooterDescText"> Real-Time Crime<br>& Safety Alerts
+</span></a></li><li class="navFooterDescSpacer" aria-hidden="true" style="width: 3%"></li>
+<li class="navFooterDescItem"><a href=https://www.pillpack.com class="nav_a"><h5 class="navFooterDescItem_heading">PillPack</h5><span class="navFooterDescText">Pharmacy Simplified</span></a></li><li class="navFooterDescSpacer" aria-hidden="true" style="width: 3%"></li>
+<li class="navFooterDescItem"><a href=/gp/browse.html?node=12653393011&ref_=footer_usrenew class="nav_a"><h5 class="navFooterDescItem_heading">Amazon Renewed</h5><span class="navFooterDescText">Refurbished tech<br>you can trust</span></a></li><li class="navFooterDescSpacer" aria-hidden="true" style="width: 3%"></li>
+<li class="navFooterDescItem"><a href=https://www.amazon.com/luna/landing-page?ref_=tmp_retail_footer class="nav_a"><h5 class="navFooterDescItem_heading">Amazon Luna</h5><span class="navFooterDescText">Video games from the cloud,<br>no console required</span></a></li><li class="navFooterDescSpacer" aria-hidden="true" style="width: 3%"></li>
+<li class="navFooterDescItem" aria-hidden="true">&nbsp;</li>
+<li class="navFooterDescSpacer" aria-hidden="true" style="width: 3%"></li>
+<li class="navFooterDescItem" aria-hidden="true">&nbsp;</li>
+</ul>
+
+    </div>
+  </div>
+
+  
+<div class="navFooterLine navFooterLinkLine navFooterPadItemLine navFooterCopyright">
+  <ul><li class="nav_first"><a href="/gp/help/customer/display.html?nodeId=508088&ref_=footer_cou" id="" class="nav_a">Conditions of Use</a> </li><li ><a href="/gp/help/customer/display.html?nodeId=GX7NJQ4ZB8MHFRNJ&ref_=footer_privacy" id="" class="nav_a">Privacy Notice</a> </li><li ><a href="/gp/help/customer/display.html?ie=UTF8&nodeId=TnACMrGVghHocjL8KB&ref_=footer_consumer_health_data_privacy" id="" class="nav_a">Consumer Health Data Privacy Disclosure</a> </li><li ><a href="/privacyprefs?ref_=footer_iba" id="" class="nav_a">Your Ads Privacy Choices</a> </li><li class="nav_last"><span id="nav-icon-ccba" class="nav-sprite"></span> </li></ul><span>© 1996-2026, Amazon.com, Inc. or its affiliates</span>
+</div>
+
+  
+</div>
+<div id="sis_pixel_r2" aria-hidden="true" style="height:1px; position: absolute; left: -1000000px; top: -1000000px;"></div><script>(function(a,b){a.attachEvent?a.attachEvent("onload",b):a.addEventListener&&a.addEventListener("load",b,!1)})(window,function(){setTimeout(function(){var el=document.getElementById("sis_pixel_r2");el&&(el.innerHTML='<iframe id="DAsis" src="//s.amazon-adsystem.com/iu3?d=amazon.com&slot=navFooter&a1=Pa0H5rShnQkRIq8WlkMU8f8DQ&a2=01016709f6cafa43f22654d7671acf3924df37dbcdf60879b9dbe25c7920f0251b8f&old_oo=0&ts=1781017457839&s=AVGTAb6uRpOiJmuqqfgdJHZRFgmsCRtITM6rd6Or7RZ0&gdpr_consent=&gdpr_consent_avl=&cb=1781017457839" width="1" height="1" frameborder="0" marginwidth="0" marginheight="0" scrolling="no" tabindex="-1" sandbox></iframe>');var event=new Event("SISPixelCardLoaded");document.dispatchEvent(event);},300)});</script>
+
+  <!-- NAVYAAN FOOTER END -->
+
+<!-- sp:end-feature:nav-footer -->
+<!-- sp:feature:configured-sitewide-assets -->
+<script>
+(window.AmazonUIPageJS ? AmazonUIPageJS : P).when('afterLoad').execute(function() {
+  (window.AmazonUIPageJS ? AmazonUIPageJS : P).load.js('https://m.media-amazon.com/images/I/41L1IVbo18L.js?AUIClients/BotCXMetricsCollectionJSAsset#1387102-T1');
+});
+</script>
+<script>
+(window.AmazonUIPageJS ? AmazonUIPageJS : P).when('afterLoad').execute(function() {
+  (window.AmazonUIPageJS ? AmazonUIPageJS : P).load.js('https://m.media-amazon.com/images/I/41bvOomAKpL.js?AUIClients/LatencyInteractiveAsset');
+});
+</script>
+<script>
+(window.AmazonUIPageJS ? AmazonUIPageJS : P).when('afterLoad').execute(function() {
+  (window.AmazonUIPageJS ? AmazonUIPageJS : P).load.js('https://m.media-amazon.com/images/I/31K7r4R7c1L.js?AUIClients/BotDetectionJSSignalCollectionAsset');
+});
+</script>
+<script>
+(window.AmazonUIPageJS ? AmazonUIPageJS : P).when('afterLoad').execute(function() {
+(function(e,d,f){f=function(){};var k=e.ue||{},m=function(c){return function(){try{return c.apply(this,arguments)}catch(b){l(b,"FATAL")}}},l=function(c){return function(b,a){a||(a="ERROR");b=b&&b.stack&&b.message?b:JSON.stringify(b);c({logLevel:a,attribution:"EdgeRECONAssets",message:b})}}(e.ueLogError||f);(function(c){return function(b,a){c("EdgeRECONAssets:"+b,a)}})(k.count||f)("registered",1);var g=function(){try{var c=d.createElement("link").relList.supports("preload")}catch(b){c=!1}return function(b){var a=
+c?d.createElement("link"):new Image;a.onerror=a.onload=m(function(){a&&a.parentElement&&a.parentElement.removeChild(a)});c?(a.rel="preload",a.as="image",a.referrerPolicy="strict-origin-when-cross-origin",a.href=b,d.head.appendChild(a)):(a.style.display="none",a.referrerPolicy="strict-origin-when-cross-origin",a.src=b,d.documentElement.appendChild(a))}}(),h="https://redirect.prod.experiment.routing.cloudfront.aws.a2z.com/x.png?timestamp\x3d"+(new Date).getTime().toString();"loading"!==d.readyState?
+setTimeout(g,1E3,h):e.addEventListener&&e.addEventListener("DOMContentLoaded",function(){setTimeout(g,1E3,h)})})(window,document);
+});
+</script>
+<script>
+(window.AmazonUIPageJS ? AmazonUIPageJS : P).when('afterLoad').execute(function() {
+  (window.AmazonUIPageJS ? AmazonUIPageJS : P).load.js('https://m.media-amazon.com/images/I/511wnkyCr7L.js?AUIClients/AmazonLightsaberPageAssets#1334498-T1.1279464-T1');
+});
+</script>
+<link rel="stylesheet" href="https://m.media-amazon.com/images/I/11ZxbGB3PBL.css?AUIClients/WebFlowIngressJs" />
+<script>
+(window.AmazonUIPageJS ? AmazonUIPageJS : P).when('afterLoad').execute(function() {
+  (window.AmazonUIPageJS ? AmazonUIPageJS : P).load.js('https://m.media-amazon.com/images/I/21a1o3dUMiL.js?AUIClients/WebFlowIngressJs');
+});
+</script>
+<script>
+(window.AmazonUIPageJS ? AmazonUIPageJS : P).when('afterLoad').execute(function() {
+  (window.AmazonUIPageJS ? AmazonUIPageJS : P).load.js('https://m.media-amazon.com/images/I/11yU05wG9HL.js?AUIClients/RufusAutomationsDesktop');
+});
+</script>
+<script>
+(window.AmazonUIPageJS ? AmazonUIPageJS : P).when('afterLoad').execute(function() {
+  (window.AmazonUIPageJS ? AmazonUIPageJS : P).load.js('https://m.media-amazon.com/images/I/11hjEQigGEL.js?AUIClients/RufusDeepResearchDesktop');
+});
+</script>
+<!-- sp:end-feature:configured-sitewide-assets -->
+<!-- sp:feature:customer-behavior-js -->
+<script type="text/javascript">if (window.ue && ue.tag) { ue.tag('FWCIMEnabled'); }</script>
+<script type="text/javascript">window.fwcimData = { customerId: 'AEXAMPLE00000' };</script>
+<script>
+(window.AmazonUIPageJS ? AmazonUIPageJS : P).when('afterLoad').execute(function() {
+  (window.AmazonUIPageJS ? AmazonUIPageJS : P).load.js('https://m.media-amazon.com/images/I/81kCF8wuZEL.js?AUIClients/FWCIMAssets');
+});
+</script>
+<!-- sp:end-feature:customer-behavior-js -->
+<!-- sp:feature:csm:body-close -->
+<div id='be' style="display:none;visibility:hidden;"><form name='ue_backdetect' action="get"><input type="hidden" name='ue_back' value='1' /></form>
+
+
+<script type="text/javascript">
+window.ue_ibe = (window.ue_ibe || 0) + 1;
+if (window.ue_ibe === 1) {
+(function(e,c){function h(b,a){f.push([b,a])}function g(b,a){if(b){var c=e.head||e.getElementsByTagName("head")[0]||e.documentElement,d=e.createElement("script");d.async="async";d.src=b;d.setAttribute("crossorigin","anonymous");a&&a.onerror&&(d.onerror=a.onerror);a&&a.onload&&(d.onload=a.onload);c.insertBefore(d,c.firstChild)}}function k(){ue.uels=g;for(var b=0;b<f.length;b++){var a=f[b];g(a[0],a[1])}ue.deffered=1}var f=[];c.ue&&(ue.uels=h,c.ue.attach&&c.ue.attach("load",k))})(document,window);
+
+
+if (window.ue && window.ue.uels) {
+        var cel_widgets = [ { "c":"celwidget" },{ "s":"#nav-swmslot > div", "id_gen":function(elem, index){ return 'nav_sitewide_msg'; } } ];
+
+                ue.uels("https://images-na.ssl-images-amazon.com/images/I/215h87l68bL.js");
+}
+var ue_mbl=ue_csm.ue.exec(function(g,b){function m(c){a=c||{};b.AMZNPerformance=a;a.transition=a.transition||{};a.timing=a.timing||{};if(b.csa){var d;a.timing.transitionStart&&(d=a.timing.transitionStart);a.timing.processStart&&(d=a.timing.processStart);d&&(csa("PageTiming")("mark","nativeTransitionStart",d),csa("PageTiming")("mark","transitionStart",d))}g.ue.exec(n,"csm-android-check")()&&a.tags instanceof Array&&(c=-1!=a.tags.indexOf("usesAppStartTime")||a.transition.type?!a.transition.type&&-1<
+a.tags.indexOf("usesAppStartTime")?"warm-start":void 0:"view-transition",c&&(a.transition.type=c));"reload"===f._nt&&g.ue_orct||"intrapage-transition"===f._nt?e&&e.timing&&e.timing.navigationStart?a.timing.transitionStart=e.timing.navigationStart:delete a.timing.transitionStart:"undefined"===typeof f._nt&&e&&e.timing&&e.timing.navigationStart&&b.history&&"function"===typeof b.History&&"object"===typeof b.history&&b.history.length&&1!=b.history.length&&(a.timing.transitionStart=e.timing.navigationStart);
+c=a.transition;d=f._nt?f._nt:void 0;c.subType=d;b.ue&&b.ue.tag&&b.ue.tag("has-AMZNPerformance");f.isl&&b.uex&&b.uex("at","csm-timing");p()}function q(a){b.ue&&b.ue.count&&b.ue.count("csm-cordova-plugin-failed",1)}function n(){return b.cordova&&b.cordova.platformId&&"android"==b.cordova.platformId}function p(){try{b.P.register("AMZNPerformance",function(){return a})}catch(c){}}function l(){if(!a)return"";ue_mbl.cnt=null;var c=a.timing,d=a.transition,d=["mts",h(c.transitionStart),"mps",h(c.processStart),
+"mtt",d.type,"mtst",d.subType,"mtlt",d.launchType];b.ue&&b.ue.tag&&(c.fr_ovr&&b.ue.tag("fr_ovr"),c.fcp_ovr&&b.ue.tag("fcp_ovr"),d.push("fr_ovr",h(c.fr_ovr),"fcp_ovr",h(c.fcp_ovr)));for(var c="",e=0;e<d.length;e+=2){var f=d[e],g=d[e+1];"undefined"!==typeof g&&(c+="&"+f+"="+g)}return c}function h(a){if("undefined"!==typeof a&&"undefined"!==typeof k)return a-k}function r(b,d){a&&(k=d,a.timing.transitionStart=b,a.transition.type="view-transition",a.transition.subType="ajax-transition",a.transition.launchType=
+"normal",ue_mbl.cnt=l)}var f=g.ue||{},k=g.ue_t0,e=b.performance,a;if(b.P&&b.P.when&&b.P.register)return b.P.when("CSMPlugin").execute(function(a){a.buildAMZNPerformance&&a.buildAMZNPerformance({successCallback:m,failCallback:q})}),{cnt:l,ajax:r}},"mobile-timing")(ue_csm,ue_csm.window);
+
+(function(d){d._uess=function(){var a="";screen&&screen.width&&screen.height&&(a+="&sw="+screen.width+"&sh="+screen.height);var b=function(a){var b=document.documentElement["client"+a];return"CSS1Compat"===document.compatMode&&b||document.body["client"+a]||b},c=b("Width"),b=b("Height");c&&b&&(a+="&vw="+c+"&vh="+b);return a}})(ue_csm);
+
+(function(a){function d(a){c&&c("log",a)}var b=document.ue_backdetect,c=a.csa&&a.csa("Errors",{producerId:"csa",logOptions:{ent:"all"}});a.ue_err.buffer&&c&&(a.ue_err.buffer.forEach(d),a.ue_err.buffer.push=d);b&&b.ue_back&&a.ue&&(a.ue.bfini=b.ue_back.value);a.uet&&a.uet("be");a.onLdEnd&&(window.addEventListener?window.addEventListener("load",a.onLdEnd,!1):window.attachEvent&&window.attachEvent("onload",a.onLdEnd));a.ueh&&a.ueh(0,window,"load",a.onLd,1);a.ue&&a.ue.tag&&(a.ue_furl?(b=a.ue_furl.replace(/\./g,
+"-"),a.ue.tag(b)):a.ue.tag("nofls"))})(ue_csm);
+
+(function(g,h){function d(a,d){var b={};if(!e||!f)try{var c=h.sessionStorage;c?a&&("undefined"!==typeof d?c.setItem(a,d):b.val=c.getItem(a)):f=1}catch(g){e=1}e&&(b.e=1);return b}var b=g.ue||{},a="",f,e,c,a=d("csmtid");f?a="NA":a.e?a="ET":(a=a.val,a||(a=b.oid||"NI",d("csmtid",a)),c=d(b.oid),c.e||(c.val=c.val||0,d(b.oid,c.val+1)),b.ssw=d);b.tabid=a})(ue_csm,ue_csm.window);
+
+(function(a){var e={rc:1,hob:1,hoe:1,ntd:1,rd_:1,_rd:1};"function"===typeof window.addEventListener&&window.addEventListener("pageshow",function(b){if(b&&b.persisted&&(b=+new Date,b={clickTime:b-1,pageVisible:b},"object"===typeof b&&"object"===typeof a.ue.markers&&"object"===typeof a.ue&&"function"===typeof a.uex)){if("function"===typeof a.uet){for(var c in a.ue.markers)!a.ue.markers.hasOwnProperty(c)||c in e||a.uet(c,void 0,void 0,b.pageVisible);a.uet("tc",void 0,void 0,b.clickTime);a.uet("ty",void 0,
+void 0,b.clickTime+2)}(c=document.ue_backdetect)&&c.ue_back&&(a.ue.bfini=+c.ue_back.value+1);a.ue.isBFonMshop=!0;a.ue.isBFCache=!0;a.ue.t0=b.clickTime;a.ue.viz=["visible:0"];"function"===typeof a.ue.tag&&(a.ue.tag("cacheSourceMemory"),a.ue.tag("history-navigation-page-cache"));c=ue_csm.csa&&ue_csm.csa("SPA");var d=ue_csm.csa&&ue_csm.csa("PageTiming");c&&d&&(c("newPage",{transitionType:"history-navigation-page-cache"},{keepPageAttributes:!0}),d("mark","transitionStart",b.clickTime));"function"===typeof a.uex&&
+a.uex("ld",void 0,void 0,a.ue.t.ld);delete a.ue.isBFonMshop;delete a.ue.isBFCache}})})(ue_csm);
+
+ue_csm.ue.exec(function(e,f){var a=e.ue||{},b=a._wlo,d;if(a.ssw){d=a.ssw("CSM_previousURL").val;var c=f.location,b=b?b:c&&c.href?c.href.split("#")[0]:void 0;c=(b||"")===a.ssw("CSM_previousURL").val;!c&&b&&a.ssw("CSM_previousURL",b);d=c?"reload":d?"intrapage-transition":"first-view"}else d="unknown";a._nt=d},"NavTypeModule")(ue_csm,window);
+ue_csm.ue.exec(function(c,a){function g(a){a.run(function(e){d.tag("csm-feature-"+a.name+":"+e);d.isl&&c.uex("at")})}if(a.addEventListener)for(var d=c.ue||{},f=[{name:"touch-enabled",run:function(b){var e=function(){a.removeEventListener("touchstart",c,!0);a.removeEventListener("mousemove",d,!0)},c=function(){b("true");e()},d=function(){b("false");e()};a.addEventListener("touchstart",c,!0);a.addEventListener("mousemove",d,!0)}}],b=0;b<f.length;b++)g(f[b])},"csm-features")(ue_csm,window);
+
+
+(function(a,e){function d(a){b&&b("recordCounter",a.c,a.v)}var c=e.images,b;a.ue_act?(b=a.csa&&a.csa("Metrics",{producerId:"csa",dimensions:{type:a.ue_act}}))&&b("recordMetric","actorType",1):b=a.csa&&a.csa("Metrics",{producerId:"csa"});c&&c.length&&a.ue.count("totalImages",c.length);a.ue.cv.buffer&&b&&(a.ue.cv.buffer.forEach(d),a.ue.cv.buffer.push=d)})(ue_csm,document);
+(function(b){function c(){var f=[];a.log&&a.log.isStub&&a.log.replay(function(a){d(f,a)});a.clog&&a.clog.isStub&&a.clog.replay(function(a){d(f,a)});f.length&&(a._flhs+=1,p&&(a._lpn.csm=(a._lpn.csm||0)+1),q(f))}function h(){a.log&&a.log.isStub&&(a.onflush&&a.onflush.replay&&a.onflush.replay(function(a){a[0]()}),a.onunload&&a.onunload.replay&&a.onunload.replay(function(a){a[0]()}),c())}function d(b,g){var c=g[1],e=g[0],d={};a._lpn[c]=(a._lpn[c]||0)+1;d[c]=e;b.push(d)}function q(a){if(k)a=l(a),b.navigator.sendBeacon(m,
+a);else{a=l(a);var c=new b[e];c.open("POST",m,!0);c.setRequestHeader&&c.setRequestHeader("Content-type","text/plain");c.send(a)}}function l(a){return JSON.stringify({rid:b.ue_id,sid:b.ue_sid,mid:b.ue_mid,mkt:b.ue_mkt,sn:b.ue_sn,reqs:a})}var e="XMLHttpRequest",p=1===b.ue_ddq,a=b.ue,r=b[e]&&"withCredentials"in new b[e],k=b.navigator&&b.navigator.sendBeacon,m="//"+b.ue_furl+"/1/batch/1/OE/",n=b.ue_fci_ft||5E3;a&&(r||k)&&(a._flhs=a._flhs||0,a._lpn=a._lpn||{},a.attach&&(a.attach("beforeunload",a.exec(h,
+"fcli-bfu")),a.attach("pagehide",a.exec(h,"fcli-ph"))),n&&b.setTimeout(a.exec(c,"fcli-t"),n),a._ffci=a.exec(c))})(window);
+
+
+(function(k,c){function l(a,b){return a.filter(function(a){return a.initiatorType==b})}function f(a,c){if(b.t[a]){var g=b.t[a]-b._t0,e=c.filter(function(a){return 0!==a.responseEnd&&m(a)<g}),f=l(e,"script"),h=l(e,"link"),k=l(e,"img"),n=e.map(function(a){return a.name.split("/")[2]}).filter(function(a,b,c){return a&&c.lastIndexOf(a)==b}),q=e.filter(function(a){return a.duration<p}),s=g-Math.max.apply(null,e.map(m))<r|0;"af"==a&&(b._afjs=f.length);return a+":"+[e[d],f[d],h[d],k[d],n[d],q[d],s].join("-")}}
+function m(a){return a.responseEnd-(b._t0-c.timing.navigationStart)}function n(){var a=c[h]("resource"),d=f("cf",a),g=f("af",a),a=f("ld",a);delete b._rt;b._ld=b.t.ld-b._t0;b._art&&b._art();return[d,g,a].join("_")}var p=20,r=50,d="length",b=k.ue,h="getEntriesByType";b._rre=m;b._rt=c&&c.timing&&c[h]&&n})(ue_csm,window.performance);
+
+
+(function(c,d){var b=c.ue,a=d.navigator;b&&b.tag&&a&&(a=a.connection||a.mozConnection||a.webkitConnection)&&a.type&&b.tag("netInfo:"+a.type)})(ue_csm,window);
+
+
+(function(c,d){function h(a,b){for(var c=[],d=0;d<a.length;d++){var e=a[d],f=b.encode(e);if(e[k]){var g=b.metaSep,e=e[k],l=b.metaPairSep,h=[],m=void 0;for(m in e)e.hasOwnProperty(m)&&h.push(m+"="+e[m]);e=h.join(l);f+=g+e}c.push(f)}return c.join(b.resourceSep)}function s(a){var b=a[k]=a[k]||{};b[t]||(b[t]=c.ue_mid);b[u]||(b[u]=c.ue_sid);b[f]||(b[f]=c.ue_id);b.csm=1;a="//"+c.ue_furl+"/1/"+a[v]+"/1/OP/"+a[w]+"/"+a[x]+"/"+h([a],y);if(n)try{n.call(d[p],a)}catch(g){c.ue.sbf=1,(new Image).src=a}else(new Image).src=
+a}function q(){g&&g.isStub&&g.replay(function(a,b,c){a=a[0];b=a[k]=a[k]||{};b[f]=b[f]||c;s(a)});l.impression=s;g=null}if(!(1<c.ueinit)){var k="metadata",x="impressionType",v="foresterChannel",w="programGroup",t="marketplaceId",u="session",f="requestId",p="navigator",l=c.ue||{},n=d[p]&&d[p].sendBeacon,r=function(a,b,c,d){return{encode:d,resourceSep:a,metaSep:b,metaPairSep:c}},y=r("","?","&",function(a){return h(a.impressionData,z)}),z=r("/",":",",",function(a){return a.featureName+":"+h(a.resources,
+A)}),A=r(",","@","|",function(a){return a.id}),g=l.impression;n?q():(l.attach("load",q),l.attach("beforeunload",q));try{d.P&&d.P.register&&d.P.register("impression-client",function(){})}catch(B){c.ueLogError(B,{logLevel:"WARN"})}}})(ue_csm,window);
+
+
+
+var ue_pty = "F3OmnichannelPostOrder";
+
+var ue_spty = "OrderDetails";
+
+
+
+var ue_adb = 4;
+var ue_adb_rtla = 1;
+ue_csm.ue.exec(function(y,a){function t(){if(d&&f){var a;a:{try{a=d.getItem(g);break a}catch(c){}a=void 0}if(a)return b=a,!0}return!1}function u(){if(a.fetch)fetch(m).then(function(a){if(!a.ok)throw Error(a.statusText);return a.text?a.text():null}).then(function(b){b?(-1<b.indexOf("window.ue_adb_chk = 1")&&(a.ue_adb_chk=1),n()):h()})["catch"](h);else e.uels(m,{onerror:h,onload:n})}function h(){b=k;l();if(f)try{d.setItem(g,b)}catch(a){}}function n(){b=1===a.ue_adb_chk?p:k;l();if(f)try{d.setItem(g,
+b)}catch(c){}}function q(){a.ue_adb_rtla&&c&&0<c.ec&&!1===r&&(c.elh=null,ueLogError({m:"Hit Info",fromOnError:1},{logLevel:"INFO",adb:b}),r=!0)}function l(){e.tag(b);e.isl&&a.uex&&uex("at",b);s&&s.updateCsmHit("adb",b);c&&0<c.ec?q():a.ue_adb_rtla&&c&&(c.elh=q)}function v(){return b}if(a.ue_adb){a.ue_fadb=a.ue_fadb||10;var e=a.ue,k="adblk_yes",p="adblk_no",m="https://m.media-amazon.com/images/G/01/csm/showads.v2.js?adspot_=1",b="adblk_unk",d;a:{try{d=a.localStorage;break a}catch(z){}d=void 0}var g=
+"csm:adb",c=a.ue_err,s=e.cookie,f=void 0!==a.localStorage,w=Math.random()>1-1/a.ue_fadb,r=!1,x=t();w||!x?u():l();a.ue_isAdb=v;a.ue_isAdb.unk="adblk_unk";a.ue_isAdb.no=p;a.ue_isAdb.yes=k}},"adb")(document,window);
+
+
+
+
+(function(c,l,m){function h(a){if(a)try{if(a.id)return"//*[@id='"+a.id+"']";var b,d=1,e;for(e=a.previousSibling;e;e=e.previousSibling)e.nodeName===a.nodeName&&(d+=1);b=d;var c=a.nodeName;1!==b&&(c+="["+b+"]");a.parentNode&&(c=h(a.parentNode)+"/"+c);return c}catch(f){return"DETACHED"}}function f(a){if(a&&a.getAttribute)return a.getAttribute(k)?a.getAttribute(k):f(a.parentElement)}var k="data-cel-widget",g=!1,d=[];(c.ue||{}).isBF=function(){try{var a=JSON.parse(localStorage["csm-bf"]||"[]"),b=0<=a.indexOf(c.ue_id);
+a.unshift(c.ue_id);a=a.slice(0,20);localStorage["csm-bf"]=JSON.stringify(a);return b}catch(d){return!1}}();c.ue_utils={getXPath:h,getFirstAscendingWidget:function(a,b){c.ue_cel&&c.ue_fem?!0===g?b(f(a)):d.push({element:a,callback:b}):b()},notifyWidgetsLabeled:function(){if(!1===g){g=!0;for(var a=f,b=0;b<d.length;b++)if(d[b].hasOwnProperty("callback")&&d[b].hasOwnProperty("element")){var c=d[b].callback,e=d[b].element;"function"===typeof c&&"function"===typeof a&&c(a(e))}d=null}},extractStringValue:function(a){if("string"===
+typeof a)return a}}})(ue_csm,window,document);
+
+
+(function(a){a.ue_cel||(a.ue_cel=function(){function m(a,r){r?r.r=u:r={r:u,c:1};D||(!ue_csm.ue_sclog&&r.clog&&b.clog?b.clog(a,r.ns||s,r):r.glog&&b.glog?b.glog(a,r.ns||s,r):b.log(a,r.ns||s,r))}function n(a,b){"function"===typeof p&&p("log",{schemaId:t+".RdCSI.1",eventType:a,clientData:b},{ent:{page:["requestId"]}})}function c(){var a=q.length;if(0<a){for(var r=[],c=0;c<a;c++){var d=q[c].api;d.ready()?(d.on({ts:b.d,ns:s}),g.push(q[c]),m({k:"mso",n:q[c].name,t:b.d()})):r.push(q[c])}q=r}}function f(){if(!f.executed){for(var a=
+0;a<g.length;a++)g[a].api.off&&g[a].api.off({ts:b.d,ns:s});B();m({k:"eod",t0:b.t0,t:b.d()},{c:1,il:1});f.executed=1;for(a=0;a<g.length;a++)q.push(g[a]);g=[];d(v);d(A)}}function B(a){m({k:"hrt",t:b.d()},{c:1,il:1,n:a});y=Math.min(w,e*y);z()}function z(){d(A);A=k(function(){B(!0)},y)}function x(){f.executed||B()}var l=a.window,k=l.setTimeout,d=l.clearTimeout,e=1.5,w=l.ue_cel_max_hrt||3E4,t="robotdetection",q=[],g=[],s=a.ue_cel_ns||"cel",v,A,b=a.ue,F=a.uet,C=a.uex,u=b.rid,D=a.ue_dsbl_cel,h=l.csa,p,y=
+l.ue_cel_hrt_int||3E3,E=l.requestAnimationFrame||function(a){a()};h&&(p=h("Events",{producerId:t}));if(b.isBF)m({k:"bft",t:b.d()});else{"function"==typeof F&&F("bb","csmCELLSframework",{wb:1});k(c,0);b.onunload(f);if(b.onflush)b.onflush(x);v=k(f,6E5);z();"function"==typeof C&&C("ld","csmCELLSframework",{wb:1});return{registerModule:function(a,r){q.push({name:a,api:r});m({k:"mrg",n:a,t:b.d()});c()},reset:function(a){m({k:"rst",t0:b.t0,t:b.d()});q=q.concat(g);g=[];for(var r=q.length,e=0;e<r;e++)q[e].api.off(),
+q[e].api.reset();u=a||b.rid;c();d(v);v=k(f,6E5);f.executed=0},timeout:function(a,b){return k(function(){E(function(){f.executed||a()})},b)},log:m,csaEventLog:n,off:f}}}())})(ue_csm);
+(function(a){a.ue_pdm||!a.ue_cel||a.ue.isBF||(a.ue_pdm=function(){function m(){try{var b=d.screen;if(b){var c={w:b.width,aw:b.availWidth,h:b.height,ah:b.availHeight,cd:b.colorDepth,pd:b.pixelDepth};g&&g.w===c.w&&g.h===c.h&&g.aw===c.aw&&g.ah===c.ah&&g.pd===c.pd&&g.cd===c.cd||(g=c,g.t=t(),g.k="sci",F(g),D&&h("sci",{h:(g.h||"0")+""}))}var k=e.body||{},f=e.documentElement||{},n={w:Math.max(k.scrollWidth||0,k.offsetWidth||0,f.clientWidth||0,f.scrollWidth||0,f.offsetWidth||0),h:Math.max(k.scrollHeight||
+0,k.offsetHeight||0,f.clientHeight||0,f.scrollHeight||0,f.offsetHeight||0)};s&&s.w===n.w&&s.h===n.h||(s=n,s.t=t(),s.k="doi",F(s));w=a.ue_cel.timeout(m,q);A+=1}catch(p){d.ueLogError&&ueLogError(p,{attribution:"csm-cel-page-module",logLevel:"WARN"})}}function n(){x("ebl","default",!1)}function c(){x("efo","default",!0)}function f(){x("ebl","app",!1)}function B(){x("efo","app",!0)}function z(){d.setTimeout(function(){e[E]?x("ebl","pageviz",!1):x("efo","pageviz",!0)},0)}function x(a,b,c){v!==c&&(F({k:a,
+t:t(),s:b},{ff:!0===c?0:1}),D&&h(a,{t:(t()||"0")+"",s:b}));v=c}function l(){b.attach&&(p&&b.attach(y,z,e),G&&P.when("mash").execute(function(a){a&&a.addEventListener&&(a.addEventListener("appPause",f),a.addEventListener("appResume",B))}),b.attach("blur",n,d),b.attach("focus",c,d))}function k(){b.detach&&(p&&b.detach(y,z,e),G&&P.when("mash").execute(function(a){a&&a.removeEventListener&&(a.removeEventListener("appPause",f),a.removeEventListener("appResume",B))}),b.detach("blur",n,d),b.detach("focus",
+c,d))}var d=a.window,e=a.document,w,t,q,g,s,v=null,A=0,b=a.ue,F=a.ue_cel.log,C=a.uet,u=a.uex,D=d.csa,h=a.ue_cel.csaEventLog,p=!!b.pageViz,y=p&&b.pageViz.event,E=p&&b.pageViz.propHid,G=d.P&&d.P.when;"function"==typeof C&&C("bb","csmCELLSpdm",{wb:1});return{on:function(a){q=a.timespan||500;t=a.ts;l();a=d.location;F({k:"pmd",o:a.origin,p:a.pathname,t:t()});m();"function"==typeof u&&u("ld","csmCELLSpdm",{wb:1})},off:function(a){clearTimeout(w);k();b.count&&b.count("cel.PDM.TotalExecutions",A)},ready:function(){return e.body&&
+a.ue_cel&&a.ue_cel.log},reset:function(){g=s=null}}}(),a.ue_cel&&a.ue_cel.registerModule("page module",a.ue_pdm))})(ue_csm);
+(function(a){a.ue_vpm||!a.ue_cel||a.ue.isBF||(a.ue_vpm=function(){function m(){var a=z(),b={w:k.innerWidth,h:k.innerHeight,x:k.pageXOffset,y:k.pageYOffset};c&&c.w==b.w&&c.h==b.h&&c.x==b.x&&c.y==b.y||(b.t=a,b.k="vpi",c=b,e(c,{clog:1}),s&&v("vpi",{t:(c.t||"0")+"",h:(c.h||"0")+"",y:(c.y||"0")+"",w:(c.w||"0")+"",x:(c.x||"0")+""}));f=0;x=z()-a;l+=1}function n(){f||(f=a.ue_cel.timeout(m,B))}var c,f,B,z,x=0,l=0,k=a.window,d=a.ue,e=a.ue_cel.log,w=a.uet,t=a.uex,q=d.attach,g=d.detach,s=k.csa,v=a.ue_cel.csaEventLog;
+"function"==typeof w&&w("bb","csmCELLSvpm",{wb:1});return{on:function(a){z=a.ts;B=a.timespan||100;m();q&&(q("scroll",n),q("resize",n));"function"==typeof t&&t("ld","csmCELLSvpm",{wb:1})},off:function(a){clearTimeout(f);g&&(g("scroll",n),g("resize",n));d.count&&(d.count("cel.VPI.TotalExecutions",l),d.count("cel.VPI.TotalExecutionTime",x),d.count("cel.VPI.AverageExecutionTime",x/l))},ready:function(){return a.ue_cel&&a.ue_cel.log},reset:function(){c=void 0},getVpi:function(){return c}}}(),a.ue_cel&&
+a.ue_cel.registerModule("viewport module",a.ue_vpm))})(ue_csm);
+(function(a){if(!a.ue_fem&&a.ue_cel&&a.ue_utils){var m=a.ue||{},n=a.window,c=n.document;!m.isBF&&!a.ue_fem&&c.querySelector&&n.getComputedStyle&&[].forEach&&(a.ue_fem=function(){function f(a,b){return a>b?3>a-b:3>b-a}function B(a,b){var c=n.pageXOffset,d=n.pageYOffset,k;a:{try{if(a){var e=a.getBoundingClientRect(),g,m=0===a.offsetWidth&&0===a.offsetHeight;c:{for(var h=a.parentNode,p=e.left||0,w=e.top||0,q=e.width||0,s=e.height||0;h&&h!==document.body;){var l;d:{try{var r=void 0;if(h)var t=h.getBoundingClientRect(),
+r={x:t.left||0,y:t.top||0,w:t.width||0,h:t.height||0};else r=void 0;l=r;break d}catch(I){}l=void 0}var u=window.getComputedStyle(h),v="hidden"===u.overflow,x=v||"hidden"===u.overflowX,y=v||"hidden"===u.overflowY,z=w+s-1<l.y+1||w+1>l.y+l.h-1;if((p+q-1<l.x+1||p+1>l.x+l.w-1)&&x||z&&y){g=!0;break c}h=h.parentNode}g=!1}k={x:e.left+c||0,y:e.top+d||0,w:e.width||0,h:e.height||0,d:(m||g)|0}}else k=void 0;break a}catch(J){}k=void 0}if(k&&!a.cel_b)a.cel_b=k,D({n:a.getAttribute(A),w:a.cel_b.w,h:a.cel_b.h,d:a.cel_b.d,
+x:a.cel_b.x,y:a.cel_b.y,t:b,k:"ewi",cl:a.className},{clog:1});else{if(c=k)c=a.cel_b,d=k,c=d.d===c.d&&1===d.d?!1:!(f(c.x,d.x)&&f(c.y,d.y)&&f(c.w,d.w)&&f(c.h,d.h)&&c.d===d.d);c&&(a.cel_b=k,D({n:a.getAttribute(A),w:a.cel_b.w,h:a.cel_b.h,d:a.cel_b.d,x:a.cel_b.x,y:a.cel_b.y,t:b,k:"ewi"},{clog:1}))}}function z(d,e){var f;f=d.c?c.getElementsByClassName(d.c):d.id?[c.getElementById(d.id)]:c.querySelectorAll(d.s);d.w=[];for(var g=0;g<f.length;g++){var h=f[g];if(h){if(!h.getAttribute(A)){var l=h.getAttribute("cel_widget_id")||
+(d.id_gen||u)(h,g)||h.id;h.setAttribute(A,l)}d.w.push(h);k(Q,h,e)}}!1===C&&(F++,F===b.length&&(C=!0,a.ue_utils.notifyWidgetsLabeled()))}function x(a,b){h.contains(a)||D({n:a.getAttribute(A),t:b,k:"ewd"},{clog:1})}function l(a){K.length&&ue_cel.timeout(function(){if(s){for(var b=R(),c=!1;R()-b<g&&!c;){for(c=S;0<c--&&0<K.length;){var d=K.shift();T[d.type](d.elem,d.time)}c=0===K.length}U++;l(a)}},0)}function k(a,b,c){K.push({type:a,elem:b,time:c})}function d(a,c){for(var d=0;d<b.length;d++)for(var e=
+b[d].w||[],h=0;h<e.length;h++)k(a,e[h],c)}function e(){M||(M=a.ue_cel.timeout(function(){M=null;var c=v();d(W,c);for(var e=0;e<b.length;e++)k(X,b[e],c);0===b.length&&!1===C&&(C=!0,a.ue_utils.notifyWidgetsLabeled());l(c)},q))}function w(){M||N||(N=a.ue_cel.timeout(function(){N=null;var a=v();d(Q,a);l(a)},q))}function t(){return y&&E&&h&&h.contains&&h.getBoundingClientRect&&v}var q=50,g=4.5,s=!1,v,A="data-cel-widget",b=[],F=0,C=!1,u=function(){},D=a.ue_cel.log,h,p,y,E,G=n.MutationObserver||n.WebKitMutationObserver||
+n.MozMutationObserver,r=!!G,H,I,O="DOMAttrModified",L="DOMNodeInserted",J="DOMNodeRemoved",N,M,K=[],U=0,S=null,W="removedWidget",X="updateWidgets",Q="processWidget",T,V=n.performance||{},R=V.now&&function(){return V.now()}||function(){return Date.now()};"function"==typeof uet&&uet("bb","csmCELLSfem",{wb:1});return{on:function(d){function k(){if(t()){T={removedWidget:x,updateWidgets:z,processWidget:B};if(r){var a={attributes:!0,subtree:!0};H=new G(w);I=new G(e);H.observe(h,a);I.observe(h,{childList:!0,
+subtree:!0});I.observe(p,a)}else y.call(h,O,w),y.call(h,L,e),y.call(h,J,e),y.call(p,L,w),y.call(p,J,w);e()}}h=c.body;p=c.head;y=h.addEventListener;E=h.removeEventListener;v=d.ts;b=a.cel_widgets||[];S=d.bs||5;m.deffered?k():m.attach&&m.attach("load",k);"function"==typeof uex&&uex("ld","csmCELLSfem",{wb:1});s=!0},off:function(){t()&&(I&&(I.disconnect(),I=null),H&&(H.disconnect(),H=null),E.call(h,O,w),E.call(h,L,e),E.call(h,J,e),E.call(p,L,w),E.call(p,J,w));m.count&&m.count("cel.widgets.batchesProcessed",
+U);s=!1},ready:function(){return a.ue_cel&&a.ue_cel.log},reset:function(){b=a.cel_widgets||[]}}}(),a.ue_cel&&a.ue_fem&&a.ue_cel.registerModule("features module",a.ue_fem))}})(ue_csm);
+(function(a){!a.ue_mcm&&a.ue_cel&&a.ue_utils&&!a.ue.isBF&&(a.ue_mcm=function(){function m(a,d){var e=a.srcElement||a.target||{},f={k:n,w:(d||{}).ow||(B.body||{}).scrollWidth,h:(d||{}).oh||(B.body||{}).scrollHeight,t:(d||{}).ots||c(),x:a.pageX,y:a.pageY,p:l.getXPath(e),n:e.nodeName};z&&"function"===typeof z.now&&a.timeStamp&&(f.dt=(d||{}).odt||z.now()-a.timeStamp,f.dt=parseFloat(f.dt.toFixed(2)));a.button&&(f.b=a.button);e.href&&(f.r=l.extractStringValue(e.href));e.id&&(f.i=e.id);e.className&&e.className.split&&
+(f.c=e.className.split(/\s+/));x(f,{c:1})}var n="mcm",c,f=a.window,B=f.document,z=f.performance,x=a.ue_cel.log,l=a.ue_utils;return{on:function(k){c=k.ts;a.ue_cel_stub&&a.ue_cel_stub.replayModule(n,m);f.addEventListener&&f.addEventListener("mousedown",m,!0)},off:function(a){f.addEventListener&&f.removeEventListener("mousedown",m,!0)},ready:function(){return a.ue_cel&&a.ue_cel.log},reset:function(){}}}(),a.ue_cel&&a.ue_cel.registerModule("mouse click module",a.ue_mcm))})(ue_csm);
+(function(a){a.ue_mmm||!a.ue_cel||a.ue.isBF||(a.ue_mmm=function(m){function n(a,b){var c={x:a.pageX||a.x||0,y:a.pageY||a.y||0,t:l()};!b&&p&&(c.t-p.t<B||c.x==p.x&&c.y==p.y)||(p=c,u.push(c))}function c(){if(u.length){F=H.now();for(var a=0;a<u.length;a++){var c=u[a],d=a;y=u[h];E=c;var e=void 0;if(!(e=2>d)){e=void 0;a:if(u[d].t-u[d-1].t>f)e=0;else{for(e=h+1;e<d;e++){var g=y,k=E,l=u[e];G=(k.x-g.x)*(g.y-l.y)-(g.x-l.x)*(k.y-g.y);if(G*G/((k.x-g.x)*(k.x-g.x)+(k.y-g.y)*(k.y-g.y))>z){e=0;break a}}e=1}e=!e}(r=
+e)?h=d-1:D.pop();D.push(c)}C=H.now()-F;s=Math.min(s,C);v=Math.max(v,C);A=(A*b+C)/(b+1);b+=1;q({k:x,e:D,min:Math.floor(1E3*s),max:Math.floor(1E3*v),avg:Math.floor(1E3*A)},{c:1});u=[];D=[];h=0}}var f=100,B=20,z=25,x="mmm1",l,k,d=a.window,e=d.document,w=d.setInterval,t=a.ue,q=a.ue_cel.log,g,s=1E3,v=0,A=0,b=0,F,C,u=[],D=[],h=0,p,y,E,G,r,H=m&&m.now&&m||Date.now&&Date||{now:function(){return(new Date).getTime()}};return{on:function(a){l=a.ts;k=a.ns;t.attach&&t.attach("mousemove",n,e);g=w(c,3E3)},off:function(a){k&&
+(p&&n(p,!0),c());clearInterval(g);t.detach&&t.detach("mousemove",n,e)},ready:function(){return a.ue_cel&&a.ue_cel.log},reset:function(){u=[];D=[];h=0;p=null}}}(window.performance),a.ue_cel&&a.ue_cel.registerModule("mouse move module",a.ue_mmm))})(ue_csm);
+
+
+
+ue_csm.ue.exec(function(b,c){var e=function(){},f=function(){return{send:function(b,d){if(d&&b){var a;if(c.XDomainRequest)a=new XDomainRequest,a.onerror=e,a.ontimeout=e,a.onprogress=e,a.onload=e,a.timeout=0;else if(c.XMLHttpRequest){if(a=new XMLHttpRequest,!("withCredentials"in a))throw"";}else a=void 0;if(!a)throw"";a.open("POST",b,!0);a.setRequestHeader&&a.setRequestHeader("Content-type","text/plain");a.send(d)}},isSupported:!0}}(),g=function(){return{send:function(c,d){if(c&&d)if(navigator.sendBeacon(c,
+d))b.ue_sbuimp&&b.ue&&b.ue.ssw&&b.ue.ssw("eelsts","scs");else throw"";},isSupported:!!navigator.sendBeacon&&!(c.cordova&&c.cordova.platformId&&"ios"==c.cordova.platformId)}}();b.ue._ajx=f;b.ue._sBcn=g},"Transportation-clients")(ue_csm,window);
+ue_csm.ue.exec(function(b,l){function B(){for(var a=0;a<arguments.length;a++){var c=arguments[a];try{var g;if(c.isSupported){var f=t.buildPayload(k,e);g=c.send(J,f)}else throw dummyException;return g}catch(d){}}a={m:"All supported clients failed",attribution:"CSMSushiClient_TRANSPORTATION_FAIL",f:"sushi-client.js",logLevel:"ERROR"};b.ue_err.buffer&&b.ue_err.buffer.push(a)}function m(){if(e.length){for(var a=0;a<n.length;a++)n[a]();B(d._sBcn||{},d._ajx||{});e=[];h={};k={};u=v=q=w=0}}function K(){var a=
+new Date,c=function(a){return 10>a?"0"+a:a};return Date.prototype.toISOString?a.toISOString():a.getUTCFullYear()+"-"+c(a.getUTCMonth()+1)+"-"+c(a.getUTCDate())+"T"+c(a.getUTCHours())+":"+c(a.getUTCMinutes())+":"+c(a.getUTCSeconds())+"."+String((a.getUTCMilliseconds()/1E3).toFixed(3)).slice(2,5)+"Z"}function x(a){try{return JSON.stringify(a)}catch(c){}return null}function C(a,c,g,f){var p=!1;f=f||{};r++;if(r==D){var s={m:"Max number of Sushi Logs exceeded",f:"sushi-client.js",logLevel:"ERROR",attribution:"CSMSushiClient_MAX_CALLS"};
+b.ue_err.buffer&&b.ue_err.buffer.push(s)}if(s=!(r>=D))(s=a&&-1<a.constructor.toString().indexOf("Object")&&c&&-1<c.constructor.toString().indexOf("String")&&g&&-1<g.constructor.toString().indexOf("String"))||L++;s&&(d.count&&d.count("Event:"+g,1),a.producerId=a.producerId||c,a.schemaId=a.schemaId||g,a.timestamp=K(),c=Date.now?Date.now():+new Date,g=Math.random().toString().substring(2,12),a.messageId=b.ue_id+"-"+c+"-"+g,f&&!f.ssd&&(a.sessionId=a.sessionId||b.ue_sid,a.requestId=a.requestId||b.ue_id,
+a.obfuscatedMarketplaceId=a.obfuscatedMarketplaceId||b.ue_mid),(c=x(a))?(c=c.length,(e.length==M||q+c>N)&&m(),q+=c,a={data:t.compressEvent(a)},e.push(a),(f||{}).n?0===E?m():u||(u=l.setTimeout(m,E)):v||(v=l.setTimeout(m,O)),p=!0):p=!1);!p&&b.ue_int&&console.error("Invalid JS Nexus API call");return p}function F(){if(!G){for(var a=0;a<y.length;a++)y[a]();for(a=0;a<n.length;a++)n[a]();e.length&&(b.ue_sbuimp&&b.ue&&b.ue.ssw&&(a=x({dct:k,evt:e}),b.ue.ssw("eeldata",a),b.ue.ssw("eelsts","unk")),B(d._sBcn||
+{}));G=!0}}function H(a){y.push(a)}function I(a){n.push(a)}var D=1E3,M=499,N=524288,z=function(){},d=b.ue||{},P=b.uex||z;(b.uet||z)("bb","ue_sushi_v1",{wb:1});var J=b.ue_surl||"https://unagi-na.amazon.com/1/events/com.amazon.csm.nexusclient.gamma",Q=["messageId","timestamp"],A="#",e=[],h={},k={},q=0,w=0,L=0,r=0,y=[],n=[],G=!1,u,v,E=void 0===b.ue_hpsi?1E3:b.ue_hpsi,O=void 0===b.ue_lpsi?1E4:b.ue_lpsi,t=function(){function a(a){h[a]=A+w++;k[h[a]]=a;return h[a]}function c(b){if(!(b instanceof Function)){if(b instanceof
+Array){for(var f=[],d=b.length,e=0;e<d;e++)f[e]=c(b[e]);return f}if(b instanceof Object){f={};for(d in b)b.hasOwnProperty(d)&&(f[h[d]?h[d]:a(d)]=-1===Q.indexOf(d)?c(b[d]):b[d]);return f}return"string"===typeof b&&(b.length>(A+w).length||b.charAt(0)===A)?h[b]?h[b]:a(b):b}}return{compressEvent:c,buildPayload:function(){return x({cs:{dct:k},events:e})}}}();(function(){if(d.event&&d.event.isStub){if(b.ue_sbuimp&&b.ue&&b.ue.ssw){var a=b.ue.ssw("eelsts").val;if(a&&"unk"===a&&(a=b.ue.ssw("eeldata").val)){var c;
+a:{try{c=JSON.parse(a);break a}catch(g){}c=null}c&&c.evt instanceof Array&&c.dct instanceof Object&&(e=c.evt,k=c.dct,e&&k&&(m(),b.ue.ssw("eeldata","{}"),b.ue.ssw("eelsts","scs")))}}d.event.replay(function(a){a[3]=a[3]||{};a[3].n=1;C.apply(this,a)});d.onSushiUnload.replay(function(a){H(a[0])});d.onSushiFlush.replay(function(a){I(a[0])})}})();d.attach("beforeunload",F);d.attach("pagehide",F);d._cmps=t;d.event=C;d.event.reset=function(){r=0};d.onSushiUnload=H;d.onSushiFlush=I;try{l.P&&l.P.register&&
+l.P.register("sushi-client",z)}catch(R){b.ueLogError(R,{logLevel:"WARN"})}P("ld","ue_sushi_v1",{wb:1})},"Nxs-JS-Client")(ue_csm,window);
+
+
+ue_csm.ue_unrt = 1500;
+(function(d,b,q){function r(a,b){var c=a.srcElement||a.target||{};e.getXPath(c);c.href&&e.extractStringValue(c.href);c.className&&c.className.split&&c.className.split(/\s+/);f+=1;e.getFirstAscendingWidget(c,function(a){ue.count("unresponsiveClicks",1)})}function t(a){if(!u(a.srcElement||a.target)){h+=1;k=!0;var s=n=d.ue.d(),c;l&&"function"===typeof l.now&&a.timeStamp&&(c=l.now()-a.timeStamp,c=parseFloat(c.toFixed(2)));p=b.setTimeout(function(){r(a,{t:s,dt:c})},v)}}function w(a){if(a){var b=a.filter(x);
+a.length!==b.length&&(m=!0,d.ue.d(),k&&m&&(g(),m=!1))}}function x(a){if(!a)return!1;var b="characterData"===a.type?a.target.parentElement:a.target;if(!b||!b.hasAttributes||!b.attributes)return!1;var c={"class":"gw-clock gw-clock-aria s-item-container-height-auto feed-carousel using-mouse kfs-inner-container".split(" "),id:["dealClock","deal_expiry_timer","timer"],role:["timer"]},d=!1;Object.keys(c).forEach(function(a){var e=b.attributes[a]?b.attributes[a].value:"";(c[a]||"").forEach(function(a){-1!==
+e.indexOf(a)&&(d=!0)})});return d}function u(a){if(!a)return!1;var b=(e.extractStringValue(a.nodeName)||"").toLowerCase(),c=(e.extractStringValue(a.type)||"").toLowerCase(),d=(e.extractStringValue(a.href)||"").toLowerCase();a=(e.extractStringValue(a.id)||"").toLowerCase();var f="checkbox color date datetime-local email file month number password radio range reset search tel text time url week".split(" ");if(-1!==["select","textarea","html"].indexOf(b)||"input"===b&&-1!==f.indexOf(c)||"a"===b&&-1!==
+d.indexOf("http")||-1!==["sitbreaderrightpageturner","sitbreaderleftpageturner","sitbreaderpagecontainer"].indexOf(a))return!0}function g(){k=!1;n=0;b.clearTimeout(p)}function y(){b.ue.onunload(function(){ue.count("armored-cxguardrails.unresponsive-clicks.violations",f);ue.count("armored-cxguardrails.unresponsive-clicks.violationRate",f/h*100||0)})}if(b.MutationObserver&&b.addEventListener&&Object.keys&&d&&d.ue&&d.ue.log&&d.ue_unrt&&d.ue_utils){var v=d.ue_unrt,l=b.performance,e=d.ue_utils,k=!1,n=
+0,p=0,m=!1,f=0,h=0;b.addEventListener&&(b.addEventListener("mousedown",t,!0),b.addEventListener("beforeunload",g,!0),b.addEventListener("visibilitychange",g,!0),b.addEventListener("pagehide",g,!0));b.ue&&b.ue.event&&b.ue.onSushiUnload&&b.ue.onunload&&y();(new MutationObserver(w)).observe(q,{childList:!0,attributes:!0,characterData:!0,subtree:!0})}})(ue_csm,window,document);
+
+
+ue_csm.ue.exec(function(g,e){if(e.ue_err){var f="";e.ue_err.errorHandlers||(e.ue_err.errorHandlers=[]);e.ue_err.errorHandlers.push({name:"fctx",handler:function(a){if(!a.logLevel||"FATAL"===a.logLevel)if(f=g.getElementsByTagName("html")[0].innerHTML){var b=f.indexOf("var ue_t0=ue_t0||+new Date();");if(-1!==b){var b=f.substr(0,b).split(String.fromCharCode(10)),d=Math.max(b.length-10-1,0),b=b.slice(d,b.length-1);a.fcsmln=d+b.length+1;a.cinfo=a.cinfo||{};for(var c=0;c<b.length;c++)a.cinfo[d+c+1+""]=
+b[c]}b=f.split(String.fromCharCode(10));a.cinfo=a.cinfo||{};if(!(a.f||void 0===a.l||a.l in a.cinfo))for(c=+a.l-1,d=Math.max(c-5,0),c=Math.min(c+5,b.length-1);d<=c;d++)a.cinfo[d+1+""]=b[d]}}})}},"fatals-context")(document,window);
+
+
+(function(m,a){function c(k){function f(b){b&&"string"===typeof b&&(b=(b=b.match(/^(?:https?:)?\/\/(.*?)(\/|$)/i))&&1<b.length?b[1]:null,b&&b&&("number"===typeof e[b]?e[b]++:e[b]=1))}function d(b){var e=10,d=+new Date;b&&b.timeRemaining?e=b.timeRemaining():b={timeRemaining:function(){return Math.max(0,e-(+new Date-d))}};for(var c=a.performance.getEntries(),k=e;g<c.length&&k>n;)c[g].name&&f(c[g].name),g++,k=b.timeRemaining();g>=c.length?h(!0):l()}function h(b){if(!b){b=m.scripts;var c;if(b)for(var d=
+0;d<b.length;d++)(c=b[d].getAttribute("src"))&&"undefined"!==c&&f(c)}0<Object.keys(e).length&&(p&&ue_csm.ue&&ue_csm.ue.event&&ue_csm.ue.event({domains:e,pageType:a.ue_pty||null,subPageType:a.ue_spty||null,pageTypeId:a.ue_pti||null},"csm","csm.CrossOriginDomains.2"),a.ue_ext=e)}function l(){!0===k?d():a.requestIdleCallback?a.requestIdleCallback(d):a.requestAnimationFrame?a.requestAnimationFrame(d):a.setTimeout(d,100)}function c(){if(a.performance&&a.performance.getEntries){var b=a.performance.getEntries();
+!b||0>=b.length?h(!1):l()}else h(!1)}var e=a.ue_ext||{};a.ue_ext||c();return e}function q(){setTimeout(c,r)}var s=a.ue_dserr||!1,p=!0,n=1,r=2E3,g=0;a.ue_err&&s&&(a.ue_err.errorHandlers||(a.ue_err.errorHandlers=[]),a.ue_err.errorHandlers.push({name:"ext",handler:function(a){if(!a.logLevel||"FATAL"===a.logLevel){var f=c(!0),d=[],h;for(h in f){var f=h,g=f.match(/amazon(\.com?)?\.\w{2,3}$/i);g&&1<g.length||-1!==f.indexOf("amazon-adsystem.com")||-1!==f.indexOf("amazonpay.com")||-1!==f.indexOf("cloudfront-labs.amazonaws.com")||
+d.push(h)}a.ext=d}}}));a.ue&&a.ue.isl?c():a.ue&&ue.attach&&ue.attach("load",q)})(document,window);
+
+
+
+
+
+var ue_wtc_c = 3;
+ue_csm.ue.exec(function(b,e){function l(){for(var a=0;a<f.length;a++)a:for(var d=s.replace(A,f[a])+g[f[a]]+t,c=arguments,b=0;b<c.length;b++)try{c[b].send(d);break a}catch(e){}g={};f=[];n=0;k=p}function u(){B?l(q):l(C,q)}function v(a,m,c){r++;if(r>w)d.count&&1==r-w&&(d.count("WeblabTriggerThresholdReached",1),b.ue_int&&console.error("Number of max call reached. Data will no longer be send"));else{var h=c||{};h&&-1<h.constructor.toString().indexOf(D)&&a&&-1<a.constructor.toString().indexOf(x)&&m&&-1<
+m.constructor.toString().indexOf(x)?(h=b.ue_id,c&&c.rid&&(h=c.rid),c=h,a=encodeURIComponent(",wl="+a+"/"+m),2E3>a.length+p?(2E3<k+a.length&&u(),void 0===g[c]&&(g[c]="",f.push(c)),g[c]+=a,k+=a.length,n||(n=e.setTimeout(u,E))):b.ue_int&&console.error("Invalid API call. The input provided is over 2000 chars.")):d.count&&(d.count("WeblabTriggerImproperAPICall",1),b.ue_int&&console.error("Invalid API call. The input provided does not match the API protocol i.e ue.trigger(String, String, Object)."))}}function F(){d.trigger&&
+d.trigger.isStub&&d.trigger.replay(function(a){v.apply(this,a)})}function y(){z||(f.length&&l(q),z=!0)}var t=":1234",s="//"+b.ue_furl+"/1/remote-weblab-triggers/1/OE/"+b.ue_mid+":"+b.ue_sid+":PLCHLDR_RID$s:wl-client-id%3DCSMTriger",A="PLCHLDR_RID",E=b.wtt||1E4,p=s.length+t.length,w=b.mwtc||2E3,G=1===e.ue_wtc_c,B=3===e.ue_wtc_c,H=e.XMLHttpRequest&&"withCredentials"in new e.XMLHttpRequest,x="String",D="Object",d=b.ue,g={},f=[],k=p,n,z=!1,r=0,C=function(){return{send:function(a){if(H){var b=new e.XMLHttpRequest;
+b.open("GET",a,!0);G&&(b.withCredentials=!0);b.send()}else throw"";}}}(),q=function(){return{send:function(a){(new Image).src=a}}}();e.encodeURIComponent&&(d.attach&&(d.attach("beforeunload",y),d.attach("pagehide",y)),F(),d.trigger=v)},"client-wbl-trg")(ue_csm,window);
+
+
+(function(k,d,h){function f(a,c,b){a&&a.indexOf&&0===a.indexOf("http")&&0!==a.indexOf("https")&&l(s,c,a,b)}function g(a,c,b){a&&a.indexOf&&(location.href.split("#")[0]!=a&&null!==a&&"undefined"!==typeof a||l(t,c,a,b))}function l(a,c,b,e){m[b]||(e=u&&e?n(e):"N/A",d.ueLogError&&d.ueLogError({message:a+c+" : "+b,logLevel:v,stack:"N/A"},{attribution:e}),m[b]=1,p++)}function e(a,c){if(a&&c)for(var b=0;b<a.length;b++)try{c(a[b])}catch(d){}}function q(){return d.performance&&d.performance.getEntriesByType?
+d.performance.getEntriesByType("resource"):[]}function n(a){if(a.id)return"//*[@id='"+a.id+"']";var c;c=1;var b;for(b=a.previousSibling;b;b=b.previousSibling)b.nodeName==a.nodeName&&(c+=1);b=a.nodeName;1!=c&&(b+="["+c+"]");a.parentNode&&(b=n(a.parentNode)+"/"+b);return b}function w(){var a=h.images;a&&a.length&&e(a,function(a){var b=a.getAttribute("src");f(b,"img",a);g(b,"img",a)})}function x(){var a=h.scripts;a&&a.length&&e(a,function(a){var b=a.getAttribute("src");f(b,"script",a);g(b,"script",a)})}
+function y(){var a=h.styleSheets;a&&a.length&&e(a,function(a){if(a=a.ownerNode){var b=a.getAttribute("href");f(b,"style",a);g(b,"style",a)}})}function z(){if(A){var a=q();e(a,function(a){f(a.name,a.initiatorType)})}}function B(){e(q(),function(a){g(a.name,a.initiatorType)})}function r(){var a;a=d.location&&d.location.protocol?d.location.protocol:void 0;"https:"==a&&(z(),w(),x(),y(),B(),p<C&&setTimeout(r,D))}var s="[CSM] Insecure content detected ",t="[CSM] Ajax request to same page detected ",v="WARN",
+m={},p=0,D=k.ue_nsip||1E3,C=5,A=1==k.ue_urt,u=!0;ue_csm.ue_disableNonSecure||(d.performance&&d.performance.setResourceTimingBufferSize&&d.performance.setResourceTimingBufferSize(300),r())})(ue_csm,window,document);
+
+
+var ue_aa_a = "C";
+if (ue.trigger && (ue_aa_a === "C" || ue_aa_a === "T1")) {
+    ue.trigger("UEDATA_AA_SERVERSIDE_ASSIGNMENT_CLIENTSIDE_TRIGGER_190249", ue_aa_a);
+}
+(function(f,b){function g(){try{b.PerformanceObserver&&"function"===typeof b.PerformanceObserver&&(a=new b.PerformanceObserver(function(b){c(b.getEntries())}),a.observe(d))}catch(h){k()}}function m(){for(var h=d.entryTypes,a=0;a<h.length;a++)c(b.performance.getEntriesByType(h[a]))}function c(a){if(a&&Array.isArray(a)){for(var c=0,e=0;e<a.length;e++){var d=l.indexOf(a[e].name);if(-1!==d){var g=Math.round(b.performance.timing.navigationStart+a[e].startTime);f.uet(n[d],void 0,void 0,g);c++}}l.length===
+c&&k()}}function k(){a&&a.disconnect&&"function"===typeof a.disconnect&&a.disconnect()}if("function"===typeof f.uet&&b.performance&&"object"===typeof b.performance&&b.performance.getEntriesByType&&"function"===typeof b.performance.getEntriesByType&&b.performance.timing&&"object"===typeof b.performance.timing&&"number"===typeof b.performance.timing.navigationStart){var d={entryTypes:["paint"]},l=["first-paint","first-contentful-paint"],n=["fp","fcp"],a;try{m(),g()}catch(p){f.ueLogError(p,{logLevel:"ERROR",
+attribution:"performanceMetrics"})}}})(ue_csm,window);
+
+
+if (window.csa) {
+    csa("Events")("setEntity", {
+        page:{pageType: "F3OmnichannelPostOrder", subPageType: "OrderDetails", pageTypeId: ""}
+    });
+}
+csa.plugin(function(d){var e,t,n,m="transitionStart",i="pageVisible",o="PageTiming",a="visibilitychange",u="$latency.visible",r=d.global,c=(r.performance||{}).timing,s=["navigationStart","unloadEventStart","unloadEventEnd","redirectStart","redirectEnd","fetchStart","domainLookupStart","domainLookupEnd","connectStart","connectEnd","secureConnectionStart","requestStart","responseStart","responseEnd","domLoading","domInteractive","domContentLoadedEventStart","domContentLoadedEventEnd","domComplete","loadEventStart","loadEventEnd"],l=d.config,f=r.Math,g=f.max,v=f.floor,p=r.document||{},S=(c||{}).navigationStart,E=S,I=0,h=0,b=null;if(r.Object.keys&&[].forEach&&!l["KillSwitch."+o]){if(!c||null===S||S<=0||void 0===S)return d.error("Invalid navigation timing data: "+S);b=new y({schemaId:"<ns>.PageLatency.6",producerId:"csa"}),"boolean"!=typeof p.hidden&&"string"!=typeof p.visibilityState||!p.removeEventListener?d.emit(u):L()?(d.emit(u),T(i,S)):d.on(p,a,function n(){L()&&(E=d.time(),p.removeEventListener(a,n),T(m,E),T(i,E),d.emit(u))}),d.on("$timing:aboveTheFold",function(n){e=n,$()}),d.on("$timing:functional",function(n){t=n,$()}),d.once("$unload",k),d.once("$load",k),d.on("$pageTransition",function(){E=d.time(),t=e=n,h=0}),d.register(o,{mark:T,instance:function(n){return new y(n)}})}function y(n){var i,o=null,a=n.ent||{page:["pageType","subPageType","requestId"]},r=n.logger||d("Events",{producerId:n.producerId,lob:l.lob||"0"});if(!n||!n.producerId||!n.schemaId)return d.error("The producer id and schema Id must be defined for PageLatencyInstance.");function c(){return i||E}function e(){o=d.UUID()}this.mark=function(e,t){if(null!=e)return t=t||d.time(),e===m&&(i=t),d.once(u,function(){r("log",{messageId:o,__merge:function(n){n.markers[e]=function(n,e){return g(0,e-(n||E))}(c(),t),n.markerTimestamps[e]=v(t)},markers:{},markerTimestamps:{},navigationStartTimestamp:c()?new Date(c()).toISOString():null,schemaId:n.schemaId},{ent:a})}),t},e(),d.on("$beforePageTransition",e)}function T(n,e){n===m&&(E=e);var t=b.mark(n,e);d.emit("$timing:"+n,t)}function k(){if(!I){for(var n=0;n<s.length;n++)c[s[n]]&&T(s[n],c[s[n]]);I=1}}function L(){return!p.hidden||"visible"===p.visibilityState}function $(){e===n||t===n||h||(T("timeToInteractive",g(e,t)),h=1)}});csa.plugin(function(f){var e,n,r,o,c="length",i="number",l="addedNodes",s="removedNodes",a="nodeName",u="nodeValue",d="parentElement",v="target",h="getEntriesByName",m="checkVisibility",g={opacityProperty:!0,visibilityProperty:!0},t="_csa_",p=t+"nnh",y=t+"flt",E=t+"llt",S=t+"vlb",T=t+"vla",b=t+"vlab",x=t+"vlta",I=t+"vlr",N=t+"vl_thr",_=t+"vl_sl",L=t+"vl_lm",w=L+"i",M=t+"vl_em",O=t+"vlt",B=t+"vp",C=t+"eb",V=t+"pcc",k=t+"nrm",W=t+"inv_",P=W+"mslt",A=W+"h",R="previousSibling",D="nextSibling",H="visuallyLoaded",X="vlDbg",Y="Total",F="client",$="offset",q="scroll",J="Width",Q="Height",j="width",K="height",U=F+J,z=F+Q,G=$+J,Z=$+Q,tt=q+J,et=q+Q,nt="_elt",rt="_eid",it=10,ot=5,at=35,ut=100,ft="IFRAME",ct={50:1,90:1,100:1},lt={SCRIPT:1,STYLE:1,NOSCRIPT:1,LINK:1,META:1},st=["_csa_visual_load_hidden_"],dt=["a-truncate-cut"],vt={"nav-flyout-anchor":1,"nav-flyout-iss-anchor":1},ht=["TEXTAREA","SELECT",ft],mt=f.global,gt=f.timeout,pt=mt.Math,yt=pt.min,Et=pt.max,St=pt.floor,Tt=pt.ceil,bt=mt.document||{},xt=bt.body||{},It=bt.documentElement||{},Nt=mt.performance||{},_t=(Nt.timing||{}).navigationStart,Lt=Date.now,wt=Object.values||(f.types||{}).ovl,Mt=f("PageTiming"),Ot=f("SpeedIndexBuffers"),Bt=0,Ct=[],Vt=[],kt=[],Wt=[],Pt=[],At=[],Rt=[],Dt=it,Ht=it,Xt=.1,Yt=.1,Ft=0,$t=0,qt=0,Jt=0,Qt=0,jt=0,Kt=0,Ut=1,zt=0,Gt={},Zt=[],te=0,ee=0,ne=0,re=0,ie=0,oe={},ae=0,ue=0,fe=0,ce=0,le=0;function se(){var t=Lt(),e=0;for(!Bt&&o&&o.d&&(De("QueStart"+o.d),Bt=1);o;){if(0!==o[c]){if(!1!==o.h(o[0])&&o.shift(),e++,!jt&&e%it==0&&Lt()-t>ot)break}else(o=o.n)&&o.d&&De("QueStart"+o.d)}Ft=0,o&&(Ft||(!0===bt.hidden?(jt=1,se()):f.timeout(se,0)))}function de(t,e,n,r){De("BufStart"),zt=St(t),Ct=e,Vt=n,Rt=r;var i=bt.createTreeWalker(bt.body,NodeFilter.SHOW_TEXT,null,null);bt.body[nt]=t,kt.push({w:i}),Wt.push({img:bt.images,iter:0}),Pt.push({vid:bt.getElementsByTagName("VIDEO"),iter:0}),ht.forEach(function(t){At.push({iel:bt.getElementsByTagName(t),iter:0,rt:ft===t})}),Ct.h=he,Ct.n=Vt,Ct.d="MutInt",Vt.h=Ne,Vt.n=kt,Vt.d="Mut",kt.h=Le,kt.n=Wt,kt.d="Txt",Wt.h=we,Wt.n=Pt,Wt.d="Img",Pt.h=Me,Pt.n=At,Pt.d="Vid",At.h=Oe,At.n=Rt,At.d="IntEl",Rt.h=Be,Rt.d="VpUpd",o=Ct,se()}function ve(t,e){for(var n=t;n&&(t===n||!n[y]||!n[E]);){n[y]||(n[y]=t[y]),n[E]||(n[E]=t[E]);var r=n[y]-_t;n[nt]=r,n[_]=r,n=n[e]}}function he(t){var e=t.iter||0;for(Dt=Dt<=0?it:Dt;e<t.m[c]&&0<Dt;){var n=t.m[e];ve(n,R),ve(n,D),re+=1,t.iter=e+=1,Dt-=1}return t.m[c]<=e}function me(e,t){return e&&e.classList&&pe(e.classList.contains)&&t&&0<t[c]&&pe(t.some)&&t.some(function(t){return e.classList.contains(t)})}function ge(t){return typeof t===i&&!isNaN(t)}function pe(t){return"function"==typeof t}function ye(t){return t&&t.endsWith&&t.endsWith("px")?+t.substring(0,t[c]-2):e}function Ee(t){if(t&&p in t)return t[p];var e=t&&!lt[t[a]||""]&&(!pe(t[m])||t[m](g))&&"none"!==(t.style||{}).display&&!function(t){var e=(t||{}).style||{},n=!1;if("absolute"===e.position){var r=ye(e[K]),i=ye(e[j]),o=ye(e.top),a=ye(e.left);(ge(r)&&ge(o)&&r+o<0||ge(i)&&ge(a)&&i+a<0)&&(n=!0)}return n}(t)&&!me(t,st)&&!vt[t.id||""];return t&&(t[p]=e),e}function Se(t){return function(t){return t&&!t[k]&&8!==t.nodeType&&(3!==t.nodeType||0!==(t[u]||"").trim()[c])&&Ee(t)}(t)?t:e}function Te(t){t&&(t[k]=1)}function be(t){t&&!t[M]&&(ne+=t[M]=1)}function xe(t,e){var n,r=[];if(t&&pe(e)&&0<(n=t[c]))for(var i=0;i<n;i++){var o=e(t[i]);o&&r.push(o)}return r}function Ie(t){var e,n,r=0;t&&(t[s]&&1===t[s][c]&&(n=t[s][0]),t[l]&&1===t[l][c]&&(e=t[l][0]),n&&e&&n[u]===e[u]&&(r=1));return r}function Ne(t){var e=t.iter||0;for(Ht=Ht<=0?it:Ht;e<t.m[c]&&0<Ht;){var n=t.m[e];if(n){var r=n[v],i=r&&Ee(r)&&!me(r,dt),o=i?xe(n[l],Se):[],a=0<o[c],u=a&&Ie(n);if(te+=1,a&&r&&!u&&i){var f=t.t-_t;r[nt]=f,ee+=1,r[L]=f,(r[w]=o)&&pe(o.forEach)&&o.forEach(be)}xe(n[s],Te)}t.iter=e+=1,Ht-=1}return t.m[c]<=e}function _e(t,e){if(t&&!t[rt]){ie+=1;var n=t.tagName||"";oe[n]=(oe[n]||0)+1,Pe(t,e||Ce(t,1))}}function Le(t){for(var e,n=t.w,r=it;0<r&&(e=n.nextNode());){r-=1;var i=e[d],o=(i||{})[a];"BODY"===o||lt[o]||0!==(e[u]||"").trim()[c]&&(ae+=1,Pe(i,Ce(e)))}return!e}function we(t){for(var e=it;t.iter<t.img[c]&&0<e;){var n,r=t.img[t.iter],i=We(r),o=i&&Ce(i)||Ce(r);i?(i[nt]=o,n=ke(i.querySelector('[aria-posinset="1"] img')||r)||o,r=i):n=ke(r)||o,ue+=1,Pe(r,n),t.iter+=1,e-=1}return t.img[c]<=t.iter}function Me(t){for(var e,n=it;t.iter<t.vid[c]&&0<n;){var r,i=t.vid[t.iter],o=We(i),a=o&&Ce(o)||Ce(i);if(o){o[nt]=a;var u=o.querySelector('[aria-posinset="1"] img');r=u&&ke(u)||a,i=o}else r=Ve((e=i).poster,e,1)||Ve(e.currentSrc,e,0)||Ve(e.src,e,0)||a;fe+=1,Pe(i,r),t.iter+=1,n-=1}return t.vid[c]<=t.iter}function Oe(t){for(var e=it,n=t.rt;t.iter<t.iel[c]&&0<e;){var r=t.iel[t.iter],i=0;n&&(i=Ve(r.src,r,1)),_e(r,i),t.iter+=1,e-=1}return t.iel[c]<=t.iter}function Be(t){var n=[],i=0,o=0,a=$t,e=(mt.innerWidth||Et(xt[tt]||0,xt[G]||0,It[U]||0,It[tt]||0,It[G]||0),0+(mt.innerHeight||Et(xt[et]||0,xt[Z]||0,It[z]||0,It[et]||0,It[Z]||0))),r=St(0/ut),u=Tt(e/ut);Zt.slice(r,u).forEach(function(t){(t.elems||[]).forEach(function(t){if(t.lt in n||(n[t.lt]={}),!(t.id in n[t.lt])){var e=t.a;e&&(n[t.lt][t.id]=t,i+=e)}})}),bt&&bt.body&&(bt.body[S]=1),wt(n).forEach(function(t){wt(t).forEach(function(t){var e=1-o/i,n=Et(t.lt,a),r=t.a;le+=e*(n-a),o+=r,a=n,ce+=1,t.e&&(t.e[S]=1,t.e[T]=r,t.e[x]=i,t.e[O]=n),function(t,e){var n;e.e&&(e.e[I]=t);for(;Xt<=1&&Xt-.01<=t;)Re(H+(n=(100*Xt).toFixed(0)),e.lt),ct[n]&&f("Content",{target:e.e})("mark",H+n,_t+Tt(e.lt||0)),e.e&&(e.e[N]=n),Xt+=Yt}(o/i,t)})}),$t=t.t-_t,Re("atfSpeedIndex",le),Re("speedIndex",le),Re(H+"0",zt),De("CalcEnd"),He(Y+"Blocks",ce),He(Y+"Mut",te),He(Y+"ValMut",ee),He(Y+"MutEl",ne),He(Y+"MutInter",re),He(Y+"IntEl",ie),ht.forEach(function(t){He(Y+"IntEl"+t,oe[t]||0)}),He(Y+"Txt",ae),He(Y+"Img",ue),He(Y+"Vid",fe)}function Ce(t,e){for(var n=e?t:t[d],r=at+(e?1:0);n&&0<r;){if(n[nt]||0===n[nt])return Et(n[nt],zt);n=n[d],r-=1}}function Ve(t,e,n){if(t){if(!t.indexOf("data:"))return Ce(e);var r=Nt[h](t)||[];if(0<r[c])return Et(Tt(r[n?r[c]-1:0].responseEnd||0),zt)}}function ke(t){return Ve(t.currentSrc,t,1)||Ve(t.src,t,1)}function We(t){for(var e=10,n=t[d],r=[];n&&0<e;){if(n[V]&&0<n[V][c])return r.push(n[V][0]),n[V][0];if(n[V]=r,n.classList&&n.classList.contains("a-carousel-viewport"))return r.push(n),n;n=n[d],e-=1}return null}function Pe(t,e){var n,r=!e&&0!==e;if(r||t[rt]||(n=!Ee(t)))return t[P]=r,void(t[A]=n);var i=t.getBoundingClientRect(),o={x:i.left+(mt.scrollX||mt.pageXOffset),y:i.top+(mt.scrollY||mt.pageYOffset),w:i[j],h:i[K]},a=i.width*i.height,u=mt.innerWidth||Et(xt[tt]||0,xt[G]||0,It[U]||0,It[tt]||0,It[G]||0)||i.right,f=mt.innerHeight||Et(xt[et]||0,xt[Z]||0,It[z]||0,It[et]||0,It[Z]||0)||i.bottom,c=Ut++;if(0!==(a=function(t,e,n,r,i,o,a){if(e&&n&&ge(n.x)&&ge(n.y)&&ge(n.w)&&ge(n.h)&&0<n.w&&0<n.h){var u=n.y+n.h,f=n.x+n.w;if(n.y<i||a<u||n.x<r||o<f){var c=Et(r,n.x),l=Et(i,n.y),s=c-n.x,d=l-n.y,v=yt(o,f)-c,h=yt(a,u)-l,m=Et(0,v),g=Et(0,h),p=Et(0,s),y=Et(0,d);e=m*g,t&&e&&(t[b]={x:p,y:y,w:m,h:g})}}return e}(t,a,o,0,0,0+u,0+f))){for(var l={e:t,lt:e,a:a,id:c},s=St(o.y/ut),d=Tt((o.y+o.h)/ut),v=s;v<=d;v++)v in Zt||(Zt[v]={elems:[],lt:0}),Zt[v].elems.push(l);t[rt]=c,t[B]={x:0,y:0,w:u,h:f},t[C]=o}}function Ae(t,e){Mt("mark",t,e)}function Re(t,e){Ae(t,_t+Tt((Gt[t]=e)||0))}function De(t){Ae(X+t,Lt())}function He(t,e){var n=r||f("Metrics",{producerId:"csa"});n&&(r=n)("recordCounter","CSA.Latency.Page.VisualLoad."+t,e)}function Xe(){Kt||(De("CalcStart"),pe(n)?n(de):Ot("getBuffers",de),Kt=1)}_t&&wt&&Nt[h]&&(Ot("registerListener",function(){Qt&&(clearTimeout(qt),qt=gt(Xe,2500))}),f.once("$unload",function(){jt=1,Xe()}),f.once("$load",function(){Qt=1,Jt?Xe():(clearTimeout(qt),qt=gt(Xe,2500))}),f.once("$timing:functional",function(){Jt=1,Qt?Xe():(clearTimeout(qt),qt=gt(Xe,2500))}),Ot("replayModuleIsLive",function(t){n=t}),f.register("SpeedIndex",{getMarkers:function(t){t&&t(JSON.parse(JSON.stringify(Gt)))}}))});csa.plugin(function(e){var n=!1,t=e("PageTiming"),i=e.global.PerformanceObserver,r=e.global.performance;function a(){return r.timing.navigationStart}function o(){n||function(r){var a=new i(function(e){var n=e.getEntries();if(0!==n.length){var t=n[n.length-1];a.disconnect(),r({startTime:t.startTime,renderTime:t.renderTime,loadTime:t.loadTime})}});try{a.observe({type:"largest-contentful-paint",buffered:!0})}catch(e){}}(function(e){e&&(n=!0,t("mark","largestContentfulPaint",Math.floor(e.startTime+a())),e.renderTime&&t("mark","largestContentfulPaint.render",Math.floor(e.renderTime+a())),e.loadTime&&t("mark","largestContentfulPaint.load",Math.floor(e.loadTime+a())))})}i&&r&&r.timing&&(e.once("$unload",o),e.once("$load",o),e.register("LargestContentfulPaint",{}))});csa.plugin(function(r){var e=r("Metrics",{producerId:"csa"}),n=r.global.PerformanceObserver;n&&(n=new n(function(r){var t=r.getEntries();if(0===t.length||!t[0].processingStart||!t[0].startTime)return;!function(r){r=r||0,n.disconnect(),0<=r?e("recordMetric","firstInputDelay",r):e("recordMetric","firstInputDelay.invalid",1)}(t[0].processingStart-t[0].startTime)}),function(){try{n.observe({type:"first-input",buffered:!0})}catch(r){}}())});csa.plugin(function(d){var g="Metrics",e=d.config["Events.SushiCsaCustomSourceGroup"],f=d.config,l=0;function r(t){var c,i,e=t.producerId,r=t.logger,o=r||d("Events",{producerId:e,lob:f.lob||"0"}),s=(t||{}).dimensions||{},u={},n=-1;if(!e&&!r)return d.error("Either a producer id or custom logger must be defined");function a(){n!==l&&(c=d.UUID(),i=d.UUID(),u={},n=l)}this.recordMetric=function(r,n){if(!f["KillSwitch."+g]){var e=t.logOptions||{ent:{page:["pageType","subPageType","requestId"]}};e.debugMetric=t.debugMetric,a(),o("log",{messageId:c,schemaId:t.schemaId||"<ns>.Metric.4",metrics:{},dimensions:s,__merge:function(e){e.metrics[r]=n}},e)}},this.recordCounter=function(r,e){if(!f["KillSwitch.InternalCounters"]){var n=t.logOptions||{ent:{page:["pageType","subPageType","requestId"]}};if("string"!=typeof r||"number"!=typeof e||!isFinite(e))return d.error("Invalid type given for counter name or counter value: "+r+"/"+e);a(),r in u||(u[r]={});var c=u[r];"f"in c||(c.f=e),c.c=(c.c||0)+1,c.s=(c.s||0)+e,c.l=e,o("log",{messageId:i,schemaId:t.schemaId||"<ns>.InternalCounters.3",c:{},__merge:function(e){r in e.c||(e.c[r]={}),c.fs||(c.fs=1,e.c[r].f=c.f),1<c.c&&(e.c[r].s=c.s,e.c[r].l=c.l,e.c[r].c=c.c)}},n)}}}new r({producerId:"csa"}).recordMetric("baselineMetricEvent",1),e&&new r({logger:d("Events",{producerId:"csa",lob:f.lob||"0",sushiSourceGroup:e,copyBaseMetadata:!0,copyEntities:!0})}).recordCounter("csa.customsg.baselineMetric",1);d.on("$beforePageTransition",function(){l++}),d.register(g,{instance:function(e){return new r(e||{})}})});csa.plugin(function(s){var n=s.config,r=(s.global.performance||{}).timing,c=(r||{}).navigationStart||s.time(),g=0;function e(){g+=1}function i(i){i=i||{};var o=s.UUID(),t=g,r=i.producerId,e=i.logger,a=e||s("Events",{producerId:r,lob:n.lob||"0"});if(!r&&!e)return s.error("Either a producer id or custom logger must be defined");this.mark=function(e,r){var n=(void 0===r?s.time():r)-c;t!==g&&(t=g,o=s.UUID()),a("log",{messageId:o,schemaId:i.schemaId||"<ns>.Timer.1",markers:{},__merge:function(r){r.markers[e]=n}},i.logOptions)}}r&&(e(),s.on("$beforePageTransition",e),s.register("Timers",{instance:function(r){return new i(r||{})}}))});csa.plugin(function(t){var e="takeRecords",i="disconnect",n="function",o=t("Metrics",{producerId:"csa"}),c=t("PageTiming"),a=t.global,u=t.timeout,r=t.on,f=a.PerformanceObserver,m=0,l=!1,s=0,d=a.performance,h=a.document,v=null,y=!1,g=t.blank;function p(){l||(l=!0,clearTimeout(v),typeof f[e]===n&&f[e](),typeof f[i]===n&&f[i](),o("recordMetric","documentCumulativeLayoutShift",m),c("mark","cumulativeLayoutShiftLastTimestamp",Math.floor(s+d.timing.navigationStart)))}f&&d&&d.timing&&h&&(f=new f(function(t){v&&clearTimeout(v);t.getEntries().forEach(function(t){t.hadRecentInput||(m+=t.value,s<t.startTime&&(s=t.startTime))}),v=u(p,5e3)}),function(){try{f.observe({type:"layout-shift",buffered:!0}),v=u(p,5e3)}catch(t){}}(),g=r(h,"click",function(t){y||(y=!0,o("recordMetric","documentCumulativeLayoutShiftToFirstInput",m),g())}),r(h,"visibilitychange",function(){"hidden"===h.visibilityState&&p()}),t.once("$unload",p))});csa.plugin(function(e){var t,n=e.global,r=n.PerformanceObserver,c=e("Metrics",{producerId:"csa"}),o=0,i=0,a=-1,l=n.Math,f=l.max,u=l.ceil;if(r){t=new r(function(e){e.getEntries().forEach(function(e){var t=e.duration;o+=t,i+=t,a=f(t,a)})});try{t.observe({type:"longtask",buffered:!0})}catch(e){}t=new r(function(e){0<e.getEntries().length&&(i=0,a=-1)});try{t.observe({type:"largest-contentful-paint",buffered:!0})}catch(e){}e.on("$unload",g),e.on("$beforePageTransition",g)}function g(){c("recordMetric","totalBlockingTime",u(i||0)),c("recordMetric","totalBlockingTimeInclLCP",u(o||0)),c("recordMetric","maxBlockingTime",u(a||0)),i=o=0,a=-1}});csa.plugin(function(n){var e,t,r,c="CacheDetection",i="csa-ctoken-",f="csa-pfetch-",o="PreFetch",u="device",a="pre-fetch",s="setUp",l="string",d="function",h="length",g="preFetchTime",p="preFetchedRequestId",v="attribution",I="ERR",y="INVALID",S={ICDP:1},m=[y,"INPUT"].join("_"),R=[I,o,s].join("_"),k=20,w=n.store,b=n.error,q=n.warn,N=n.deleteStored,C=n.config,D=C[c+".RequestID"],E=C[c+".Callback"],O=1,F=n.global,P=F.document||{},T=F.Date,j=T.now,J=n.time,U=n("Events"),_=n("Events",{producerId:"csa",lob:C.lob||"0"});function x(){return C["KillSwitch."+c]}function A(e){return e&&typeof e===l&&S[e]}function K(e,t,n,r,c){var i=H("session-id");!function(e,t,n,r,c,i){var o={pageSource:"cache",requestId:e,cacheRequestId:c||D,cacheSource:n},u={page:o};r&&(o[v]=r);i&&(o[g]=i);t&&(u.session={id:t});U("setEntity",u)}(n,i,e,t,r,c),e!==u&&e!==a||_("log",{schemaId:"<ns>.CacheImpression.2"},{ent:"all"}),E&&E(n,i,e)}function L(){return j()+60*O*60*1e3}function V(e,t){return t&&e&&e.length<=t.length&&t.slice(0,e.length)===e}function $(e){var t;try{t=JSON.parse(e||"{}")}catch(e){}return t}function z(e,t){var n=!1,r=t||e.resultCallback;if(x())return B(r,{e:!1,ks:!0});var c=e||{},i=function(e,t){var n,r=+e;return t||r||(r=J()),(n=new T(r)).getTime()?n.toISOString():t?null:J("ISO")}(c[g],!1),o=c[p],u=c[v];if(function(e){return e&&typeof e===l&&e[h]===k}(o)&&A(u)&&function(e){return e&&typeof e===l&&0<e[h]}(i)){var a=f+o,s=L();try{w(a,JSON.stringify({e:s,t:i,a:u})),n=!0}catch(e){}n?B(r,{e:!1,ks:!1}):G(b,r,I,R,e)}else G(q,r,y,m,e)}function B(e,t){typeof e===d&&e(t)}function G(e,t,n,r,c){e(r),B(t,{e:!0,ks:!1,c:r,l:n,d:c})}function H(e){try{var t=P.cookie.match(RegExp("(^| )"+e+"=([^;]+)"));return t&&t[2].trim()}catch(e){}}n.register(o,((e={})[s]=z,e)),x()||(t=function(){var e=n.store(f+D);if(e){var t=$(e);if(t&&A(t.a))return{r:n.generateNewRequestId(),t:t.t,a:t.a,s:a}}}()||function(){var e=H("cdn-rid");if(e)return{r:e,s:"cdn"}}()||function(){if(n.store(i+D))return{r:n.generateNewRequestId(),s:u}}()||{},(r=t.r)&&K(t.s,t.a,r,D,t.t),w(i+D,L()),n.once("$load",function(){var r=T.now();N(function(e,t){if(V(i,e))return parseInt(t)<r;if(V(f,e)){var n=$(t);return!n||+n.e<r}return!1})}))});csa.plugin(function(a){var i,e="Content",t="MutationObserver",f="querySelectorAll",s="matches",o="getAttributeNames",r="getAttribute",l="dataset",c="widget",u="producerId",d="slotId",n="iSlotId",g="$csaWidget",h={ent:{element:1,page:["pageType","subPageType","requestId"]}},p=5,m=a.config[e+".BubbleUp.SearchDepth"]||35,v=a.config[e+".SearchPage"]||0,y="csaC",b=y+"Id",I="logRender",E={},w=a.config,C=w[e+".Selectors"]||[],S=w[e+".WhitelistedAttributes"]||{href:1,class:1},O=w[e+".EnableContentEntities"],A=w["KillSwitch.ContentRendered"],N=a.global,$=N.document||{},k=$.documentElement,R=N.HTMLElement,U={},j=[],D=0,L=0,M=0,P=function(e,t,n,i){var r=this,o=a("Events",{producerId:e||"csa",lob:w.lob||"0"});t.type=t.type||c,r.id=t.id,r.l=o,r.e=t,r.el=n,r.rt=i,r.dlo=h,r.op=V(n,"csaOp"),r.log=function(e,t){o("log",e,t||h)},r.entities=function(e){e(t)},t.id&&o("setEntity",{element:t})},T=P.prototype;function _(e){var t=(e=e||{}).element,n=e.target;return t?function(e,t){var n;n=e instanceof R?Q(e)||z(t[u],e,Z,a.time()):U[e.id]||G(t[u],0,e,a.time());return n}(t,e):n?x(n):a.error("No element or target argument provided.")}function x(e){var t=function(e){var t=null,n=0;for(;e&&n<m;){if(n++,B(e,b)){t=e;break}e=e.parentElement}return t}(e);return t?Q(t):new P("csa",{id:null},null,a.time())}function B(e,t){if(e&&e.dataset)return e.dataset[t]}function W(e,t,n){j.push({n:n,e:e,t:t}),X()}function q(){for(var e=a.time(),t=0;0<j.length;){var n=j.shift();if(E[n.n](n.e,n.t),++t%10==0&&a.time()-e>p)break}i=0,j.length&&X()}function X(){i=i||a.raf(q)}function Y(e){return e&&e.constructor&&"NodeList"===e.constructor.name}function H(e,t,n){return{n:e,e:t,t:n}}function K(o,c,u){f in o&&s in o&&C.forEach(function(e){for(var t=e.selector,n=o[s](t),i=o[f](t),r=i.length-1;0<=r;r--)j.unshift(H(u,{e:i[r],s:e},c));n&&j.unshift(H(u,{e:o,s:e},c))})}function z(e,t,n,i){var r=t&&t[g];if(r)return r.el=t,a.emit("$content.reregister",{c:r,t:i}),M+=1,U[r.id]=r;var o=a.UUID(),c={id:o},u=x(t);return t[l][b]=o,n(c,t),u&&u.id&&(c.parentId=u.id,!c[d]&&u.e&&(u.e.slotId?c.relatedSlotId=u.e.slotId:u.e.relatedSlotId&&(c.relatedSlotId=u.e.relatedSlotId))),G(e,t,c,i)}function F(e){return isNaN(e)?null:Math.round(e)}function G(e,t,n,i){O&&(n.schemaId="<ns>.ContentEntity.2"),n.id=n.id||a.UUID();var r=new P(e,n,t,i);return function(e){return!A&&((e.op||{}).hasOwnProperty(I)||v)}(r)&&function(e,t){var n={},i=a.exec(F);e.el&&(n=e.el.getBoundingClientRect()),e.log({schemaId:"<ns>.ContentRender.3",timestamp:t,width:i(n.width),height:i(n.height),positionX:i(n.left+N.pageXOffset),positionY:i(n.top+N.pageYOffset)})}(r,i),a.emit("$content.register",r),D+=1,U[n.id]=r}function J(){var e=a("Metrics",{producerId:"csa"});if(e){var t="recordCounter",n="CSA.Content.Base.Widgets.",i="Registered";e(t,n+"Instrumented",Object.keys(U).length),e(t,n+i,D),e(t,n+"De"+i,L),e(t,n+"Re"+i,M),D=L=M=0}}function Q(e){return U[(e[l]||{})[b]]}function V(n,i){var r={};return o in(n=n||{})&&Object.keys(n[l]).forEach(function(e){if(!e.indexOf(i)&&i.length<e.length){var t=function(e){return(e[0]||"").toLowerCase()+e.slice(1)}(e.slice(i.length));r[t]=n[l][e]}}),r}function Z(e,t){o in t&&(function(e,t){var n=V(e,y);Object.keys(n).forEach(function(e){t[e]=n[e]})}(t,e),d in e&&(e[n]=e[d]),function(t,n){(t[o]()||[]).forEach(function(e){e in S&&(n[e]=t[r](e))})}(t,e))}k&&$[f]&&N[t]&&(C.push({selector:"*[data-csa-c-type]",entity:Z}),C.push({selector:".celwidget",entity:function(e,t){Z(e,t),e[d]=e[d]||t[r]("cel_widget_id")||t.id,e.legacyId=t[r]("cel_widget_id")||t.id,e.type=e.type||c}}),E[1]=function(e,i){e.forEach(function(e){var t=e.addedNodes;Y(t)&&Array.prototype.forEach.call(t,function(e){j.unshift(H(2,e,i))});var n=e.removedNodes;Y(n)&&Array.prototype.forEach.call(n,function(e){j.unshift(H(5,e,i))})})},E[2]=function(e,t){K(e,t,3)},E[3]=function(e,t){var n=e.e;Q(n)||z("csa",n,e.s.entity,t)},E[4]=function(){a.register(e,{instance:_})},E[5]=function(e,t){K(e,t,6)},E[6]=function(e,t){var n=e.e||{},i=(n[l]||{})[b];if(i&&i in U&&function(e){return!e||!e.isConnected}(n)){var r=U[i];!function(e,t){a.emit("$content.deregister",{c:e,t:t}),delete U[e.id],e.el=null,L+=1}(r,t),n[g]=r}},new N[t](function(e){W(e,a.time(),1)}).observe(k,{childList:!0,subtree:!0}),W(k,a.time(),2),W(null,a.time(),4),a.on("$content.export",function(t){Object.keys(t).forEach(function(e){T[e]=t[e]})}),a.on("$beforePageTransition",J),a.on("$beforeunload",J))});csa.plugin(function(r){var o,t="ContentImpressions",e="KillSwitch.",i="IntersectionObserver",s="getAttribute",c="dataset",a="intersectionRatio",m="impressionData",l="observe",u="unobserve",f="csaCId",v=1e3,d=r.global,n=r.config,g=n[e+t],h=n[e+t+".ContentViews"],p=((d.performance||{}).timing||{}).navigationStart||r.time(),I={};function w(t){t&&(t.v=1,function(t){if(h)return;t.vt=r.time(),t.el.log({schemaId:"<ns>.ContentView.4",timeToViewed:t.vt-t.el.rt,pageFirstPaintToElementViewed:t.vt-p})}(t))}function T(t){t&&!t.it&&(t.i=r.time()-t.is>v,function(t){if(g)return;t.it=r.time(),t.el.log({schemaId:"<ns>.ContentImpressed.3",timeToImpressed:t.it-t.el.rt,pageFirstPaintToElementImpressed:t.it-p})}(t))}d[i]&&(o=new d[i](function(t){var n=r.time();t.forEach(function(t){var e=function(t){if(t&&t[s])return I[t[c][f]]}(t.target);if(e){r.emit("$content.intersection",{meta:e.el,t:n,e:t});var i=t.intersectionRect;t.isIntersecting&&0<i.width&&0<i.height&&(e.v||w(e),.5<=t[a]&&!e.is&&(e.is=n,e.timer=r.timeout(function(){T(e)},v))),t[a]<.5&&!e.it&&e.timer&&(d.clearTimeout(e.timer),e.is=0,e.timer=0)}})},{threshold:[0,.5,.99]}),r.on("$content.register",function(t){var e=t.el;e&&(I[t.id]={el:t,v:0,i:0,is:0,vt:0,it:0},o[l](e))}),r.on("$content.deregister",function(t){var e=(t||{}).c,i=e.el;if(e.id in I){var n=I[e.id];n&&(d.clearTimeout(n.timer),n.is=0,n.timer=0),e[m]=n,delete I[e.id]}i&&o[u]&&o[u](i)}),r.on("$content.reregister",function(t){var e=(t||{}).c,i=e.el,n=e[m];n&&(I[e.id]=n),i&&o[l](i)}))});csa.plugin(function(e){e.config["KillSwitch.ContentLatency"]||e.emit("$content.export",{mark:function(t,n){var o=this;o.t||(o.t=e("Timers",{logger:o.l,schemaId:"<ns>.ContentLatency.4",logOptions:o.dlo})),o.t("mark",t,n)}})});csa.plugin(function(t){function n(i,e,o){var c={};function r(t,n,e){t in c&&o<=n-c[t].s&&(function(n,e,i){if(!m)return;E(function(t){T(n,t),t.w[n][e]=a((t.w[n][e]||0)+i)})}(t,i,n-c[t].d),c[t].d=n),e||delete c[t]}this.update=function(t,n){n.isIntersecting&&e<=n.intersectionRatio?function(t,n){t in c||(c[t]={s:n,d:n})}(t,s()):r(t,s())},this.stopAll=function(t){var n=s();for(var e in c)r(e,n,t)},this.reset=function(){var t=s();for(var n in c)c[n].s=t,c[n].d=t},this.stop=r}var e=t.config,s=t.time,i="ContentInteractionsSummary",o=e[i+".FlushInterval"]||5e3,c=e[i+".FlushBackoff"]||1.5,r=t.global,u=t.on,a=Math.floor,f=(r.document||{}).documentElement||{},l=((r.performance||{}).timing||{}).responseStart||t.time(),d=o,p=0,m=!0,v=t.UUID(),g=t("Events",{producerId:"csa",lob:e.lob||"0"}),w=new n("it0",0,0),I=new n("it50",.5,1e3),h=new n("it100",.99,0),b={},A={};function $(){w.stopAll(!0),I.stopAll(!0),h.stopAll(!0),S()}function C(){w.reset(),I.reset(),h.reset(),S()}function S(){d&&(clearTimeout(p),p=t.timeout($,d),d*=c)}function U(n){E(function(t){T(n,t),t.w[n].mc=(t.w[n].mc||0)+1})}function E(t){g("log",{messageId:v,schemaId:"<ns>.ContentInteractionsSummary.2",w:{},__merge:t},{ent:{page:["requestId"]}})}function T(t,n){t in n.w||(n.w[t]={})}e["KillSwitch."+i]||(u("$content.intersection",function(t){if(t&&t.meta&&t.e){var n=t.meta.id;if(n in b){var e=t.e.boundingClientRect||{};e.width<5||e.height<5||(w.update(n,t.e),I.update(n,t.e),h.update(n,t.e),!t.e.isIntersecting||n in A||(A[n]=1,function(n,e){E(function(t){T(n,t),t.w[n].ttfv=a(e)})}(n,s()-l)))}}}),u("$content.register",function(t){(t.e||{}).slotId&&(b[t.id]={},function(e){E(function(t){var n=e.id;T(n,t),t.w[n].sid=(e.e||{}).slotId,t.w[n].cid=(e.e||{}).contentId})}(t))}),u("$content.deregister",function(t){if(t){var n=t.c,e=t.t;if(n){var i=n.id;w.stop(i,e),I.stop(i,e),h.stop(i,e)}}}),u("$beforePageTransition",function(){$(),C(),v=t.UUID(),S()}),u("$beforeunload",function(){w.stopAll(),I.stopAll(),h.stopAll(),d=null}),u("$visible",function(t){t?C():($(),clearTimeout(p)),m=t},{buffered:1}),u(f,"click",function(t){for(var n=t.target,e=25;n&&0<e;){var i=(n.dataset||{}).csaCId;i&&U(i),n=n.parentElement,e-=1}},{capture:!0,passive:!0}),S())});csa.plugin(function(d){var t,o,i="normal",u="reload",e="history",s="new-tab",n="ajax",r=1,a=2,c="lastActive",l="lastInteraction",f="used",p="csa-tabbed-browsing",y="visibilityState",g="page",v="experience",b="request",I="initialized",m={"back-memory-cache":1,"tab-switch":1,"history-navigation-page-cache":1},h="TabbedBrowsing",T="<ns>."+h+".4",S="visible",w=d.global,x=d.config,P=d("Events",{producerId:"csa",lob:x.lob||"0"}),q=w.location||{},$=w.document,z=w.JSON,A=((w.performance||{}).navigation||{}).type,C=d.store,E=d.on,O=d.storageSupport(),k=!1,R={},j={},B={},J={},K={},M=!1,N=!1,D=!1,F=0,G=0,H=x["CSA.isRunningInsideMShop"];function L(i){try{return z.parse(C(p,void 0,{session:i})||"{}")||{}}catch(i){d.error('Could not parse storage value for key "'+p+'": '+i)}return{}}function Q(i,e){C(p,z.stringify(e||{}),{session:i})}function U(i){return"string"==typeof i}function V(i,e){return U(i)?i:e}function W(i){var e=j.tid||i.id,t={},n=R[c]||{};for(var r in n)n.hasOwnProperty(r)&&(t[r]=n[r]);!H&&t.tid!==e||(t.tid=e,t.pid=i.id,t.ent=K),J={pid:i.id,tid:e,ent:K,lastInteraction:j[l]||{},initialized:!0},B={lastActive:t,lastInteraction:R[l]||{},time:d.time(),initialized:!0}}function X(i){var e=i===s,t=$.referrer,n=!(t&&t.length)||!~t.indexOf(q.origin||""),r=e&&!H&&n,a={type:i,toTabId:J.tid,toPageId:J.pid,transitTime:d.time()-R.time||null};r||function(i,e,t){var n=i===u,r=e||H&&(!(j[I]&&j.ent)||D)?R[c]||{}:j,a=R[l]||{},d=j[l]||{},o=e||H&&!(d.id&&!d[f])?a:d;t.fromTabId=r.tid,t.fromPageId=r.pid;var s=r.ent||{};U(s.rid)&&(t.fromRequestId=s.rid||null),U(s.ety)&&(t.fromExperienceType=s.ety||null),U(s.esty)&&(t.fromExperienceSubType=s.esty||null),n||!o.id||o[f]||(t.interactionId=o.id||null,o.sid&&(t.interactionSlotId=o.sid||null),a.id===o.id&&(a[f]=!0),d.id===o.id&&(d[f]=!0))}(i,e,a),P("log",{navigation:a,schemaId:T},{ent:{page:["pageType","subPageType","requestId"]}})}function Y(i){D=function(i){return i&&i in m}(i.transitionType),function(){R=L(!1),j=L(!0);var i=R[l],e=j[l],t=!1,n=!1;i&&e&&i.id===e.id&&i[f]!==e[f]&&(t=!i[f],n=!e[f],e[f]=i[f]=!0,t&&Q(!1,R),n&&Q(!0,j))}(),W(i),M=!0,function(i){var e,t;e=_(),t=ei(!0),(e||t)&&W(i)}(i),F=1}function Z(){k&&!D?X(n):(k=!0,function(){if(A===a||D)X(e);else if(A===r)X(j[I]?u:s);else{X(j[I]||H&&R[I]?i:s)}}())}function _(){var i=t,e={};return!!(M&&i&&i.e&&i.w)&&(i.w("entities",function(i){e=i||{}}),j[l]={id:i.e.messageId,sid:e.slotId,used:!(R[l]={id:i.e.messageId,sid:e.slotId,used:!1})},!(t=null))}function ii(i,e){var t=i||{},n=e||{};return t.rid!==n.rid||t.ety!==n.ety||t.esty!==n.esty}function ei(i){var e=!1;if(N=H&&i||$[y]===S,M){var t=R[c]||{};e=function(i,e,t,n){var r=!1,a=i[c];return N?(!a||a.tid!==J.tid||!a[S]||a.pid!==t||!a.ent&&n||n&&ii(a.ent,n))&&(i[c]={visible:!0,pid:t,tid:e,ent:n},r=!0):!H&&a&&a.tid===J.tid&&a[S]&&(r=!(a[S]=!1)),r}(R,(D?t.tid:null)||j.tid||t.tid||J.tid,(D?t.pid:null)||j.pid||t.pid||J.pid,(D?t.ent:null)||j.ent||t.ent||J.ent)}return e}x["KillSwitch."+h]||O.local&&O.session&&z&&$&&y in $&&(o=function(){try{return w.self!==w.top}catch(i){return!0}}(),E("$beforePageTransition",function(){G=1}),E("$entities.set",function(i){if(!o&&i){var e=(i[b]||{}).id||(i[g]||{}).requestId,t=(i[v]||{}).experienceType||(i[g]||{}).pageType,n=(i[v]||{}).experienceSubType||(i[g]||{}).subPageType,r=ii(K,{rid:e,ety:t,esty:n});if(K.rid=V(e,K.rid),K.ety=V(t,K.ety),K.esty=V(n,K.esty),!G&&r&&F){var a=R[c]||{};a.tid===j.tid&&(a.ent=K,Q(!1,R)),j.ent=K,Q(!0,j)}}},{buffered:1}),E("$pageChange",function(i){o||(Y(i),Z(),Q(!1,B),Q(!0,J),j=J,R=B,G=0)},{buffered:1}),E("$content.interaction",function(i){t=i,_()&&(Q(!1,R),Q(!0,j))}),E($,"visibilitychange",function(){!o&&ei()&&Q(!1,R)},{capture:!1,passive:!0}))});csa.plugin(function(c){var e=c("Metrics",{producerId:"csa"});c.on(c.global,"pageshow",function(c){c&&c.persisted&&e("recordMetric","bfCache",1)})});csa.plugin(function(n){var e,t,i,o,r,a,c,u,f,s,l,d,p,g,m,v,h,b,y="hasFocus",S="$app.",T="avail",$="client",w="document",I="inner",P="offset",D="screen",C="scroll",E="Width",F="Height",O=T+E,q=T+F,x=$+E,z=$+F,H=I+E,K=I+F,M=P+E,W=P+F,X=C+E,Y=C+F,j="up",k="down",A="none",B=20,G=n.config,J=G["KillSwitch.PageInteractionsSummary"],L=n("Events",{producerId:"csa",lob:G.lob||"0"}),N=1,Q=n.global||{},R=n.time,U=n.on,V=n.once,Z=Q[w]||{},_=Q[D]||{},nn=Q.Math||{},en=nn.abs,tn=nn.max,on=nn.ceil,rn=((Q.performance||{}).timing||{}).responseStart,an=function(){return Z[y]()},cn=1,un=100,fn={},sn=1,ln=0,dn=0,pn=k,gn=A;function mn(){c=t=o=r=e,i=d=0,a=u=f=s=l=0,pn=k,gn=A,dn=ln=0,yn(),bn()}function vn(){rn&&!o&&(c=on((o=p)-rn),sn=1)}function hn(){var n=m-i;(!t||t&&t<=p)&&(n&&(++a,sn=dn=1),i=m,n),function(){if(gn=d<m?k:j,pn!==gn){var n=en(m-d);B<n&&(++l,ln&&!dn&&++a,pn=gn,sn=ln=1,d=m,dn=0)}else dn=0,d=m}(),t=p+un}function bn(){u=on(tn(u,m+b)),g&&(f=on(tn(f,g+h))),sn=1}function yn(){p=R(),g=en(Q.pageXOffset||0),m=tn(Q.pageYOffset||0,0),v=0<g||0<m,h=Q[H]||0,b=Q[K]||0}function Sn(){yn(),vn(),hn(),bn()}function Tn(){if(r){var n=on(R()-r);s+=n,r=e,sn=0<n}}function $n(){r=r||R()}function wn(n,e,t,i){e[n+E]=on(t||0),e[n+F]=on(i||0)}function In(n){var e=n===fn,t=an();if(t||sn){if(!e){if(!N)return;N=0,t&&Tn()}var i=function(){var n={},e=Z.documentElement||{},t=Z.body||{};return wn("availableScreen",n,_[O],_[q]),wn(w,n,tn(t[X]||0,t[M]||0,e[x]||0,e[X]||0,e[M]||0),tn(t[Y]||0,t[W]||0,e[z]||0,e[Y]||0,e[W]||0)),wn(D,n,_.width,_.height),wn("viewport",n,Q[H],Q[K]),n}(),o=function(){var n={scrollCounts:a,reachedDepth:u,horizontalScrollDistance:f,dwellTime:s,vScrollDirChanges:l};return"number"==typeof c&&(n.clientTimeToFirstScroll=c),n}();e?sn=0:(mn(),rn=R(),t&&(r=rn)),L("log",{activity:o,dimensions:i,schemaId:"<ns>.PageInteractionsSummary.3"},{ent:{page:["pageType","subPageType","requestId"]}})}}function Pn(){Tn(),In(fn)}function Dn(n,e){return function(){cn=e,n()}}function Cn(){an=function(){return cn},cn&&!r&&(r=R())}"function"!=typeof Z[y]||J||(mn(),v&&vn(),U(Q,C,Sn,{passive:!0}),U(Q,"blur",Pn),U(Q,"focus",Dn($n,1)),V(S+"android",Cn),V(S+"ios",Cn),U(S+"pause",Dn(Pn,0)),U(S+"resume",Dn($n,1)),U(S+"resign",Dn(Pn,0)),U(S+"active",Dn($n,1)),an()&&(r=rn||R()),V("$beforeunload",In),U("$beforeunload",In),U("$document.hidden",Pn),U("$beforePageTransition",In),U("$afterPageTransition",function(){sn=N=1}))});csa.plugin(function(e){var o,n,r="Navigator",a="<ns>."+r+".5",i=e.global,c=e.config,d=i.navigator||{},t=d.connection||{},l=i.Math.round,u=e("Events",{producerId:"csa",lob:c.lob||"0"});function v(){o={network:{downlink:void 0,downlinkMax:void 0,rtt:void 0,type:void 0,effectiveType:void 0,saveData:void 0},language:void 0,doNotTrack:void 0,hardwareConcurrency:void 0,deviceMemory:void 0,cookieEnabled:void 0,webdriver:void 0},w(),o.language=d.language||null,o.doNotTrack=function(){switch(d.doNotTrack){case"1":return"enabled";case"0":return"disabled";case"unspecified":return d.doNotTrack;default:return null}}(),o.hardwareConcurrency="hardwareConcurrency"in d?l(d.hardwareConcurrency||0):null,o.deviceMemory="deviceMemory"in d?l(d.deviceMemory||0):null,o.cookieEnabled="cookieEnabled"in d?d.cookieEnabled:null,o.webdriver="webdriver"in d?d.webdriver:null}function k(){u("log",{network:(n={},Object.keys(o.network).forEach(function(e){n[e]=o.network[e]+""}),n),language:o.language,doNotTrack:o.doNotTrack,hardwareConcurrency:o.hardwareConcurrency,deviceMemory:o.deviceMemory,cookieEnabled:o.cookieEnabled,webdriver:o.webdriver,schemaId:a},{ent:{page:["pageType","subPageType","requestId"]}})}function w(){!function(n){Object.keys(o.network).forEach(function(e){o.network[e]=n[e]})}({downlink:"downlink"in t?l(t.downlink||0):null,downlinkMax:"downlinkMax"in t?l(t.downlinkMax||0):null,rtt:"rtt"in t?(t.rtt||0).toFixed():null,type:t.type||null,effectiveType:t.effectiveType||null,saveData:"saveData"in t?t.saveData:null})}function f(){w(),k()}function y(){v(),k()}c["KillSwitch."+r]||(v(),k(),e.on("$afterPageTransition",y),e.on(t,"change",f))});csa.plugin(function(a){a.emit("$csa.loaded")});
+(function(p,n,w,l){var r={EX:{}};(function(){return"object"===typeof performance&&"function"===typeof performance.now?function(){return performance.now()}:"function"===typeof Date.now?Date.now:function(){return(new Date).getTime()}})();var u=function(a,b,c,e){var f={};try{if(5<=e)return{};b=b||n;c=c||a;for(var k,g=Object.keys(c),d,h=0;h<g.length;h++)d=g[h],k=c[d],"object"!==typeof k||Array.isArray(k)?f[d]=b[d]:f[d]=null==b[d]?null:u(a,b[d],c[d],e+1)}catch(l){m(l,"ex in collecting-")}return f},v=function(a,
+b){var c="";try{var e=b.toString(),e=e.replace(/\n/g,"").replace(/\s\s+/g," ");c=e==="function "+a+"() { [native code] }"||e==="function "+a+"() { [native code]}"?"0x6":e=e.replace(/function/,"fx").replace(/\[native code\]/,"nc")}catch(f){c="ex"}return c},s=function(a,b,c,e){var f=[];try{if(5<=e)return[];c=c||b;for(var k=Object.keys(c),g=0;g<k.length;g++){var d=k[g];if("object"!=typeof c[d]||null==c[d]||Array.isArray(c[d]))switch(!0){case !0===a[d]:f[g]=1;break;case !1===a[d]:f[g]=0;break;case 0===
+a[d]:f[g]=0;break;case "function"===typeof a[d]:f[g]=v(d,a[d]);break;case null!=a[d]:f[g]=a[d];break;default:f[g]=null}else f[g]=null!=a[d]?s(a[d],b,c[d],e+1):s({},b,c[d],e+1)}}catch(h){m(h,"ex in compression-")}return f},q=function(a,b){try{p.ue&&p.ue.event&&p.ue.event(x(b,a),"a9_tq","a9_tq.FraudMetrics.3")}catch(c){m(c,"ex in logging-")}},h=function(a,b,c){try{q(b+a.stack,c)}catch(e){m(e,"ex in logging-")}},m=function(a,b){p.ueLogError&&p.ueLogError(a,{logLevel:"ERROR",attribution:"A9TQForensics",
+message:b})},y=function(){try{if(l&&l.userAgent&&/chrome/i.test(l.userAgent)&&l.userAgentData&&l.userAgentData.brands)for(var a=l.userAgentData.brands,b=0;b<a.length;b++)if(a[b].brand&&/google/i.test(a[b].brand))return!0;return!1}catch(c){h(c,"ex in identifying Chrome Browser ","103")}},t=function(a){try{a&&!a.stack&&(a.stack=a.toString())}catch(b){h(b,"ex in populating stack trace ","100")}},x=function(a,b){try{var c={vfrd:a};"object"===typeof b?c.info=JSON.stringify(b,function(a,b){return"function"===
+typeof b?v(a,b):b}):"string"===typeof b&&(c.info=b);return{server:window.location.hostname,fmp:c}}catch(e){return m(e,"ex in constructing pixel - "),{server:window.location.hostname,fmp:{vfrd:"0"}}}};(function(a,b){try{try{try{r.mimeTypesLength=n.navigator.mimeTypes.length,r.pluginsLength=n.navigator.plugins.length}catch(c){h(c,"ex in basic props ","30")}n.a9tqDerivedFeatures=r}catch(e){h(e,"ex in evaluation-","30")}var f=u(a,b,null,0);try{n.a9tqDerivedFeatures=null,delete n.a9tqDerivedFeatures}catch(k){h(k,
+"ex in deleting derivedFeatures-","30")}var g=s(f,a,null,0);q(g,"2")}catch(d){m(d,"ex in full attribute flow-")}})({window:{innerHeight:0,innerWidth:0,outerWidth:0,outerHeight:0,length:0,callPhantom:"",__phantomas:"",PhantomEmitter:"",_phantom:"",_WEBDRIVER_ELEM_CACHE:"",domAutomationController:"",domAutomation:"",spawn:"",emit:"",Buffer:"",TEMPORARY:"",external:"",Components:{classes:"",wdIStatus:"",wdIMouse:"",wdICoordinate:"",interfaces:"","interface":{nsICommandProcessor:""}},netscape:{security:{privilegemanager:""}},
+isExternalUrlSafeForNavigation:0,opera:{_browserjsran:""},onabsolutedeviceorientation:"",onstorage:"",chrome:"",clearInterval:"",clearTimeout:"",eval:"",alert:"",prompt:"",scroll:"",onhelp:"",maxConnectionsPerServer:"",opr:"",devicePixelRatio:"",webdriver:"",InstallTrigger:"",safari:"",ontouchstart:""},screen:{availHeight:0,availWidth:0,width:0,height:0,colorDepth:0,pixelDepth:0,orientation:{angle:0,onchange:0}},navigator:{appCodeName:"",appName:"",appVersion:"",deviceMemory:0,doNotTrack:0,hardwareConcurrency:0,
+language:"",maxTouchPoints:0,product:"",productSub:0,vendor:"",vendorSub:"",userAgent:"",languages:[],platform:"",webdriver:0,msLaunchUri:"",permissions:"",oscpu:"",msMaxTouchPoints:"",userAgentData:""},document:{id:"",height:"",width:"",except:"",style:{position:"",top:"",left:"",visibility:"",opacity:"",hidden:"",webkitHidden:"",msHidden:"",mozHidden:""},referer:"",webdriver:""},a9tqDerivedFeatures:{mimeTypesLength:"",pluginsLength:"",EX:{a:[],b:[]}},history:{length:""}},n);(function(){var a=[];
+try{var b=Date.now(),c="function"===typeof w.hasPrivateToken?1:0,e="www.amazon.com"===n.location.hostname?1:0,f="function"===typeof AbortController?1:0,k=y()?1:0;if(k&&c&&e&&f){var g=atob("aHR0cHM6Ly93d3cuYW1hem9uLmNvbS90dC9p"),d=new AbortController,l=setTimeout(function(){try{d.abort()}catch(a){t(a),h(a,"ex in set PST timeout ","100")}},2E3);fetch(g,{privateToken:{version:1,operation:"token-request"},signal:d.signal}).then(function(c){a=[1,Date.now()-b,c.status];q(a,"101")})["catch"](function(a){t(a);
+h(a,"ex in PST Issuance API call ","100")})["finally"](function(){clearTimeout(l)})}else a=[0,Date.now()-b,k,c,e,f],q(a,"101")}catch(m){t(m),h(m,"ex in PST issuance flow ","102")}})()})(ue_csm,window,document,navigator);
+
+
+
+ue.exec(function(d,c){function g(e,c){e&&ue.tag(e+c);return!!e}function n(){for(var e=RegExp("^https://(.*\.(images|ssl-images|media)-amazon\.com|"+c.location.hostname+")/images/","i"),d={},h=0,k=c.performance.getEntriesByType("resource"),l=!1,b,a,m,f=0;f<k.length;f++)if(a=k[f],0<a.transferSize&&a.transferSize>=a.encodedBodySize&&(b=e.exec(String(a.name)))&&3===b.length){a:{b=a.serverTiming||[];for(a=0;a<b.length;a++)if("provider"===b[a].name){b=b[a].description;break a}b=void 0}b&&(l||(l=g(b,"_cdn_fr")),
+a=d[b]=(d[b]||0)+1,a>h&&(m=b,h=a))}g(m,"_cdn_mp")}d.ue&&"function"===typeof d.ue.tag&&c.performance&&c.location&&n()},"cdnTagging")(ue_csm,window);
+
+
+}
+(n=>{var A,E=1e6,M=(n.Symbol||{}).iterator;n.RXVM=function(r){(r=r||{}).mi&&(E=r.mi);var i=n([1,function(n){n.u.t[m(n)]=h(n)},2,function(n){n.i[0].t[m(n)]=h(n)},3,h,4,function(n){var r=h(n),t=h(n),n=h(n);w(n)&&(n[t]=r)},5,function(n){var r=h(n),t=m(n);w(r)&&"function"==typeof r[M]&&(n.u.t[t]=r[M]())},6,function(n){var r=n.u.t[m(n)],r=r&&r.next?r.next():A,t=m(n),u=x(n);w(r)&&!1===r.done?n.u.t[t]=r.value:d(n,u)},10,function(n){n.u.o.push(h(n))},11,function(n){n.u.o.push(n.v)},12,function(n){for(var r=F(n);0<r--;)n.l.push(S(n))},30,function(n){return!h(n)},42,function(){},43,function(n){for(var r=F(n);0<r--;)n.u.t.push(n._.pop())},45,a(!0),44,a(!1),48,v(0,y),49,v(1,y),50,v(2,y),51,v(-1,y),52,v(0,_),53,v(1,_),54,v(2,_),55,v(-1,_),58,function(n){d(n,x(n))},59,s(!0),60,s(!1),64,function(n){var r=x(n),t=p(n,n.u.h);return d(n,r),t},65,function(n){var r=F(n),t=x(n),u=p(n,n.u.h);n.u.t[r]=u,d(n,t)}]),o={40:function(n,r){return"__rx_cls"in n?n.__rx_cls===r.__rx_ref:n instanceof r}},t=(o[20]=Math.pow,l(16,"+"),l(17,"-"),l(18,"*"),l(19,"/"),l(21,"%"),l(22,"&"),l(23,"|"),l(24,"^"),l(25,"<<"),l(26,">>"),l(27,">>>"),l(28,"&&"),l(29,"||"),l(31,">"),l(33,">="),l(32,"<"),l(34,"<="),l(35,"=="),l(36,"==="),l(37,"!="),l(38,"!=="),l(39," in "),n([10,A,11,null,14,!0,15,!1])),u=n([1,function(n){return n.v},17,F,18,function(n){n=m(n)|m(n)<<8|m(n)<<16|m(n)<<24;return n=2147483647<n?-4294967295+n-1:n},19,function(n){for(var r=[],t=0;t<4;t++)r.push(m(n));return new Float32Array(new Uint8Array(r).buffer)[0]},12,S,13,function(n){return n.l[F(n)]},20,function(){return[]},21,function(n){for(var r=F(n),t=[];0<r--;)t.unshift(h(n));return t},24,function(n){for(var r,t,u,i=F(n),o=[];0<i--;)o.unshift((u=t=void 0,r=m(r=n),t=128&r?-1:1,u=r>>3&15,r&=7,15!=u?0==u?r/8*t*.015625:t*(1+r/8)*Math.pow(2,u-7):NaN));return o},22,function(){return{}},23,function(n){for(var r=F(n)/2,t={};0<r--;){var u=h(n);t[h(n)]=u}return t},32,function(n){return n.u.t[F(n)]},33,function(n){return n.i[0].t[F(n)]},48,function(n){var r=h(n),n=h(n);return w(n)?("function"==typeof(r=n[r])&&(r.__rx_this=n),r):n},50,function(n){return n.u.o.pop()},52,function(n){return typeof h(n)}]);function f(n){for(;0<n.p--&&(r=n).u&&r.u.h<r.m.length;){r=m(n);n.v=e(r,n)}var r}function e(n,r){var t,u;return n in o?(t=h(r),u=h(r),o[n](u,t)):n in i?i[n](r):void k("e2:"+n+":"+r.u.h)}function c(n,r){return{F:n,h:n,t:[],o:[],S:r}}function n(n){for(var r={},t=0;t<n.length;t+=2)r[n[t]]=n[t+1];return r}function a(i){return function(n){var r=i?h(n):A,t=n.i.pop(),u=A,u=t.S?t.t[0]:r;return n._=[],n.u=n.i[n.i.length-1],b(n,n.u.F),u}}function v(u,i){return function(n){var r=h(n),t=u;for(-1===u&&(t=F(n));0<t--;)n._.push(h(n));if(n.v=A,r)return i(r,n)}}function s(u){return function(n){var r=h(n),t=x(n);(u&&r||!r&&!u)&&d(n,t)}}function l(u,i){o[u]=function(n,r){var t=Function("a","b","return a"+i+"b");return(o[u]=t)(n,r)}}function _(n,r){var t;if(n.__rx_ref&&n.g===r){var u=c(n.__rx_ref,!0);u.t.push({__rx_cls:n.__rx_ref}),r.i.push(u),r.u=u,b(r,u.F)}else if("function"==typeof n){u=r._.reverse().splice(0),u=Function.prototype.bind.apply(n,[null].concat(u));try{t=new u,r._=[]}catch(n){}}else k("e5:"+n+":"+r.u.h);return t}function y(n,r){var t;if(n.__rx_ref&&n.g===r){var u=c(n.__rx_ref);u.t.push(n.__rx_this||this),r.i.push(u),r.u=u,b(r,u.F)}else if("function"==typeof n){u=r._.reverse().splice(0);try{t=n.apply(n.__rx_this||this,u),r._=[]}catch(n){}}else k("e4:"+n);return t}function h(n){var r=m(n);return 0<(128&r)?e(127&r,n):r in t?t[r]:r in u?u[r](n):void k("e3:"+r)}function p(t,u){var n=g(function(){var n=c(u),r=n.t;return r.push(this),r.push.apply(r,arguments),t.i.push(n),t.u=n,t.p=E,b(t,n.F),f(t),t.v});return n.__rx_ref=u,n.g=t,n}function w(n){if(n!==A&&null!==n)return 1;r.unsafe&&k("e10"+n)}function b(n,r){n.k=r%127+37}function d(n,r){n.u.h+=r}function m(n){return n.m[n.u.h++]^n.k}function x(n){n=m(n)|m(n)<<8;return n=32767<n?-65535+n-1:n}function F(n){for(var r,t=0,u=0,i=n.u.h,o=n.m,f=n.k;t+=(127&(r=o[i+u]^f))*(1<<7*u),u+=1,0<(128&r););return n.u.h+=u,t}function S(n){for(var r=F(n),t="";0<r--;)t+=String.fromCharCode(m(n));return t}function g(n){return function(){try{return n.apply(this,arguments)}catch(n){k(n)}}}function k(n){if(r.unsafe)throw Error(n)}this.execute=g(function(n,r){var t,u;return 82!==n[0]&&88!==n[1]?k("e1"):(n=n,t=3,(u=c(0)).t[0]=(r=r)||{},u.h=t,b(r={m:n,p:E,v:0,i:[u],u:u,_:[],l:[],k:0},0),f(t=r),t)})}})("undefined"==typeof window?global:window);
+(n=>{for(var t="undefined"==typeof window?n:window,i=0,n="addEventListener",e="ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/".split(""),u=[],r=t.rx||{},o=r.c||{},f=o.rxp||"/rd/uedata",c=o.fi||1e3,a=1.5,d=1e4,x={},w={},m={},v={},h=0,l=0;l<e.length;l++)u[e[l]]=l;function p(n,r){return function(){try{return n.apply(this,arguments)}catch(n){s(n.message||n,n)}}}function s(n,r){if(m[i]=[(n=(""+(n||"")).substring(0,100)).length].concat((new TextEncoder).encode(n)),o.DEBUG)throw r||n;b()}function y(n,r){r=p(r),n in w||(w[n]=[]),w[n].push(r),n in x&&r()}function g(n,r){n in x||(x[n]=r,(w[n]||[]).forEach(function(n){n(r)}))}function A(n){for(var r=0,t=0,i="",o=0;o<n.length;o+=1)for(t+=8,r=r<<8|n[o];6<=t;)i+=e[r>>t-6],r&=255>>8-(t-=6);return 0<t&&(i+=e[r<<6-t]),i}function U(n){for(var r=0,t=0,i=[],o=0;o<n.length&&"="!==n[o];o+=1)for(t+=6,r=r<<6|u[n[o]];8<=t;)i.push(r>>t-8),r&=255>>8-(t-=8);return new Uint8Array(i)}function b(){!h&&0<c&&(setTimeout(p(I),c),c=Math.min(d,c*a),h=1)}function E(r){let t=[];return Object.keys(r).forEach(n=>{t.push(parseInt(n)),t=t.concat(r[n])}),t}function I(){h=0;var n=E(m);0<n.length&&rx.ep(n,T),m={}}function T(n){n=A(new Uint8Array(n));n=f+"?rid="+rx.rid+"&sid="+rx.sid+"&rx="+n;(new Image).src=n}function j(n){g("load",n)}function L(n){j(n),g("unload",n),I()}(t.rx=r).err=s,r.r=p(y),r.e=p(g),r.exec=p,r.p=p(function(n,r){g("rxm:"+n,r),m[255&n]=r,b()}),r.pc=p(function(n,r){v[255&n]=r,n=E(v),r=rx.ep4(n,rx.fnpb),n=A([rx.fnpv].concat(rx.fnpb,r)),document.cookie="rxc="+n+"; max-age=86400; path=/"}),r.ex64=p(function(r,n){y(n||"init",function(){var n;t.RXVM&&(n=U(r),t.$RX||(t.$RX=new t.RXVM({mi:o.mi})),$RX.execute(n,t))})}),r.e64=p(A),r.d64=p(U),r.erc4=p(function(){var n=rx.fnpb,r=rx.fnpv,t=rx.ep4(E(m),n);return A(new Uint8Array([r].concat(n,t)))}),g("init",{}),"complete"===document.readyState?j({}):n in t&&(t[n]("load",p(j)),t[n]("beforeunload",p(L)),t[n]("pagehide",p(L)))})(window);
+rx.ex64("UlgBKT4nV10haERRTSFMSFBJIUFKS0AgU0RJUEAjSUBLQlFNIVFNQEsvSktGSkhVSUBRQC1GRElJR0RGTidCUSBDSUpKVyFhRFFAJktKUi9wTEtRHWRXV0RcJlZAUS5wTEtRFhdkV1dEXCNHUENDQFcjVlBHUUlAIkBLRldcVVEhS0RIQCJkYHYIZmdmI0FMQkBWUSJ2bWQIFxATIGFgZ3BiIUBdQEYmV0xBJlZMQSQkFSglBSUkJ7gzFSkkRgUkJCa4FSkjRldcVVFKBSUVKS1IVmZXXFVRSgUlZCIBJa6EsbWJjtHg/fHA6+bq4eD3pIWGtYmD4Ovm6uHghLSEpYSohGQtoiUFLy8sP8HTmNsjHw8pDi8rLy0oLSo0LhweIyweIy8PLj+f3fPfJ7YOKg4sLywvFM/RLyy2HiMrDi8OLC8strU/Pg4sDiwcHiMsHiMvDy4/xbqBgSYOLC8sLy8strU/Iw4sDiwcHiMsHiMvDy4/m/LkuyIOLC8sLy8strU/Pg4sDiwDtT8uDixkLD4lETk7PgoaOBo7PgoaORo7GjgaOz4aPho5GjsWZC+bJXJbWFpNWF1NWFxIWVhfSFlYXkhZWFFIWWX5SNlbeVFIWV15UXlReVpYUclIWHlRY7+mWFFIWWX5SNlbeVF3WVhczEjZW8lpzGlUXHlbeVF5W8lpeVF5WnlcanhQWnlceVF5WlhRyUhYeVFjkKZceVhQX1BTHFlYXsxI2VvJSFh5XlhfzEjZW8lpeV55WnlfanhQWnlfeV55WmhpVV0pLCoxeV3BacxI2VvJaXlfeVppeV55WnlaeVNj76Z0eV1kLmIlt56gO7ydkZqRnK2skZq8nbyesZ2ms5ygO7ydkZu7nJi8npGUvJ3cj5xsd3ZLTmZGdkpANCM1MyoyZkZql5iukZu8nbG8nbBkKbElQ2pU9fZJbPZJbmloRFhYZWRYZWNJaHt5gG9pY1lYZWJYZWlJaFp1aVhlYVhlaEloaWtpXVhlZUlo+FhlbUhpeWxpbGldWGVnSWh9aUhra1hleGljXVhlZUloWmNZWGVmSGxaWlhlZkhseWxIaVtYZXpYZXlJa2tIbElsf2556GllbUluZGoBHmV8ZXtjWkljSGpaRGQoXCWqg4CDHKCEoYO9H6GDgIGtsbGMjbGMiqCBkpBphoCKsLGMi7GMgKCBs5yAsYyIsYyBoIGAgoC0sYyMoIERsYyEoYCQhYCFgLSxjI6ggZSAoYKCsYyRgIq0sYyMoIGzirCxjI+hhbOzsYyPoYWQhaGAs6CLoYOhhayAZCsiJFR9Tl54X35+fn5OXnhffX59fk1PcmpPcm5efF9+cml0PxZ/iaOXkq+vg6KCo6Cno5GSrqvLz9LN0Nbpx9uSr7ODoae3oK6lxsfB0NvS1q+wrbWmsyKjr6evtq+xgqOuodDD1aniv6JMZmVjR2ZbV2pwRmVrZ2NGY2tiODgCFQxGZkpGY6mQg6mQkI+jdE1edE1Nfnx+TU9yak9ybl58X31yaXQ/VH8MJhUXKyJUS05EQgcmNjc2JyUhJhsXKjAGJSsnIwYhKyJ4eEJVTgYmCgYhdE1edE1Nfnt+Q09yaF59W39OT3N8HhMTT3N4Lw0QEhYMGl5/an1fe198dHtNc3sgIBoNXn5TFBUoPQUkBSkuIRcpJ0BVBSQUFSg9BSQFKC4hFykmQFURBSQUFSg9BSQFLy4hFyknQBEFJBQVKD0FJAUtLiEXKSRNBSQZuRUoPwUkFSg8BSQxJRQVKD0FJAUrFyQVKD8FJBUoPAUk","load");
+rx.ex64("UlgBKSInV10hQUpLQCBTRElQQCNJQEtCUU0mVUpSIENJSkpXIFdKUEtBJCQVKSFAXUBGFSglBSUkJxUpIWhEUU0FJSQmFSkja1BIR0BXBSVkITklUnh4e2h5fFl4en96fXN5eHvpWX1Ze0OIhlRZe2QgNSWymKi4nbmYiqmUmrmYmLSYZCNnJQUvHw8rDi8vLC8vLT8uKw4vKigqKzkuHB4jKg8sPyy/DiwOKz4vDi0vLS8UytEfHiIqXV9cWg8svR4jLQ4vDi0DL2QiayVfdXV2RHl3VHVFVXFUdXV3dUVVclR1dXB1RUR5cVV2VHZiZYuLd3V/RUR5cVV2VHdiZYuLd3V/RUR5cVV2VHBiZYuLd3V/d2F3RkZGWXVkLWUlbEZ2ZkBnRkZFRmpSQdFWuEZ3VkVnRd1WT3dWRWdF0Va4RndWRmdF3VZPd1ZGZ0XRVrhGd1ZHZ0XdVk93VkdnRWQs1SWgirq7h4Pi+M3i5eL/7qqIq4qVipaKLYeN5f7m6e75v6uKgLq7h47i+MXqxaqIq4qAlrm5t4qDi6aeiZp3ipqLiomai7crmourioaLiomaCwuJiooaq4qai7cvmourioyLpp6Jmouai7q7h4/n5Oy5qomrioC6u4aOqom5ioiKubuGj6qJq4iaiZiKq4qamoqKmZoLg4qAuruGjaqJuYqPioqIG5qEq4i3KZqLq4iui7m7ho+qiZl5dHR0momYiquKmZoLg4qAuruGjaqJuYqPioqImouKjhyrjxwSmoGriKuJpp6JEZqDq44dmnSKq45kL6glqoCAgxaxkIGhgBiQibGQgKGAgIKQgL0XkAEBg6GDhoGAgpN+fn5+gIUXkJ4bkIuhg4CEF5B+hqGDvSWQnqGFiIGssY2Cz+DPoIK9JZCBoYWcgbOxjIWgg5Nzfn5+kIOTgBMSkAGJoYShgqyAu5yBs7GMhaCDEJCOoYWQg5OAExESkAGJoYSQgKGCrICtFAUkBSIuIRcpJ1ZEFSglBSUUBSQFLS4hFykmVkRHFSglBSUUBSQFLC4hFykhQEMUExUoJQUlFAUkBS8uIRcpIUFDFBMVKCUFJRQFJAUhLiEXKSFEVlBIFSglBSUUBSQFIC4hFykhRERTQhUoJQUlFAUkBSMuIRcpIURWUUEVKCUFJQ==","load");
+rx.ex64("UlgBKSQnV10kJCkjGWtqa2AbJCc0JWQmbyUVPj4zPz4+r6IePg8zNkpMWk1+WFpRS6IpDzM2UV5JVlheS1BNHj8fPj4+r6IePg8zPExWWw8yPx4/Hz4ODzM+Vw8yPx4/Hz4SPhQVKSFAXUBGFSglBSUFJhUkJCEkIQUhKSZDS1UVKCUFJSEwIbM02iQFIbM02iS+NC0FIbM02iS+NDUFIbM02iS+ND0FISkhQ0tVRxUoJQUlIQUnKSFDS1VTFSglBSU=","load");
+rx.ex64("UlgBKSMnV10hQF1ARiBWSUxGQCdAESdAQydWUyQkFSglBSUkJxUpIW92amsFJSQmFSkhaERRTQUlJCEVKSlJSkZESXZRSldEQkAFJSQgFSktTFZjTEtMUUAVKSNrUEhHQFcFJSQjKCUkIhUpIUNLVVMFJCQtFSkhQ0tVRwUkJCw0QSQuMSQpLmQoviUYcrYyHDc3BhcwFzIKkDwWN0I2BwY6NVIAAhc3Fjc3NDcEBjs0FjQnMyc3NzU3BwY7NBY0JzM9BAY7NRc3FjUENzI3AwY6PGNfWEIOd0REV08XNhYyPQIGOj1iU05CclNVWVJTRBc2NQY6MFJTVVlSUzcHNwQ3MzcHBjozRldERVMXNBYzGzcaOQMCPzMTMwACMy8lMCQ/NjMfM2QrUCV5U2NiXlshJiA7PDU7NCtzUHJTU1BTZmJeWQY3KiYXPDE9Njcgc1JRYl5UNzwxPTY3U2NTclBZYGJfUXNTc1pgU1FTYGJeVDE9PDEzJkdTc1VyUXNaWWNiXlE3ZGZzU2BZVmBzVHNWVsJDU2JfV3NTX1dzU35kKhwlZk5GRnxtQU5ATUltR01KTU5RTH18QU5sTl1NR358QEktPDwgNXxdTGxOfmxMdpKzfW1CbUBOR1hgZDUFJaO1LYOog56Ju7mFg/rs/d3g5Ozm/P2oiaiAqIaLg4ilZDRbJQUqLyqzPS4uLhEOKi8rszgeIyoPIi8oHg4vDisfDysOKBIvaC4fDysOLRIvPi4vKL2/Dio/L7+8Di0OKg4oLyi+vA4ovw4qPy+8DiwOKh8eIi1PTF0PLQ4oDj3j4uITLxIvKi4vKD8uFCouLygOLCoOKA4vDisqDisjKg8iAmQ3OSUaNQABPTVBREJZEDokNBE1ETIRMxEwECABECEdITQlKCAFJBQVKCQFJAU3LiEXKSZWQ0AFJBQVKCQFJAUoLiEXKSdCQQUk","load");
+rx.ex64("UlgBKS8sUkBHQVdMU0BXI2pHT0BGUSFOQFxWIkxLQUBdakMhQUpLQCBTRElQQCBkV1dEXCN2XEhHSkkgdVdKXVwnV10kJDQ1JCc0JCQmuDMVKSxLRFNMQkRRSlcFJSQhuDMVKS1BSkZQSEBLUQUlZCA2JbK1BgaolJLo9Pnh7+rx//DsuZhkIyglGh2tlxEwPTAAPTARM2QiCiVrcHFMQ3FMQGBBYEFEQEBHQENYQXBxTEJhQ01FIiUiHmVQQUB9QENBbE97o75sTmQtuyVeRUR5dkR5dVV0VXRxdXVydXb8dEVEeXdUdnhyKzUGBhUNVWV0dWh10nlyVHZo0ER5clV0RFR2VXR1SHV2dFl6RUR5d1R2eHMrJw0ZFhsYVWV0dWh10nlzVHZo0ER5c1V0RFR2VXR1SHV2dFl6RUR5d1R2eHIrJAYbDA1VZXR1aHXSeXxUdmjQRHl8VXREVHZVdHVIdXZ0WXpOB4tZe2QsBSW9ugowtpebnPT2+/vH//b54/j6MLaXm5/I5//2+eP4+mQv5iUWDQwwMV9OWV1IWXlQWVFZUkgdODA6X11SSl1PPT09DQwwNltZSH9TUkhZREgcPTA5S1leW1A9Pj0Aohw+PjwRMg0MMDBbWUh5REhZUk9VU1IcPjAla3l+e3BjWFleSVtjTllSWFlOWU5jVVJaUz8MMCtpcnF9b3d5eGNueXJ4eW55bmNreX57cD03DQwwMFtZSGxdTl1RWUhZThw+Dj0/PQCYNhw/PjwRMg0MMT8cPzA3b0tVWkhvVF1YWU4dLTw9ET1kLgYlrqkgtIiP7erq4fbM4e3j7PClhLSIj+vx8OH2zOHt4+zwpYRkKQ4lBgGIHCAmRUJCSV57RUhYRA0sHCAnT0BFSUJYe0VIWESxOhwgKE5DSFUNKCQoMC0FKQUuBS8FLAUtBSIFIwUgZCtTJUVubn5vbm1+b2pOYmxpbGs+b15fY2sKFwoMX2JmTm9Pa19ubmpuU8tlT2psb25qYVNPamVvbm749k9tfm5Pbm5t/35uT21dX2NsHAkKX2JmTm/4fm9Pav9PbWNrBwsDMFXFkF1fY24fX2JmTm96bU9uTm1ObkMXFSkkVxUoLAUlBSspIUlKREE=","load");
+rx.ex64("UlgBKS8mVkNANURBQWBTQEtRaUxWUUBLQFcsSEpQVkBBSlJLIkhKUFZAUFUhQF1ARjZXQEhKU0BgU0BLUWlMVlFAS0BXLFFMSEB2UURIVS5VQFdDSldIREtGQCZLSlIkVyQkNAUkJzQqJCYyISspIkZEVVFQV0ArKSJVRFZWTFNAJCE0zSIkILgzFSktQUpGUEhAS1EFJSQjFSkhaERRTQUlJCIVKSdXXQUlJC0VKS5WQFFsS1FAV1NESQUlJCwVKShGSUBEV2xLUUBXU0RJBSUkLyskLiskKjQlJDQxJDcxZDZDJaG3FhWqgBWqgYqLp4mAhLq7h4n46qqMqpqKioq4u4aLqoyIu5qLqpm7mourioeP5ujU6Li7houqjIi7moqqmbuaiquKh4/m6NTmuLuGi6qMiLuaiaqZu5qJq4qHj+bo1PiJmauKp2QxFCVcRUZ7d1dzdVd1V3p7dEVGe3dXc3VXdVd7e3VGV2VHRntyV3FXZX1EV35XckR0eHdaZDABJQYuJiMfHCEpDSkvDS8NICEuHxwhKQ0pLw0vDSEhLx0NJQ0iAGQzACV+aMp1XlVUeFZeW2VkWFcnNTZ1U3VFVVVVZmRYVSR1U3RVdVV4ZDIzJVZ8TU1wdU1welx9YHxNcHtdfH9tfFFkPWElvJanp5qfp5qQtpeKlqeakbeWlpWWlpQGtoe3lZWYB4aWtpiVnJmmp5uT5+Lk/7aGt5SrNraVtpiel6e2gae2hKe2grsUFSghBSIFMiQpJBQVKCEFIgU9JCgkFxUoLAUiBTEpIUlKREEXFSgsBSIFMykjUEtJSkRB","load");
+rx.ex64("UlgBKS8nVkQjRkpLRkRRJlZDQCxISlBWQEhKU0AhQF1ARiZWREchRkBMSSFVUFZNJkRHViRXJCQ0BCQnNO0kJCY02iQkITIhKykiRkRVUVBXQCspIlVEVlZMU0AkIDTNIiQjuDMVKS1BSkZQSEBLUQUlJCIVKSFoRFFNBSUkLRUpJ1ddBSUkLBUpLlZAUWxLUUBXU0RJBSUkLxUpKEZJQERXbEtRQFdTREkFJSQoKyQrKyQ2NCUkMTEkMDEkMzFkMp8lQ1X090hn90hkaGlFa2dmWFlkaUhhSHxiWFlkaUhhSH1qWWRoaFhoW2hoaFpZZGtIYWpZeGlIf1l4aUloZW0EGjYKWllka0hhall4aEh/WXhoSWhlbQQaNgRaWWRrSGFqWXhrSH9ZeGtJaGVtBBo2GlpZZGtIYWpZeGpIf1l4akloZW0ECDYKWllka0hhall4bUh/WXhtSWhlbQQINgRaWWRrSGFqWXhsSH9ZeGxJaGVtBAg2Gmt/SWhFZD0RJQMaGSU5SE1NbF9MR11lQFpdTEdMWwgvKggtCCIkKhkIPhgZJC0IIQg+IhsIIAgsGyslKAVkPA8lS2NsblJRbXITBAwOFwQkFwQPFS0IEhUEDwQTQGdiQGVAamxiUEBrQG1NZD8QJaWzEa6Cjo+jjYKAvr+Ciq6HrpuOjo6+v4KKroeumoS+v4KOr469jo6Ovb+Djv+uh6+Oro6jZD56JGJIeXlFSicmPnlFQjksOy8mOyQoJyosaElUSHlFQD0gJCwaPSgkOWlISEtISErUWEl5RUw5KC4sEWlISE3UWEl5RUw5KC4sEGlIddXtaFhpTe1oWWlKSEllddXWaEvYaEZpS2hGRUlLRkNLWUNLWENLW0N170NoRj1Je3lFTCg9KCd7aE7YaFlpSthoWGlNSExIeHlFTTo4Oz1oTtndWEvYaUpoWd1YS9hpTWhYQnh5RE9oTntIT0h11O1oRmlL7VhJaU9CSXh5RE5oXVhJc1RJeHlET2hO21ihTtrYaEZpS2lPSE5IeHlETmhdaU5170NoW3dJeHlEQWhO2GhbaUxYSNt5RUsZAGhOWEtCeHlEQWhO2GhbaUxCe3lFSiQgJ2hOe3tIQUh4eUROaFzbWKFOaUFLWtlYSGhaS0ZpS0tZaUpLWGlNS1tpTEtHR3XWaEpoWkBJeWhTeWheeWhQZRQVKCEFLQU+JC4kFxUoLAUtBT0pIUlKREEXFSgsBS0FPykjUEtJSkRB","load");
+rx.ex64("UlgBKSAnV10mVkNAI1ZGV0pJSSFAXUBGJFckJDQHJCc07SQkJjTaJCQhMiErKSJGRFVRUFdAKykiVURWVkxTQCQgNM0iJCMVKSFoRFFNBSUkIhUoJQUlJC0VKS5WQFFsS1FAV1NESQUlJCwVKShGSUBEV2xLUUBXU0RJBSUkLyskKCskNDQlJDcxJDYxZDFDJR0LqqkWOqkWPTY3GzU6OAYHOzVEVhYwFiU2NjYEBzo2FjA0ByY3FiQHJjcXNjszRFRoVAQHOjYWMDQHJjYWJAcmNhc2OzNEVGhaBAc6NhYwNAcmNRYkByY1FzY7M0RUaEQ1JBc2G2QwESWLkpGtscDFxeTXxM/V7cjS1cTPxNOAoaKApYCqrKORgLWQkayigKaAtaqTgKmApJOjraCNZDMPJXBYUFVpalZJKD83NSw/Hyw/NC4WMykuPzQ/KHtaWXtee1FXWGt7U3tWdmQyDiWitBapgomIpIqCh7m4hIv76eq4hYipiKmaiYmJuriEifi4hYipiKiJqYmkZD2QJRM5CAg0O1ZXTwg0M0hdSl5XSlVZVltdGTglOQg0MUxRVV1rTFlVSBg5OTo5OTulKTgIND9LW0pXVFRhGTgEpKcZOqkZNhg6GTYxODo2Mjo3MjooMgSeMhk2DjgJCDQ7WVpLGT6pGTcYOzk8OQkINDxbXVFUGT6qKdA/q6kZNhg6GDw5PTkJCDQ8SE1LUBkqGD06KagpORkpOjYYOjo3GDs6NTYEpxk7GSkxOAgZLwgZLAgZLhQUFSgmFSglBSUFPSQuJBcVKCEVKCUFJQUwKSFJSkRBFxUoIRUoJQUlBTIpI1BLSUpEQQ==","load");
+rx.ex64("UlgBKSEnV10kWS1VRFdWQGxLUSZWQ0AkJDQGJCcpI1ddCFVLUSQmNP0hJCEVKCUFJSQgFSkpSUpGREl2UUpXREJABSVkIzQkR2xs+nxt/nyFal1hYgMMGwQKDBkEAgM+GQwfGfB7XWFrGQQABAMK8HtdYWYdCB8LAh8ADAMOCExtbG9dTG9MaGxuZmxpfGxRy2dNbzhtXF1haB4dAQQZTW9gbGxvbFxdYG9MbV18bU1vcE1sbGxobFxdYG9MbV18bE1vcHxtbGxrbF9dYW4ADBVdYWkgDBkFTG18bfxNaE1sbG5sbGn9fGxNa1HMTG5NbmptbG5mbGl8bGn9TWn9YGz9TWxhbUxvTGheXWBuTGlpfGxn8HxsTWlhbx4BX11gbkxpTW5hbwMJXl1gbkxpaX6goaFQZ01uYWkDCTIBXF1haQgLXFtdYG1MbU1uZl9dYWwdTGlfTGxBFxUpJFcFIQUjKSFJSkRB","load");
+rx.ex64("UlgBKScnV10mVkNAJCQ0FSQnFSglBSUkJhUpIUBDFBMVKCUFJWQhISRkT0/TWH5CSD0tPCsrIG9OT0x+Qks5Jyo6Jm5PT01+QkgmKycpJjpuT09KfkJEJyAgKzwZJyo6Jm9OT0t+QkUnICArPAYrJykmOm9OfH5DT29MbkxCTD05fX5DT29MSl2DgoJzRG5MQko9OREifH5DT29Mbk1CTD0mfX5DT29MSl2DgoJzRG5NQko9JhEifH5DT29MbkpCTDg5fX5DT29MSl2DgoJzRG5KQko4OREifH5DT29MbktCTDgmfX5DT29MSl2DgoJzRG5LQko4JhEif29NbkxFf29Nbk1Ff29NbkpFf29NbktFfX5CSC0hIC0vOlpKfHx8fEV8fkJPPm9MfG9PYhcVKSRXFSglBSUFISkhSUpEQQ==","load");
+(i=>{let n=i.Math;function e(){for(let t=0;t<this.length;t+=1)this[t]=n.max(0,this[t])}function o(){for(let t=0;t<this.length;t+=1)this[t]=1/(1+n.exp(0-this[t]))}function r(t,n){var r=new i.Float32Array(t*n);return r.rows=t,r.columns=n,r.R=e,r.S=o,r}i.rx.M=function(t,n,r){return t.rows=n,t.columns=r,t.R=e,t.S=o,t},i.rx.M.zero=r,i.rx.M.mul=function(e,o,t){var n=e.rows,f=e.columns,u=o.columns,l=r(n,u);for(let i=0;i<n;i+=1)for(let r=0;r<u;r+=1){let n=t[r];for(let t=0;t<f;t+=1)n+=e[i*f+t]*o[t*u+r];l[i*u+r]=n}return l}})(window);
+rx.ex64("UlgBKTcnV10kaCJSQExCTVFWI0lAS0JRTSFHTERWIkNKV1JEV0EgQkRISEQgVklMRkAhR0BRRCFIQERLLVNEV0xES0ZAIkBVVkxJSkspQ0BEUVBXQGtKV0hWI0lEXEBXViFBSktAIFNESVBAIVFcVUAhVVBWTSQkFSkhaERRTQUlJCcVKCUFJSQmuDMVKSRGBSckIRUoJBUoJQUlZCBnJW1FdWdCRXZLRWZEZkVmR01CdEtEZkZCZkRLQmZGBlxGTWdVVmplCxMKR2JlVmtiRmZWa2RGZkZnS2dNQnRLQ2ZGamQj4iWnj768gYusjayOnYyHiL6BiqyMvryBi6yNHp2OrI6sjoeIvoGErIy+vIGLrI0enY+sjh6djqyOh4i+gYWsjL68gYusjR6diKyOHp2PrI6HiL6BhqyMiKyPgYesjMzsjEdtbW59bFDMXGFvTG1MbiBsXVxgaB8dHhhNbfxcYWdMbFxMblxhZkxsf23+/VxMblxhZUxsXExuTG1cTG5cYWpMbHxcTG5cYWRMbG1naF5MbkxtbW78fW1MblbFk0FMbYeIvoGJrIygZCI9JXMZVVl2XG1tUVwPfVxwfVxSXWtUXHlZdWQtPSVfNXl1UnhJSXV4Kll4VFl4fnFHeHBVdVlkLMUlupOVsZCcnbGRlbGTnJyxkdFUkQ4kJCc0JRmFFSgmBSQFJ6IlFxUoIhUoKQUltTQgtzQgBSe3NCAFJyQmJBQVKS1MVmNMS0xRQBUpI2tQSEdAVwQlFQUnBSQ7JBkkLyUhFTQlBSYFJwUkFxUpJkhMSwQkFQUnBSQVNCcFJi4XFSkmSERdBCQXFTQkBSY0FTQmBSYkNhU0IQUmJC4hFwUnBSQkJ7U0JAUnH0vaFgQhJhUoJgUkNCQFJCQkJCAVKCgFJSEjISArJRQVKCAFIAUkJCQkH8jaCAUkmpWjnJSxkb1kL/IlXHZ2dWNGR3tyERsYGAVWduRmckd6dEd6e1d2dnR2ckd6eld2c3FzctZ3S9N7chMSGQQSR3pnV3JSd0BWcnRXdEd6c1dyR3p1V3J8Rkd6Zld1RXZ0R3p0R3pzV3JNHndL03t+FRYDFB8ZGAUaR3pnV3Jsd0BWcXRHenxXcld0R3p1V3J8Rkd6Zld1RU1Nd0vTe3MFEhsCR3pnV3J5d0NWcHxGR3pmV3VFTWp3S9N7cAQeEBoYHhNHemdXcnx3Q1Z/fEZHemZXdUVNLYhBVn5XdUd6e1d2WnYhBSEoJAUnIQUsKSdoaQUnIQUvKSBWVUBGVgUsGRUpIGFgZ3BiBSYQJSEFICkgYUBLVkAFLCEFIyksZ0RRRk1rSldIBSwhBSIpIXdAaXAFLCEFLSkidkxCSEpMQQUs","load");
+rx.ex64("UlgBKSgnTEEtQ0BEUVBXQFYhQUpLQCBTRElQQCBISkFASSFRXFVAIEFAS1ZAIlJATEJNUVYhR0xEVixHRFFGTUtKV0giQFVWTElKSyFXQElQJ1ZTJCQVKSdXXQUlJCe4MxUpJEYFJCQmNGUkITTpLSQgLiQjMDopIVZGelYpIVZGekgpIVZGekYpIUhWelYpIUhWekgpIUhWekYpIUhEelYpIUhEekgpIUhEekYpIUhGelYpIUhGekgpIUhGekYpIE1BSXodKSBNQUl6EikgTUFJehMpIE1BSXoQKSBNQUl6ESkgTUFJehYpIE1BSXoXKSBNQUl6FCkhU016SSknU00pIVNSekkpJ1NSKSFWTXpJKSdWTSkhVlJ6SSknVlIpIUtBekkpJ0tBKSdWSWULJXxWVlVDVlTKQWdbVTIxd1ZSdlFTUVNSRVdmZ1tTJyIkP3dVZ3dSd1Rtvqh6d1UuFBUpIFZVQEZWFSknaGkFJDIhMC0yJykiVkxCSEpMQSggMiMwJDYkUCiaKC09NRwenh+SmRocmp+dZx1nExkoIigjKCAyJyguKCAyIzZKN6YfKC8wZTbdzEkfNsB3TR82XPmGHzacFygfNsqkYB82t9lMHzbIbf4fNrIS5x823yVvHzZa5zQeNjgk5x82gb7nHzZRtJsfNn3/yR82JsqVHzZpbiofNhtBamU2fN1zZTYAR31lNnYOe2U25OQpZTbTcmJlNqJ/HGU2nuJEZTbyQiFlNgFQQmU2iFh7ZTZMTnllNhRpQGU2JNR5ZTYucnplNn3cHmU2rTUWmzbfEOabNjC0jZs2J6SZmzb3pPCbNqBv5Js2jNIcmjZV2vcZNqAwHZo2u/qvmzYU3LKbNr+Ubpo25NClGzZh4oaaNvOWoRs2uSH4mza8NPoaNmAI5Bo2gBv5Gjb+qPwaNvae2Ro2s1v/Gja0R/8aNrbNyBo2g8uBGjYHG+YaNmnJ6Bo2g9zPGjbmLZkaNo3SMGU2LSSRGjbtE5oaKCIoLCggMiMwNTbQG3VlNqNCfWU2bJZ9ZTYLy3tlNjrkKWU2k5tiZTYNyR9lNgyIRGU2es4gZTbhMk1lNjbTe2U2gmd7ZTbmPkBlNhEMemU2fSV6ZTa/DxhlKC09pScjIa0mp6gmIaiuricsJC8hICegJKWhry6goqQlLqIvpKenI6OjLaeiLS0jo6IloiWkoi+jpi2gpCItLKCioKKlrK4loKEktqIhoSS3obehrSQkrye1qSUkoqmqJCSvJK+qtCa3pCWtrCclIaqgtaG3JiepJKCoJyGpqakkIaUjJKyjIq8nI6OpIikupqOioqIkJK4kr6MhJKyotScjJyIkoKIkpConqKaxJiSspKmkoa6jtKmgqqesrqOhoK6vrKmtriC2oSKmrCAgLa6gqaCqoKMkp6ChrackLCexpaoloaKip6Oup6CgpbW1oySjJ6KotSe3oSSirCekIbWgtaG3KCIoIyggMicoLiggMiM2SjemHygvMGU2ht0tGTaJhd0eNiWuSB42U659GTakDS4ZNsKavh42uvV1GTY91RYZNmZdGRk27lZIGTa0sJgZNjxzTB42MT8fGTZ1FioZNgkFTR42/7K6GTaBpJ8eNrBZRZk2w34tGTbLRMafNrUaIp42fBjcnjYKjeKeNj2PPhk2CX/OHzZR5SkZNsPcmxk2LzfGHzZehaOZNllKMpk2xBVjHjaJmmMeNilpBJo2CWxEnzbavoqaNvREs5s2AfrDmDa7wa+aNqEfC5o2UbWkmzZMHUiaNhBnDps24OXtmzaQcLuaNuBhT5o2JFRvmTZnX5iaNuqgBJo2qxK0GjbsjJEaNsYuXxo2BbgdGjZNmGYaNr9gsho2WLu0GjYkX3IaNmntuxo2gJh+GjZXxpEaNqeJhRo2nH2xGjZXtDAaNq5BaRo2zhWXGigiKCwoIDIjMDU2TzvqHjYoMEOZNiYLNBk2thISnjaE7iWeNoL5IZk2R8zxnjZXnhQZNh7kdx82SIM6GTbloZYZNmfQ9x82vPWomTagSD+ZNuabBB42SSd1HigtPdUmJSSlISSltKcmJSS3tSQlJaylJCEnJaQkI6QiJScmISEnpLazpCezJKEhoiS9pKeyJSWlpCUlpaWjJSSkpaWppKWnJackpCQlpqUhJSQmJSYlpyQnpaWlJSaloSUlpyW2pCQkpCQnJSUkJL0ltKeppKenpbYkpSQlpaeppKQmpSSkPqCpviu8J68zt6ysvKy/LCUlJCWlJScnJiUlpCUlpaukpCMlJKUko6UnJSSkJyWxJaWgJSQlp6QnpaokJKSlJichoaaxpCC2KrSvoaSgp6IntiynqSSiI6Imt6YkLKSnoKEpIiAkJCmsKiQgLKEnJaWkpKQnJSWkpKUlJaQlJSckJ6QkoCWkpCGkpaQkpSWkpyWnpaalpKetp6akpKElpqQhIyK3paEqsSwgpy+3JSWlpKSkJSUlpKSkpSWlJyWkpaYlpKGlJaSipKSkpKelJKWjJKSkJaanIackJCcvJaAmJSQkICSuJCMkJCYkpCSgJKSgpK+loKSipKWloKaloSShJ6Wrp6QkJCWlo6GmpCSjJCcloaclJSEkpqOgI6YvoSQnJSEktCclIaUnJiclty8kJSIhIKMnIyInISg0ISQnpSYkJSUmJSUnJSUkJKUnJCQgJ6clJi4iIyWkpSWlJiampKUlpCInIqcloKynpSgiKCMoICkjSURcQFdWML4kNsdDJGE2VKOkZjT1KjQlNCU2J8EkYTYGV6VmNPUqNCU0JTY8dLVnNpQAbGc03yQ0JTQlNrtfv2Y2foGxZzT1KjQlNCU2jd+yZjYWkrFnNPUqNCU0JTZ/ahxnNv30Z2Q03yQ0JTQlNhZThmc2foKCZDS1JjQlNCU2g/eQZzZT2oZkNIUjNCU0JTZjLTlnNqIaMGQ03yQ0JTQlNom0sWQ213ypZTRBNCU0JTYBphpnNuxBfmQ03yQ0JTQlNpLeDmU26V93GjQqNCU0JTbEyv4bNucK/hs0QTQlNCU2MOzqGzb4oaUbNEE0JTQlNpKo9Bs256lcGzRBNCU0JTaJoecZNk2Lix80QTQlNCU2OhbCGDaWVFUZNEE0JTQlNkzXxRg2V4ZBGTRBNCU0JTY4cu8bNhE4RRs0QTQlNCU2Tr/sGTYl8IofNEE0JTQlNszuO2Y21fMbYTStAjQlNtXzG2E2EFg7ZjauwhthNK0CNCU2rsIbYTYeFyRhNkHqcWE0rQI0JTZB6nFhNrkOJGE2fOdxYTStAjQlNnzncWE2xnBLZjYqHk5hNK0CNCU2Kh5OYTY8FElmNkICTmE0rQI0JTZCAk5hNpv+PmE2BRhEYTStAjQlNgUYRGE2W/U+YTZ9BURhNK0CNCU2fQVEYTZTdPRnNpPyA2Y0iSc0JTSJJzYpNshnNvU/K2Y0iSc0JTSJJzaTEMhlNrYxfGQ0MTQlNCUpKUNARFFQV0BrSldIVi4mMiMXKCEXKCQ0JSglLiYwJBckIiRkLYIlo7UtuYSFqIiojIiJpYuMuYSFqIi5uYWL7u2oiIiIiIiLnIi5hY/l7Ofu/eGojoyojoqPio3Dibi5hIipjamIiIyIuLmFju/m+/7o++25hI2pjamMiI+IuLmFjezvuL+oiLmYiamPgru5hY/q5ufq6P2pi7uciLmEiamNiIuIszh2tRe5hYzk5dbt5aiLgom7uYWI+aiIqYuoiru5hYv56qiIqYuoiqVkLDIlHAQGOj1FU0J/WEJTREBXWhc2FzIXPhoXFSkkVwUkBSwpIUlKREEZFSkgYWBncGIFJyglIQUiKSN6ekhBSVYFJA==","load");
+rx.ex64("UlgBKSghaERRTTZXQEhKU0BgU0BLUWlMVlFAS0BXLEhKUFZASEpTQCBGSUxGTiNWRldKSUkmUURCJ1ddIEZKUEtRIkZJTEBLUX0iRklMQEtRfCJWRldKSUl8IUBdQEY1REFBYFNAS1FpTFZRQEtAVyQkuDMVKS1BSkZQSEBLUQUlJCe4MxUpJ1BABSUkJhUpJlBAXQUlJCEVKSFWVFdRFSglBSUkIBUpJlVKUhUoJQUlJCMVKSZER1YVKCUFJSQiMiErKSJVRFZWTFNAKykiRkRVUVBXQCQtNEEkLDRBJC8uJC4uJCkuJCguJCsuJCouJDU0JSQ0NCVkNwwliJGSr6ODoqGDpYOor6CRkq+jg6Khg6WDqa+hkZKvo4OioYOlg66vpo5kNkAlemxgXVVxUmVQYWBdVXFSXEY4MSN9IyQiPz43fTk+JDUiMTMkOT8+bMxxU2BcUzkjPHFSWVBicVNdVlxSMSRsYF1XcVJLUGJgXVdxUkFRXEEDJCI/PjcZPiQ1IjEzJDk/PmBxQnxkMT8lETsGpqUrOgo3Mxo7pSs6CjcyGjs5OgobKRZkMHMlc1lkxP5TeVb+U3lVdlhqeV1JWsl5VWhVUHhZU2p5XUlayXlWaFVReFlTSGpqU2l5XGpZWllaSch4WnlJZPl5UHlJW1hoeUtaVWhVUHhZWlZoVVF4WXRkMwslGDIPlTgSPCEzAhI1ohI8Az45EjMjMhIjMSMyD5ISOhIjMDMDEiAxPAM+ORIzH2QydiVPVFVoblVoY0RlRHBnb2RUVWhuVWhjRGVEcWduZFRVaG5VaGNEZURzZ2lkVlVoaURlZkRiRG9oZ1ZVaGlEZWZEYkRuaGZWVWhpRGVmRGJEaWhhSRcVKSRXFSgjBSUFMikhSUpEQQ==","load");
+rx.ex64("UlgBKScmUURCJ1ddJCS4MxUpLUFKRlBIQEtRBSUkJ7gzFSknUEAFJSQmFSkmUEBdBSVkIWolcFpua1ddCT48HiMrelvLV1NmcwAFYAZwcst7WldecwUne3JQamtXXjY6Lzgza1ddODQ0MDI+elppWllaa2tXXy8pMjZrSll7WUdae1l2WmQgGiUELhMfIi8OLRsvHh8iLw4tvw8uIz1dVwJHRkhHSlxbAk5MW0ZAQRUTsw4sHyMsRlxDDi0mLx0OLCIuIy1OWwNkI3clWENTdn9zc3NzQ0J+dwECHhsGUnN+czJxQmNzc25zUnNzcHNOUnBbckNCfnYTBh0QU3JScHNxc0NCfngRGhMAMR0WFzMGUnFjcnN2c0NTd1J2XhcVKSRXFSgkBSUFIykhSUpEQQ==","load");
+rx.ex64("UlgBKS4nV10jd0BCYF1VI0ZKSk5MQCNJQEtCUU0gQ0lKSlctRlZWd1BJQFYsUEtBQENMS0BBIFdQSUBWNVRQQFdcdkBJQEZRSldkSUkhUUBWUSUkJBUpIWhEUU0FJSQnFSglBSUkJrgzFSkkRgUnJCEVKS1BSkZQSEBLUQUlJCAVKS5WQFFsS1FAV1NESQUlJCMVKShGSUBEV2xLUUBXU0RJBSUkIhUpL1ZAUXFMSEBKUFEFJRAVKCQFJSlne1VVSV0IREJAS1ENGh8IfhUIHHgOen4VCBx4DgwaCEpTQFdJRFwNGh8IDRofR0RWQFkIVlFKVQhHUFFRSksMDBoBJC0kExUoJAUlKSRMKRpVVUldCERCQEtRDRofCH4VCBx4Dnp+FQgceA4MGghKU0BXSURcDRofCA0aH0dEVkBZVlFKVQhHUFFRSksMDBokLCQkLykpREhfSwhGUV1TCExBJC4pLkRIX0sIRlZWCExBJCm4NPUqFSkgRkF6V0wFJiQouDTljCIVKSBGQXpWRgUmZCp3JRA6Cgs3PkhLV1JPCzY5Gj83OQAbOjk6OjgqOwebCzY4GzkbOBE7Cgs3PFJVX15DdF0LGzgbOas3OgYbOh8qOzoHOjk7FjU6OKsqOhs4AfDEFjRkNR8lupOQkgOArQOArbGQkJUDgK0DgK2xk6GhnZfj8P/1/vywkIMBgJAAsZKxlZCaoKGclbCQo4GxkpC8kGQ0nSV7U2FxX3BRbFFRUHxgYFxTPj8nYFxUFDEkNXFQQ0G4V1FbYWBdVHFRYlNgXFgkPwMkIjk+N1FhUUF0UVRRYnFAcFNwUlFVUVFWwFxea3ADMT01AzkkNW0cMSjAcFXAXEJrcAAxJDhtf2twHTEofRE3NW3AcFTAXFNtYX5wUWz0XFY4JCQgI2pgXFggIj8kPzM/PGBcWDw/MzEkOT8+cVBfUFFWwFxYa3ADNTMlIjVwVlRwVl1ScVR8ZDcVJaaMsROtjI+NoIaxK4CLub2AiK2Mi42gvYCIrYyxK4CLub2Aiq2Mi42gvYCKrYyghmQ2dSRoc3JPSmNGTlAZKyYcf2AyMi46byMlJyw2YB9DQ0NDQFNCfuJyT0FiQ2JAc0Jzck9LY0pyTkArJnJiQGJDfkNRQnFjU0FT6kNT0kNjSHNjRGNMb0xDQNJTQ2JAeIa9c3JPSmNGTkcxNjsuJ19WQ0NBQ0NGU0J+4nJPQWJBYkYDQkNH309Ick5JNic6NgEtLDYnLDZyYkZiQXNyT0tjS2JHfkNRQnFjU0FT/AZTxntjSXNjRGNMb0xDRtJTQ2JGePa9Q0TfVnJOSTE2Oy4nESonJzYxY0ZDRVNCfuJyT0FiRGJFKEJzY1ByYkViRENKQ37cYkpBQngOQkNLU0J+4nJPQWJKYkt/QkNI309Ick5FITExFic6NnJiS2JKc3JPS2NLYkh+Q1FCcWNTQVP8BlPGe2NJc2NEY0xvTENL0lNDYkt4+r1DRdJTQ2JFeMm9b01kMSklsqS5lp2YqbmeuZa0ZDA5JQMZCDo3KBUoOCkbCCwIJQg6KycoGwguCCQIPQUXFSkkVxUoJQUlBTApIUlKREE=","load");
+/* ◬ */
+</script>
+
+</div>
+
+<noscript>
+    <img height="1" width="1" style='display:none;visibility:hidden;' src='//fls-na.amazon.com/1/batch/1/OP/ATVPDKIKX0DER:147-7999693-6862434:RBWFGARJB4TBW5KMJP91$uedata=s:%2Frd%2Fuedata%3Fnoscript%26id%3DRBWFGARJB4TBW5KMJP91:0' alt=""/>
+</noscript>
+
+<script>window.ue && ue.count && ue.count('CSMLibrarySize', 101876)</script>
+<!-- sp:end-feature:csm:body-close -->
+</div></body></html>
+<!--       _
+       .__(.)< (MEOW)
+        \___)   
+ ~~~~~~~~~~~~~~~~~~-->
+<!-- sp:eh:4g46/y28TUbY+Euj9OE4jJ9PvZE5V7QSMNZo6laBhvFq1DnIa7UGylMEQ5OwWYnjg0Ppj/7R9XXh+DdfTquwHmRytdb976qrPLbhCt7WyTZACfhFvIePKOwFp/I= -->

--- a/tests/resources/orders/order-details-fopo-147-7999693-6862434.html
+++ b/tests/resources/orders/order-details-fopo-147-7999693-6862434.html
@@ -1,0 +1,5463 @@
+<!doctype html><html lang="en-us" class="a-no-js" data-19ax5a9jf="dingo"><!-- sp:feature:head-start -->
+<head><script>var aPageStart = (new Date()).getTime();</script><meta charset="utf-8"/>
+<!-- sp:end-feature:head-start -->
+<!-- sp:feature:csm:head-open-part1 -->
+
+<script type='text/javascript'>var ue_t0=ue_t0||+new Date();</script>
+<!-- sp:end-feature:csm:head-open-part1 -->
+<!-- sp:feature:cs-optimization -->
+<meta http-equiv='x-dns-prefetch-control' content='on'>
+<link rel="preconnect" href="https://images-na.ssl-images-amazon.com" crossorigin>
+<link rel="preconnect" href="https://m.media-amazon.com" crossorigin>
+<!-- sp:end-feature:cs-optimization -->
+<!-- sp:feature:csm:head-open-part2 -->
+<script type='text/javascript'>
+window.ue_ihb = (window.ue_ihb || window.ueinit || 0) + 1;
+if (window.ue_ihb === 1) {
+
+var ue_csm = window,
+    ue_hob = +new Date();
+(function(d){var e=d.ue=d.ue||{},f=Date.now||function(){return+new Date};e.d=function(b){return f()-(b?0:d.ue_t0)};e.stub=function(b,a){if(!b[a]){var c=[];b[a]=function(){c.push([c.slice.call(arguments),e.d(),d.ue_id])};b[a].replay=function(b){for(var a;a=c.shift();)b(a[0],a[1],a[2])};b[a].isStub=1}};e.exec=function(b,a){return function(){try{return b.apply(this,arguments)}catch(c){ueLogError(c,{attribution:a||"undefined",logLevel:"WARN"})}}}})(ue_csm);
+
+
+    var ue_err_chan = 'jserr-rw';
+(function(d,e){function h(f,b){if(!(a.ec>a.mxe)&&f){a.ter.push(f);b=b||{};var c=f.logLevel||b.logLevel;c&&c!==k&&c!==m&&c!==n&&c!==p||a.ec++;c&&c!=k||a.ecf++;b.pageURL=""+(e.location?e.location.href:"");b.logLevel=c;b.attribution=f.attribution||b.attribution;a.erl.push({ex:f,info:b})}}function l(a,b,c,e,g){d.ueLogError({m:a,f:b,l:c,c:""+e,err:g,fromOnError:1,args:arguments},g?{attribution:g.attribution,logLevel:g.logLevel}:void 0);return!1}var k="FATAL",m="ERROR",n="WARN",p="DOWNGRADED",a={ec:0,ecf:0,
+pec:0,ts:0,erl:[],ter:[],buffer:[],mxe:50,startTimer:function(){a.ts++;setInterval(function(){d.ue&&a.pec<a.ec&&d.uex("at");a.pec=a.ec},1E4)}};l.skipTrace=1;h.skipTrace=1;h.isStub=1;d.ueLogError=h;d.ue_err=a;e.onerror=l})(ue_csm,window);
+
+
+var ue_id = '0B5GGA052RDJB96RMAEG',
+    ue_url = '/rd/uedata',
+    ue_drfp = true,
+    ue_navtiming = 1,
+    ue_mid = 'ATVPDKIKX0DER',
+    ue_sid = '147-7999693-6862434',
+    ue_sn = 'www.amazon.com',
+    ue_furl = 'fls-na.amazon.com',
+    ue_surl = 'https://unagi.amazon.com/1/events/com.amazon.csm.nexusclient.prod',
+    ue_int = 0,
+    ue_fcsn = 1,
+    ue_urt = 3,
+    ue_rpl_ns = 'cel-rpl',
+    ue_ddq = 1,
+    ue_fpf = '//fls-na.amazon.com/1/batch/1/OP/ATVPDKIKX0DER:147-7999693-6862434:0B5GGA052RDJB96RMAEG$uedata=s:',
+    ue_sbuimp = 1,
+    ue_ibft = 0,
+    ue_lpsi = 6000,
+    ue_lob = '1',
+    ue_act = '-1',
+    ue_dsbl_cel = 1,
+    ue_awsscrid = 1,
+
+    ue_swi = 1;
+var ue_viz=function(){(function(b,f,d){function g(){return(!(p in d)||0<d[p])&&(!(q in d)||0<d[q])}function h(c){if(b.ue.viz.length<w&&!r){var a=c.type;c=c.originalEvent;/^focus./.test(a)&&c&&(c.toElement||c.fromElement||c.relatedTarget)||(a=g()?f[s]||("blur"==a||"focusout"==a?t:u):t,b.ue.viz.push(a+":"+(+new Date-b.ue.t0)),a==u&&(b.ue.isl&&x("at"),r=1))}}for(var r=0,x=b.uex,a,k,l,s,v=["","webkit","o","ms","moz"],e=0,m=1,u="visible",t="hidden",p="innerWidth",q="innerHeight",w=20,n=0;n<v.length&&!e;n++)if(a=
+v[n],k=(a?a+"H":"h")+"idden",e="boolean"==typeof f[k])l=a+"visibilitychange",s=(a?a+"V":"v")+"isibilityState";h({});e&&f.addEventListener(l,h,0);m=g()?1:0;d.addEventListener("resize",function(){var a=g()?1:0;m!==a&&(m=a,h({}))},{passive:!0});b.ue&&e&&(b.ue.pageViz={event:l,propHid:k})})(ue_csm,ue_csm.document,ue_csm.window)};window.ue_viz=ue_viz;
+
+(function(d,k,R){function I(a){return a&&a.replace&&a.replace(/^\s+|\s+$/g,"")}function w(a){return"undefined"===typeof a}function M(a){return"function"===typeof a}function G(a,b){for(var c in b)b[x](c)&&(a[c]=b[c])}function N(a){try{var b=R.cookie.match(RegExp("(^| )"+a+"=([^;]+)"));if(b)return b[2].trim()}catch(c){}}function S(l,b,c){var s=(E||{}).type;if("device"!==c||2!==s&&1!==s){if(l){d.ue_id=a.id=a.rid=l;if("device"===c||"pre-fetch"===c)a.oid=I(l);p&&(p=p.replace(/((.*?:){2})(\w+)/,function(a,
+b){return b+l}));J&&(e("id",J,l),J=0)}b&&(p&&(p=p.replace(/(.*?:)(\w|-)+/,function(a,c){return c+b})),d.ue_sid=b);c&&a.tag("page-source:"+c);d.ue_fpf=p}}function T(){var a={};return function(b){b&&(a[b]=1);b=[];for(var c in a)a[x](c)&&b.push(c);return b}}function F(d,b,c,s){s=s||+new K;var f,k;if(b||w(c)){if(d)for(k in f=b?e("t",b)||e("t",b,{}):a.t,f[d]=s,c)c[x](k)&&e(k,b,c[k]);return s}}function e(d,b,c){var e=b&&b!=a.id?a.sc[b]:a;e||(e=a.sc[b]={});"id"===d&&c&&(U=1);return e[d]=c||e[d]}function V(d,
+b,c,e,k){c="on"+c;var f=b[c];M(f)?d&&(a.h[d]=f):f=function(){};b[c]=function(a){k?(e(a),f(a)):(f(a),e(a))};b[c]&&(b[c].isUeh=1)}function W(l,b,c,s){function z(b,c,g){b=[b];var f=0,s={},m,h;u.latency={};c?(b.push("m=1"),s[c]=1):s=a.sc;for(h in s)if(s[x](h)){var z=e("wb",h),n=e("t",h)||{},v=e("t0",h)||a.t0,r,q;if(c||2==z){r=z?f++:"";b.push("sc"+r+"="+h);var p=A,t=A;2==z&&k.csa?(t=(p=d.ue_awsscrid?k.csa("Content",{element:{type:"scope",slotId:h,csmRequestId:""+g}}):k.csa("Content",{element:{type:"scope",
+slotId:h}}))&&M(p))&&+v&&p("mark","t0",+v):p=t=A;for(q in n)w(n[q])||null===n[q]||(b.push(q+r+"="+(n[q]-v)),t&&p("mark",X[q]||q,+n[q]));b.push("t"+r+"="+n[l]);u.latency["t"+r]=n[l];if(e("ctb",h)||e("wb",h))m=1}}!D&&m&&b.push("ctb=1");return b.join("&")}function v(b,c,g,e,l){if(!(!b||d.ue_swsfp&&e)){var f=d.ue_err;d.ue_url&&!d.ue_drfp&&!e&&!l&&b&&0<b.length&&(e=new Image,a.iel.push(e),e.src=b,a.count&&a.count("postbackImageSize",b.length));p?(l=k.encodeURIComponent)&&b&&(e=new Image,b=""+d.ue_fpf+
+l(b)+":"+(+new K-d.ue_t0),a.iel.push(e),e.src=b):a.log&&(a.log(b,"uedata",{n:1}),a.ielf.push(b));f&&!f.ts&&f.startTimer();a.b&&(f=a.b,a.b="",v(f,c,g,1))}}function r(b){var c=E?E.type:A,d=2==c||a.isBFonMshop,c=c&&!d,e=a.bfini;if(!U||a.isBFCache)e&&1<e&&(b+="&bfform=1",c||(a.isBFT=e-1)),d&&(b+="&bfnt=1",a.isBFT=a.isBFT||1),a.ssw&&a.isBFT&&(a.isBFonMshop&&(a.isNRBF=0),w(a.isNRBF)&&(d=a.ssw(a.oid),d.e||w(d.val)||(a.isNRBF=1<d.val?0:1)),w(a.isNRBF)||(b+="&nrbf="+a.isNRBF)),a.isBFT&&!a.isNRBF&&(b+="&bft="+
+a.isBFT);return b}if(!a.paused&&(b||w(c))){for(var m in c)c[x](m)&&e(m,b,c[m]);a.isBFonMshop||F("pc",b,c);m="ld"===l&&b&&e("wb",b);var B=!d.ue_swsfp||!m,n=e("id",b)||a.id;m||n===a.oid||(J=b,ga(n,(e("t",b)||{}).tc||+e("t0",b),+e("t0",b),e("pty",b),e("spty",b)));var C=e("id",b)||a.id,q=e("id2",b)||d.ue_id2,g=a.url+"?"+l+"&v="+a.v+"&id="+C,D=e("ctb",b)||e("wb",b),u={eventName:l,version:a.v,id:C,sessionId:d.ue_sid||"",obfuscatedMarketplaceId:d.ue_mid||""},t;D&&(g+="&ctb="+D);q&&(g+="&id2="+q);1<d.ueinit&&
+(g+="&ic="+d.ueinit);if(!("ld"!=l&&"ul"!=l||b&&b!=C)){if("ld"==l){try{k[O]&&k[O].isUeh&&(k[O]=null)}catch(N){}if(k.chrome)for(q=0;q<P.length;q++)Y(L,P[q]);(q=R.ue_backdetect)&&q.ue_back&&q.ue_back.value++;d._uess&&(t=d._uess());a.isl=1}B&&a._bf&&(g+="&bf="+a._bf());d.ue_navtiming&&f&&(e("ctb",C,"1"),a.isBFonMshop||F("tc",A,A,Q));B&&H&&!a.isBFonMshop&&!Z&&(f&&G(a.t,{na_:f.navigationStart,ul_:f.unloadEventStart,_ul:f.unloadEventEnd,rd_:f.redirectStart,_rd:f.redirectEnd,fe_:f.fetchStart,lk_:f.domainLookupStart,
+_lk:f.domainLookupEnd,co_:f.connectStart,_co:f.connectEnd,sc_:f.secureConnectionStart,rq_:f.requestStart,rs_:f.responseStart,_rs:f.responseEnd,dl_:f.domLoading,di_:f.domInteractive,de_:f.domContentLoadedEventStart,_de:f.domContentLoadedEventEnd,_dc:f.domComplete,ld_:f.loadEventStart,_ld:f.loadEventEnd,ntd:(M(H.now)&&!w(Q)?new K(Q+H.now())-new K:0)+a.t0}),E&&G(a.t,{ty:E.type+a.t0,rc:E.redirectCount+a.t0}),Z=1);a.isBFonMshop||G(a.t,{hob:d.ue_hob,hoe:d.ue_hoe});a.ifr&&(g+="&ifr=1",u.ifr=!0)}F(l,b,c,
+s);var y,h;m||b&&b!==C||ha(b);c=d.ue_mbl;B&&c&&c.cnt&&!m&&(g+=c.cnt());m?e("wb",b,2):"ld"==l&&(a.lid=I(C));for(y in a.sc)if(1==e("wb",y))break;if(m){if(a.s)return;g=z(g,null,n)}else c=z(g,null,n),c!=g&&(c=r(c),a.b=c),t&&(g+=t),g=z(g,b||a.id,n);g=r(g);if(a.b||m)for(y in a.sc)2==e("wb",y)&&delete a.sc[y];y=0;B&&a._rt&&(g+="&rt="+a._rt());t=k.csa;if(!m&&t)for(h in n=e("t",b)||{},c=t("PageTiming"),n)n[x](h)&&c("mark",X[h]||h,n[h]);m||(a.s=0,(h=d.ue_err)&&0<h.ec&&h.pec<h.ec&&(h.pec=h.ec,g+="&ec="+h.ec+
+"&ecf="+h.ecf),y=e("ctb",b),"ld"!==l||b||a.markers?a.markers&&a.isl&&!m&&b&&G(a.markers,e("t",b)):(a.markers={},G(a.markers,e("t",b))),e("t",b,{}));B&&a.tag&&a.tag().length&&(g+="&csmtags="+a.tag().join("|"),u.csmtags=a.tag(),a.tag=T());h=a.viz||[];n=h.length;B&&n&&(h=h.splice(0,n),g+="&viz="+h.join("|"),u.viz=h);w(d.ue_pty)||(g+="&pty="+d.ue_pty+"&spty="+d.ue_spty+"&pti="+d.ue_pti,u.pty=d.ue_pty,u.spty=d.ue_spty,u.pti=d.ue_pti);a.tabid&&(g+="&tid="+a.tabid);a.aftb&&(g+="&aftb=1");!B||!a._ui||b&&
+b!=C||(g+=a._ui());g+="&lob="+(d.ue_lob||"0");a.a=g;v(g,l,y,m,b&&"string"===typeof b&&-1!==b.indexOf("csa:"));m||(u.lob=d.ue_lob||"0",u.browserData=g,(b=t&&t("UEData"))&&b("log",u))}}function ha(a){var b=k.ue_csm_markers||{},c;for(c in b)b[x](c)&&F(c,a,A,b[c])}function D(a,b,c){c=c||k;if(c[$])c[$](a,b,!1);else if(c[aa])c[aa]("on"+a,b)}function Y(a,b,c){c=c||k;if(c[ba])c[ba](a,b,!1);else if(c[ca])c[ca]("on"+a,b)}function da(){function a(){d.onUl()}function b(a){return function(){c[a]||(c[a]=1,W(a))}}
+var c={},e,f;d.onLd=b("ld");d.onLdEnd=b("ld");d.onUl=b("ul");e={stop:b("os")};k.chrome?(D(L,a),P.push(a)):e[L]=d.onUl;for(f in e)e[x](f)&&V(0,k,f,e[f]);d.ue_viz&&ue_viz();D("load",d.onLd);F("ue")}function ga(e,b,c,f,p){var v=d.ue_mbl,r=k.csa,m=r&&r("SPA"),r=r&&r("PageTiming");v&&v.ajax&&v.ajax(b,c);m&&r&&(e={requestId:e,transitionType:"soft"},"string"===typeof f&&(e.pageType=f,d.ue_pty=f),"string"===typeof p&&(e.subPageType=p,d.ue_spty=p),m("newPage",e),r("mark","transitionStart",b));a.tag("ajax-transition")}
+d.ueinit=(d.ueinit||0)+1;var a=d.ue=d.ue||{};a.t0=k.aPageStart||d.ue_t0;a.id=d.ue_id;a.url=d.ue_url;a.rid=d.ue_id;a.a="";a.b="";a.h={};a.s=1;a.t={};a.sc={};a.iel=[];a.ielf=[];a.viz=[];a.v="0.348446.0";a.paused=!1;var x="hasOwnProperty",L="beforeunload",O="on"+L,$="addEventListener",ba="removeEventListener",aa="attachEvent",ca="detachEvent",X={cf:"criticalFeature",af:"aboveTheFold",fn:"functional",fp:"firstPaint",fcp:"firstContentfulPaint",bb:"bodyBegin",be:"bodyEnd",ld:"loaded"},K=k.Date,H=k.performance||
+k.webkitPerformance,f=(H||{}).timing,E=(H||{}).navigation,Q=(f||{}).navigationStart,p=d.ue_fpf,U=0,Z=0,P=[],J=0,A;a.oid=I(a.id);a.lid=I(a.id);a._t0=a.t0;a.tag=T();a.ifr=k.top!==k.self||k.frameElement?1:0;a.markers=null;a.attach=D;a.detach=Y;if("000-0000000-8675309"===d.ue_sid){var ea=N("cdn-rid"),fa=N("session-id");ea&&fa&&S(ea,fa,"cdn")}d.uei=da;d.ueh=V;d.ues=e;d.uet=F;d.uex=W;a.reset=S;a.pause=function(d){a.paused=d};da()})(ue_csm,ue_csm.window,ue_csm.document);
+
+
+ue.stub(ue,"event");ue.stub(ue,"onSushiUnload");ue.stub(ue,"onSushiFlush");
+
+ue.stub(ue,"log");ue.stub(ue,"onunload");ue.stub(ue,"onflush");
+(function(b){var a=b.ue;a.cv={};a.cv.scopes={};a.cv.buffer=[];a.count=function(b,d,c){var e=a.cv;a.d();c&&c.scope&&(e=a.cv.scopes[c.scope]=a.cv.scopes[c.scope]||{});if(void 0===d)return e[b];e[b]=d;a.cv.buffer.push({c:b,v:d})};a.count("baselineCounter2",1);a&&a.event&&(a.event({requestId:b.ue_id||"rid",server:b.ue_sn||"sn",obfuscatedMarketplaceId:b.ue_mid||"mid"},"csm","csm.CSMBaselineEvent.4"),a.count("nexusBaselineCounter",1,{bf:1}))})(ue_csm);
+
+
+(function(g,h,l){if("function"===typeof h.addEventListener&&"function"===typeof l.querySelectorAll){var e,r=["mouseenter","mouseleave"],t="click dblclick mousedown mouseover mouseout touchstart keydown keypress MSPointerDown pointerdown focusin".split(" ").concat(r),n=!1,p=[];var u=function(a){for(var b=[];a;)b.push(a),a=a.parentNode;return b};var q=function(a,b){var d=-1,c;for(c=0;c<b.length;c++)if(b[c]===a){d=c;break}return d};var v=function(a,b){a=q(a,b);0<=a&&b.splice(a,1)};var x=function(a){a=
+u(a);for(var b,d,c=0;c<a.length;c++)if(d=a[c],(b=d.nodeName)&&b!==l.nodeName){b=b.toLowerCase();if(d.id)return b+"#"+d.id+(f?">"+f:"");(d=d.getAttribute("class"))&&(b=b+"."+d.split(" ").join("."));var f=b+(f?">"+f:"")}return f};var y=function(a){return a.replace(/[^\w.:\-]/g,function(a){return"#"===a?"::":">"===a?":-":"_"})};var w=function(a,b){if(g.ue&&g.ue.count&&g.ueLogError){a=x(a);var d=y(a);var c="degraded"===b?"A UX degrading element has entered the viewport: "+a:"A "+b+" was not handled on element: "+
+a;g.ueLogError({m:c,fromOnError:1},{logLevel:"ERROR",attribution:a,message:c});b=["TNR","TNR:"+b,"TNR:"+d,"TNR:"+b+":"+d];for(e=0;e<b.length;e++)g.ue.count(b[e],(g.ue.count(b[e])||0)+1)}};var z=function(a){a=a.getBoundingClientRect();return a.top<a.bottom&&a.left<a.right&&0<=a.bottom&&a.top<=h.innerHeight&&0<=a.right&&a.left<=h.innerWidth};var m=function(){n||(n=!0,setTimeout(function(){[].forEach.call(l.querySelectorAll("[data-ux-degraded]"),function(a){z(a)?0>q(a,p)&&(p.push(a),w(a,"degraded")):
+v(a,p)});n=!1},250))};h.addEventListener("scroll",m);h.addEventListener("resize",m);m=function(a){var b=!1,d=0>q(a,r);l.addEventListener(a,function(c){if(!b){b=!0;var f=[],e=d?u(c.target):[c.target],g,h;for(g=0;g<e.length;g++){var k=e[g];k.getAttribute&&("mouseover"===a&&k===c.target&&((h=k.getAttribute("data-ux-jq-mouseenter"))||""===h)&&f.push(k),((h=k.getAttribute("data-ux-"+a))||""===h)&&f.push(k))}f.length?(c.ack=c.acknowledge=function(a){a=a||c.currentTarget;v(a,f)},setTimeout(function(){var c;
+for(c=0;c<f.length;c++)w(f[c],a);b=!1},250)):b=!1}},!0)};for(e=0;e<t.length;e++)m(t[e])}})(ue_csm,window,document);
+
+
+var ue_hoe = +new Date();
+}
+window.ueinit = window.ue_ihb;
+</script>
+
+<!-- 8o4cnvr7gljjs5y -->
+<script>window.ue && ue.count && ue.count('CSMLibrarySize', 12839)</script>
+<!-- sp:end-feature:csm:head-open-part2 -->
+<!-- sp:feature:aui-assets -->
+<link rel="stylesheet" href="https://m.media-amazon.com/images/I/21uDPuQuYwL._RC|51SvmD+jTBL.css_.css?AUIClients/AmazonUI" />
+<link rel="stylesheet" href="https://m.media-amazon.com/images/I/11WsGYSItxL._RC|01DE6WSvLKL.css,41ixaNR85ML.css,31LMk2aP6xL.css,21JMC7OC91L.css,01xH+fhFIJL.css,0168Xo81wHL.css,413Vvv3GONL.css,1170nDgl0uL.css,01Rw4F+QU6L.css,11NeGmEx+fL.css,01LmAy9LJTL.css,01IdKcBuAdL.css,01iHqjS7YfL.css,01eVBHHaY+L.css,21D3IemrALL.css,11pDJV08stL.css,51yqRfvysvL.css,01HWrzt-WgL.css,01XPHJk60-L.css,11aX6hlPzjL.css,01GAxF7K5tL.css,01ZM-s8Z3xL.css,21gEzBqpmtL.css,11FeoxrgiyL.css,21TxBPhrLyL.css,01rSTIgNJIL.css,21Dt9D2TuML.css,31GD5I7tbCL.css,01i092IYHUL.css,01oaPOLX+-L.css,31Qk3MvcMIL.css,11PDZ29p-PL.css,11kbPm9N5xL.css,215WpAjwzoL.css,11sUwulETuL.css,114aTS6SjML.css,01xFKTPySiL.css,21GcfcmbahL.css,21OD8FuBraL.css,11XozyxiH7L.css,21n1oEPZnHL.css,11HVvPbE6JL.css,119Cktja74L.css,11PMguLK6gL.css,01890+Vwk8L.css,11TZSntL0oL.css,01qiwJ7qDfL.css,21AS3Iv3HQL.css,016mfgi+D2L.css,01VinDhK+DL.css,31un+UKeIeL.css,21msrr4h2yL.css,013-xYw+SRL.css_.css?AUIClients/AmazonUI#us.not-trident.1353409-T2" />
+<script>
+(function(b,a,c,d){if((b=b.AmazonUIPageJS||b.P)&&b.when&&b.register){c=[];for(a=a.currentScript;a;a=a.parentElement)a.id&&c.push(a.id);return b.log("A copy of P has already been loaded on this page.","FATAL",c.join(" "))}})(window,document,Date);(function(a,b,c,d){"use strict";a._pSetI=function(){return null}})(window,document,Date);(function(c,e,I,B){"use strict";c._pd=function(){var a,u;return function(C,f,h,k,b,D,v,E,F){function w(d){try{return d()}catch(J){return!1}}function l(){if(m){var d={w:c.innerWidth||b.clientWidth,h:c.innerHeight||b.clientHeight};5<Math.abs(d.w-q.w)||50<d.h-q.h?(q=d,n=4,(d=a.mobile||a.tablet?450<d.w&&d.w>d.h:1250<=d.w)?k(b,"a-ws"):b.className=v(b,"a-ws")):0<n&&(n--,x=setTimeout(l,16))}}function G(d){(m=d===B?!m:!!d)&&l()}function H(){return m}if(!u){u=!0;var r=function(){var d=["O","ms","Moz","Webkit"],
+c=e.createElement("div");return{testGradients:function(){return!0},test:function(a){var b=a.charAt(0).toUpperCase()+a.substr(1);a=(d.join(b+" ")+b+" "+a).split(" ");for(b=a.length;b--;)if(""===c.style[a[b]])return!0;return!1},testTransform3d:function(){return!0}}}(),y=b.className,z=/(^| )a-mobile( |$)/.test(y),A=/(^| )a-tablet( |$)/.test(y);a={audio:function(){return!!e.createElement("audio").canPlayType},video:function(){return!!e.createElement("video").canPlayType},canvas:function(){return!!e.createElement("canvas").getContext},
+svg:function(){return!!e.createElementNS&&!!e.createElementNS("http://www.w3.org/2000/svg","svg").createSVGRect},offline:function(){return navigator.hasOwnProperty&&navigator.hasOwnProperty("onLine")&&navigator.onLine},dragDrop:function(){return"draggable"in e.createElement("span")},geolocation:function(){return!!navigator.geolocation},history:function(){return!(!c.history||!c.history.pushState)},webworker:function(){return!!c.Worker},autofocus:function(){return"autofocus"in e.createElement("input")},
+inputPlaceholder:function(){return"placeholder"in e.createElement("input")},textareaPlaceholder:function(){return"placeholder"in e.createElement("textarea")},localStorage:function(){return"localStorage"in c&&null!==c.localStorage},orientation:function(){return"orientation"in c},touch:function(){return"ontouchend"in e},gradients:function(){return r.testGradients()},hires:function(){var a=c.devicePixelRatio&&1.5<=c.devicePixelRatio||c.matchMedia&&c.matchMedia("(min-resolution:144dpi)").matches;E("hiRes"+
+(z?"Mobile":A?"Tablet":"Desktop"),a?1:0);return a},transform3d:function(){return r.testTransform3d()},touchScrolling:function(){return f(/Windowshop|android|OS ([5-9]|[1-9][0-9]+)(_[0-9]{1,2})+ like Mac OS X|SOFTWARE=([5-9]|[1-9][0-9]+)(.[0-9]{1,2})+.*DEVICE=iPhone|Chrome|Silk|Firefox|Trident.+?; Touch/i)},ios:function(){return f(/OS [1-9][0-9]*(_[0-9]*)+ like Mac OS X/i)&&!f(/trident|Edge/i)},android:function(){return f(/android.([1-9]|[L-Z])/i)&&!f(/trident|Edge/i)},mobile:function(){return z},
+tablet:function(){return A},rtl:function(){return"rtl"===b.dir}};for(var g in a)a.hasOwnProperty(g)&&(a[g]=w(a[g]));for(var t="textShadow textStroke boxShadow borderRadius borderImage opacity transform transition".split(" "),p=0;p<t.length;p++)a[t[p]]=w(function(){return r.test(t[p])});var m=!0,x=0,q={w:0,h:0},n=4;l();h(c,"resize",function(){clearTimeout(x);n=4;l()});b.className=v(b,"a-no-js");k(b,"a-js");!f(/OS [1-8](_[0-9]*)+ like Mac OS X/i)||c.navigator.standalone||f(/safari/i)||k(b,"a-ember");
+h=[];for(g in a)a.hasOwnProperty(g)&&a[g]&&h.push("a-"+g.replace(/([A-Z])/g,function(a){return"-"+a.toLowerCase()}));k(b,h.join(" "));b.setAttribute("data-aui-build-date",F);C.register("p-detect",function(){return{capabilities:a,localStorage:a.localStorage&&D,toggleResponsiveGrid:G,responsiveGridEnabled:H}});return a||{}}}}()})(window,document,Date);(function(a,p,q,k){function m(e,b,c,g){a.P.when.apply(a.P,b).register("flow:"+e,function(){var a=g.apply(this,arguments);return c||a})}function l(e){a.P.log(e,"FATAL","AmazonUIPageJS@AUIDefineJS")}function f(a,b,c){Object.defineProperty(a,b,{value:c,writable:!1})}function n(e,b,c){"string"!==typeof e&&a.P.error("Anonymous modules are not supported.");var g=c!==k?c:"function"===typeof b?b:k;g||a.P.error("A callback must be provided");var f,h=[];if(c&&Array.isArray(b)&&(h=b.reduce(function(b,d){if("module"===
+d||"require"===d)a.P.error('"module" or "require" injection is not supported.');else if("exports"===d){d=f={};var c="flow:"+e+"-exports";a.P.declare(c,d);b.push(c)}else 0!==d.lastIndexOf("@amzn/",0)?l("Dependency "+d+" does not begin with '@amzn/'"):b.push("flow:"+d);return b},[]),b.length!==h.length))return;m(e,h,f,g)}"use strict";Object.prototype.hasOwnProperty.call(a,"aui")?l("AUIDefineJS is already present globally"):(f(a,"aui",{}),f(a.aui,"amd_define",n))})(window,document,Date);(function(g,h,C,D){function K(a){l&&l.tag&&l.tag(p(":","aui",a))}function q(a,b){l&&l.count&&l.count("aui:"+a,0===b?0:b||(l.count("aui:"+a)||0)+1)}function L(a){try{return a.test(navigator.userAgent)}catch(b){return!1}}function x(a,b,c){a.addEventListener?a.addEventListener(b,c,!1):a.attachEvent&&a.attachEvent("on"+b,c)}function p(a,b,c,f){b=b&&c?b+a+c:b||c;return f?p(a,b,f):b}function y(a,b,c){try{Object.defineProperty(a,b,{value:c,writable:!1})}catch(f){a[b]=c}return c}function M(a,b){a.className=
+N(a,b)+" "+b}function N(a,b){return(" "+a.className+" ").split(" "+b+" ").join(" ").replace(/^ | $/g,"")}function aa(a,b,c){var f=c=a.length,e=function(){f--||(E.push(b),F||(m?m.set(z):setTimeout(z,0),F=!0))};for(e();c--;)O[a[c]]?e():(u[a[c]]=u[a[c]]||[]).push(e)}function ba(a,b,c,f,e){var d=h.createElement(a?"script":"link");x(d,"error",f);e&&x(d,"load",e);a?(d.type="text/javascript",d.async=!0,c&&/AUIClients|images[/]I/.test(b)&&d.setAttribute("crossorigin","anonymous"),d.src=b):(d.rel="stylesheet",
+d.href=b);h.getElementsByTagName("head")[0].appendChild(d)}function P(a,b){return function(c,f){function e(){ba(b,c,d,function(b){G?q("resource_unload"):d?(d=!1,q("resource_retry"),e()):(q("resource_error"),a.log("Asset failed to load: "+c));b&&b.stopPropagation?b.stopPropagation():g.event&&(g.event.cancelBubble=!0)},f)}if(Q[c])return!1;Q[c]=!0;q("resource_count");var d=!0;return!e()}}function ca(a,b,c){for(var f={name:a,guard:function(c){return b.guardFatal(a,c)},guardTime:function(a){return b.guardTime(a)},
+logError:function(c,d,e){b.logError(c,d,e,a)}},e=[],d=0;d<c.length;d++)A.hasOwnProperty(c[d])&&(e[d]=H.hasOwnProperty(c[d])?H[c[d]](A[c[d]],f):A[c[d]]);return e}function v(a,b,c,f,e){return function(d,k){function n(){var a=null;f?a=k:"function"===typeof k&&(q.start=r(),a=k.apply(g,ca(d,h,l)),q.end=r());if(b){A[d]=a;a=d;for(O[a]=!0;(u[a]||[]).length;)u[a].shift()();delete u[a]}q.done=!0}var h=e||this;"function"===typeof d&&(k=d,d=D);b&&(d=d?d.replace(R,""):"__NONAME__",I.hasOwnProperty(d)&&h.error(p(", reregistered by ",
+p(" by ",d+" already registered",I[d]),h.attribution),d),I[d]=h.attribution);for(var l=[],m=0;m<a.length;m++)l[m]=a[m].replace(R,"");var q=w[d||"anon"+ ++da]={depend:l,registered:r(),namespace:h.namespace};d&&ea.hasOwnProperty(d);c?n():aa(l,h.guardFatal(d,n),d);return{decorate:function(a){H[d]=h.guardFatal(d,a)}}}}function S(a){return function(){var b=Array.prototype.slice.call(arguments);return{execute:v(b,!1,a,!1,this),register:v(b,!0,a,!1,this)}}}function J(a,b){return function(c,f){f||(f=c,c=
+D);var e=this.attribution;return function(){n.push(b||{attribution:e,name:c,logLevel:a});var d=f.apply(this,arguments);n.pop();return d}}}function B(a,b){this.load={js:P(this,!0),css:P(this)};y(this,"namespace",b);y(this,"attribution",a)}function T(){h.body?k.trigger("a-bodyBegin"):setTimeout(T,20)}"use strict";var t=C.now=C.now||function(){return+new C},r=function(a){return a&&a.now?a.now.bind(a):t}(g.performance),fa=r(),ea={},l=g.ue;K();K("aui_build_date:3.26.5-2026-06-03");var U={getItem:function(a){try{return g.localStorage.getItem(a)}catch(b){}},
+setItem:function(a,b){try{return g.localStorage.setItem(a,b)}catch(c){}}},m=g._pSetI(),E=[],ha=[],F=!1,ia=navigator.scheduling&&"function"===typeof navigator.scheduling.isInputPending;var z=function(){for(var a=m?m.set(z):setTimeout(z,0),b=t();ha.length||E.length;)if(E.shift()(),m&&ia){if(150<t()-b&&!navigator.scheduling.isInputPending()||50<t()-b&&navigator.scheduling.isInputPending())return}else if(50<t()-b)return;m?m.clear(a):clearTimeout(a);F=!1};var O={},u={},Q={},G=!1;x(g,"beforeunload",function(){G=
+!0;setTimeout(function(){G=!1},1E4)});var R=/^prv:/,I={},A={},H={},w={},da=0,ja=String.fromCharCode(92),n=[],V=!0,W=g.onerror;g.onerror=function(a,b,c,f,e){e&&"object"===typeof e||(e=Error(a,b,c),e.columnNumber=f,e.stack=b||c||f?p(ja,e.message,"at "+p(":",b,c,f)):D);var d=n.pop()||{};e.attribution=p(":",e.attribution||d.attribution,d.name);e.logLevel=d.logLevel;e.attribution&&console&&console.log&&console.log([e.logLevel||"ERROR",a,"thrown by",e.attribution].join(" "));n=[];W&&(d=[].slice.call(arguments),
+d[4]=e,W.apply(g,d))};B.prototype={logError:function(a,b,c,f){b={message:b,logLevel:c||"ERROR",attribution:p(":",this.attribution,f)};if(g.ueLogError)return g.ueLogError(a||b,a?b:null),!0;console&&console.error&&(console.log(b),console.error(a));return!1},error:function(a,b,c,f){a=Error(p(":",f,a,c));a.attribution=p(":",this.attribution,b);throw a;},guardError:J(),guardFatal:J("FATAL"),guardCurrent:function(a){var b=n[n.length-1];return b?J(b.logLevel,b).call(this,a):a},guardTime:function(a){var b=
+n[n.length-1],c=b&&b.name;return c&&c in w?function(){var b=r(),e=a.apply(this,arguments);w[c].async=(w[c].async||0)+r()-b;return e}:a},log:function(a,b,c){return this.logError(null,a,b,c)},declare:v([],!0,!0,!0),register:v([],!0),execute:v([]),AUI_BUILD_DATE:"3.26.5-2026-06-03",when:S(),now:S(!0),trigger:function(a,b,c){var f=t();this.declare(a,{data:b,pageElapsedTime:f-(g.aPageStart||NaN),triggerTime:f});c&&c.instrument&&X.when("prv:a-logTrigger").execute(function(b){b(a)})},handleTriggers:function(){this.log("handleTriggers deprecated")},
+attributeErrors:function(a){return new B(a)},_namespace:function(a,b){return new B(a,b)},setPriority:function(a){V?V=!1:this.log("setPriority only accept the first call.")}};var k=y(g,"AmazonUIPageJS",new B);var X=k._namespace("PageJS","AmazonUI");X.declare("prv:p-debug",w);k.declare("p-recorder-events",[]);k.declare("p-recorder-stop",function(){});y(g,"P",k);T();if(h.addEventListener){var Y;h.addEventListener("DOMContentLoaded",Y=function(){k.trigger("a-domready");h.removeEventListener("DOMContentLoaded",
+Y,!1)},!1)}var Z=h.documentElement,ka=g._pd(k,L,x,M,Z,U,N,q,"3.26.5-2026-06-03");L(/UCBrowser/i)||ka.localStorage&&M(Z,U.getItem("a-font-class"));k.declare("a-event-revised-handling",!1);k.declare("a-fix-event-off",!1);q("pagejs:pkgExecTime",r()-fa)})(window,document,Date);
+(function(d,G,I,J){function r(h){k&&k.tag&&k.tag(g(":","aui",h))}function e(h,d){k&&k.count&&k.count("aui:"+h,0===d?0:d||(k.count("aui:"+h)||0)+1)}function t(d){try{return d.test(navigator.userAgent)}catch(y){return!1}}function l(d){return"function"===typeof d}function w(d,g,e){d.addEventListener?d.addEventListener(g,e,!1):d.attachEvent&&d.attachEvent("on"+g,e)}function g(d,e,l,k){e=e&&l?e+d+l:e||l;return k?g(d,e,k):e}"use strict";var k=d.ue,A=String.fromCharCode(92),B=["webpack://@import/chromium-server/"];
+P.execute("RetailPageServiceWorker",function(){function h(a,b){m.controller&&a?(a={feature:"retail_service_worker_messaging",command:a},b&&(a.data=b),m.controller.postMessage(a)):a&&e("sw:sw_message_no_ctrl",1)}function y(a){var b=a.data;if(b&&"retail_service_worker_messaging"===b.feature&&b.command&&b.data){var c=b.data;a=d.ue;var f=d.ueLogError;switch(b.command){case "log_counter":a&&l(a.count)&&c.name&&a.count(c.name,0===c.value?0:c.value||1);break;case "log_tag":a&&l(a.tag)&&c.tag&&(a.tag(c.tag),
+b=d.uex,a.isl&&l(b)&&b("at"));break;case "log_error":f&&l(f)&&c.message&&f({message:c.message,logLevel:c.level||"ERROR",attribution:c.attribution||"RetailServiceWorker"});break;case "log_weblab_trigger":if(!c.weblab||!c.treatment)break;a&&l(a.trigger)?a.trigger(c.weblab,c.treatment):(e("sw:wt:miss"),e("sw:wt:miss:"+c.weblab+":"+c.treatment));break;default:e("sw:unsupported_message_command",1)}}}function v(a,b){return"sw:"+(b||"")+":"+a+":"}function z(a,b){try{m.register("/service-worker.js").then(function(){e(a+
+"success")}).catch(function(c){C(c,a,b)})}catch(c){C(c,a,b)}}function C(a,b,c){var f;a:{if(a&&"object"===typeof a&&"string"===typeof a.stack)for(f=0;f<B.length;f++)if(-1!==a.stack.indexOf(B[f])){f=!0;break a}f=!1}f?e(b+"error:suppressed"):(P.logError(a,"[AUI SW] Failed to "+c+" service worker: ","ERROR","RetailPageServiceWorker"),e(b+"failure"))}function D(){n.forEach(function(a){r(a)})}function q(a){return a.capabilities.isAmazonApp&&a.capabilities.android}function E(a,b,c){if(b)if(b.mshop&&q(a))a=
+v(c,"mshop_and"),b=b.mshop.action,n.push(a+"supported"),b(a,c);else if(b.browser){a=t(/Chrome/i)&&!t(/Edge/i)&&!t(/OPR/i)&&!a.capabilities.isAmazonApp&&!t(new RegExp(A+"bwv"+A+"b"));var f=b.browser;b=v(c,"browser");a?(a=f.action,n.push(b+"supported"),a(b,c)):n.push(b+"unsupported")}}function F(a,b,c){a&&n.push(v("register",c)+"unsupported");b&&n.push(v("unregister",c)+"unsupported");D()}try{var m=navigator.serviceWorker}catch(a){r("sw:nav_err")}(function(){if(m){var a=function(){h("page_loaded",{rid:d.ue_id,
+mid:d.ue_mid,pty:d.ue_pty,sid:d.ue_sid,spty:d.ue_spty,furl:d.ue_furl})};w(m,"message",y);h("client_messaging_ready");P.when("load").execute(a);w(m,"controllerchange",function(){h("client_messaging_ready");"complete"===G.readyState&&a()})}})();var n=[],p=function(a,b){var c=d.uex,f=d.uet;a=g(":","aui","sw",a);"ld"===b&&l(c)?c("ld",a,{wb:1}):l(f)&&f(b,a,{wb:1})},H=function(a,b,c){function f(a){b&&l(b.failure)&&b.failure(a)}function k(){n=setTimeout(function(){r(g(":","sw:"+h,u.TIMED_OUT));f({ok:!1,
+statusCode:u.TIMED_OUT,done:!1});p(h,"ld")},c||4E3)}var u={NO_CONTROLLER:"no_ctrl",TIMED_OUT:"timed_out",UNSUPPORTED_BROWSER:"unsupported_browser",UNEXPECTED_RESPONSE:"unexpected_response"},h=g(":",a.feature,a.command),n,q=!0;if("MessageChannel"in d&&m&&"controller"in m)if(m.controller){var t=new MessageChannel;t.port1.onmessage=function(c){(c=c.data)&&c.feature===a.feature&&c.command===a.command?(q&&(p(h,"cf"),q=!1),p(h,"af"),clearTimeout(n),c.done||k(),c.ok?b&&l(b.success)&&b.success(c):f(c),c.done&&
+p(h,"ld")):e(g(":","sw:"+h,u.UNEXPECTED_RESPONSE),1)};k();p(h,"bb");m.controller.postMessage(a,[t.port2])}else r(g(":","sw:"+a.feature,u.NO_CONTROLLER)),f({ok:!1,statusCode:u.NO_CONTROLLER,done:!0});else r(g(":","sw:"+a.feature,u.UNSUPPORTED_BROWSER)),f({ok:!1,statusCode:u.UNSUPPORTED_BROWSER,done:!0})};(function(){m?(p("ctrl_changed","bb"),m.addEventListener("controllerchange",function(){r("sw:ctrl_changed");p("ctrl_changed","ld")})):e(g(":","sw:ctrl_changed","sw_unsupp"),1)})();(function(){var a=
+function(){p(b,"ld");var a=d.uex;H({feature:"page_proxy",command:"request_feature_tags"},{success:function(b){b=b.data;Array.isArray(b)&&b.forEach(function(a){"string"===typeof a?r(g(":","sw:ppft",a)):e(g(":","sw:ppft","invalid_tag"),1)});e(g(":","sw:ppft","success"),1);k&&k.isl&&l(a)&&a("at")},failure:function(a){e(g(":","sw:ppft","error:"+(a.statusCode||"ppft_error")),1)}})};if("requestIdleCallback"in d){var b=g(":","ppft","callback_ricb");d.requestIdleCallback(a,{timeout:1E3})}else b=g(":","ppft",
+"callback_timeout"),setTimeout(a,0);p(b,"bb")})();var x={reg:{},unreg:{}};x.reg.mshop={action:z};x.reg.browser={action:z};(function(a){var b=a.reg,c=a.unreg;m&&m.getRegistrations?(P.when("A").execute(function(b){if((a.reg.mshop||a.unreg.mshop)&&"function"===typeof q&&q(b)){var f=a.reg.mshop?"T1":"C",g=d.ue;g&&g.trigger?g.trigger("MSHOP_SW_CLIENT_446196",f):e("sw:mshop:wt:failed")}E(b,c,"unregister")}),w(d,"load",function(){P.when("A").execute(function(a){E(a,b,"register");D()})})):(F(b&&b.browser,
+c&&c.browser,"browser"),P.when("A").execute(function(a){"function"===typeof q&&q(a)&&F(b&&b.mshop,c&&c.mshop,"mshop_and")}))})(x)})})(window,document,Date);
+'use strict';(function(b){function t(a,e,d){function h(a,b,c){var f=Array(e.length);~m&&(f[m]={});~n&&(f[n]=c);for(c=0;c<q.length;c++){var h=q[c],g=a[c];f[h]=g}for(c=0;c<p.length;c++)h=p[c],g=b[c],f[h]=g;a=d.apply(null,f);return~m?f[m]:a}"string"!==typeof a&&b.P.error("C001");var c=-1<a.indexOf("/")&&(-1<a.indexOf("es3")||-1<a.indexOf("evergreen")),r=c&&-1<a.indexOf("@");c&&!r&&(a=a.substring(0,a.lastIndexOf("/")));if(!w[a]){w[a]=!0;d||(d=e,e=[]);a=a.split(":",2);c=a[1]?a[0]:void 0;var g=(a[1]||a[0]).replace(/@capability\//,
+"@c/"),x=-1<g.indexOf("/")?g.split("/")[0]:g,l=c?b.P._namespace(c):b.P;a=!g.lastIndexOf("@c/",0);c=!g.lastIndexOf("@m/",0);for(var q=[],u=[],p=[],v=[],n=-1,m=-1,k=0;k<e.length;k++){var f=e[k];"module"===f&&l.error("C002");"exports"===f?m=k:"require"===f?n=k:f.lastIndexOf("@p/",0)?f.lastIndexOf("@c/",0)&&f.lastIndexOf("@m/",0)?f.lastIndexOf("./",0)?(q.push(k),u.push("mix:"+f)):(f=x+"/"+f.substr(2),p.push(k),v.push(f)):(p.push(k),v.push(f)):(q.push(k),u.push(f.substr(3)))}var y=a||c||r||~n||p.length;
+l.when.apply(l,u).register("mix:"+g,function(){var a=[].slice.call(arguments);return y?{capabilities:v,cardModuleFactory:function(b,c){b=h(a,b,c);b.P=l;return b},require:~n?t:void 0}:h(a,[],function(){})});y&&l.when("mix:@amzn/mix.client-runtime","mix:"+g).execute(function(a,b){a.registerCapabilityModule(g,b)});l.when("mix:"+g).register("xcp:"+g,function(a){return a});var t=function(a,b,c){try{var e=a[0],d=e.lastIndexOf("./",0)?e:x+"/"+e.substr(2),f=d.lastIndexOf("@p/",0)?"mix:"+d:d.substr(3);l.when(f).execute(function(a){try{b(a)}catch(A){c(A)}})}catch(z){c(z)}}}}
+"use strict";var w={};b.mix_d||((b.Promise?P:P.when("3p-promise")).register("@p/promise-is-ready",function(a){b.Promise=b.Promise||a}),(Array.prototype.includes?P:P.when("a-polyfill")).register("@p/polyfill-is-ready",function(){}),b.mix_d=function(a,b,d){P.when("@p/promise-is-ready","@p/polyfill-is-ready").execute("@p/mix-d-deps",function(){t(a,b,d)})},b.xcp_d=b.mix_d,P.when("mix:@amzn/mix.client-runtime").execute(function(a){P.declare("xcp:@xcp/runtime",a)}));b.mixTimeout||(b.mixTimeout=function(a,
+e,d){b.mixCardInitTimeouts||(b.mixCardInitTimeouts={});b.mixCardInitTimeouts[e]&&clearTimeout(b.mixCardInitTimeouts[e]);b.mixCardInitTimeouts[e]=setTimeout(function(){P.log("Client-side initialization timeout","WARN",a)},d)});b.mix_csa_map=b.mix_csa_map||{};b.mix_csa_internal=b.mix_csa_internal||function(a,e,d){return b.mix_csa_map[e]=b.mix_csa_map[e]||b.csa(a,d)};b.mix_csa_internal_key=b.mix_csa_internal_key||function(a,b){for(var d="",e=0;e<b.length;e++){var c=b[e];void 0!==a[c]&&"object"!==typeof a[c]&&
+(d+=c+":"+a[c]+",")}if(!d)throw Error("bad mix-csa key gen.");return d};b.mix_csa_event=b.mix_csa_event||function(a){try{var e=b.mix_csa_internal_key(a,["producerId"])}catch(d){return P.logError(d,"MIX C005","WARN",void 0),function(){}}try{return b.mix_csa_internal("Events",e,a)}catch(d){return P.logError(d,"MIX C004","WARN",e),function(){}}};b.mix_csa=b.mix_csa||function(a,e){try{e=e||"";var d=document.querySelectorAll(a);if(1<d.length)for(var h=0;h<d.length;h++){if(d[h].querySelector(e)){var c=
+d[h];break}}else 1===d.length&&(c=d[0]);if(!c)throw Error(" ");return b.mix_csa_internal("Content",a,{element:c})}catch(r){return P.logError(r,"MIX C004","WARN",a),function(){}}}})(window);
+(window.AmazonUIPageJS ? AmazonUIPageJS : P).when('sp.load.js').execute(function() {
+  (window.AmazonUIPageJS ? AmazonUIPageJS : P).load.js('https://m.media-amazon.com/images/I/61xJcNKKLXL.js?AUIClients/AmazonUIjQuery');
+  (window.AmazonUIPageJS ? AmazonUIPageJS : P).load.js('https://m.media-amazon.com/images/I/11I0WXrZVoL._RC|11Y+5x+kkTL.js,51DFoGfFeXL.js,115zbyk371L.js,11GgN1+C7hL.js,01+z+uIeJ-L.js,01VRMV3FBdL.js,21NadQlXUWL.js,01vRf9id2EL.js,31on-La90vL.js,11a7qqY8xXL.js,11PZSUl3FLL.js,51C4kaFbiAL.js,11FhdH2HZwL.js,11wb9K3sw0L.js,11BrgrMAHUL.js,11GPhx42StL.js,210X-JWUe-L.js,01Svfxfy8OL.js,61lbT4bHNWL.js,01ikBbTAneL.js,31xywoXPfpL.js,01qXJuwGmxL.js,01WlsjNmqIL.js,11F929pmpYL.js,31Zn4S+IOkL.js,01rpauTep4L.js,31rqCOnXDNL.js,011FfPwYqHL.js,21P5VvHf-XL.js,01-E15R8CKL.js,21kN0q4IA-L.js,01VvIkYCafL.js,11vb6P5C5AL.js,01Od3PfWdaL.js_.js?AUIClients/AmazonUI');
+  (window.AmazonUIPageJS ? AmazonUIPageJS : P).load.js('https://m.media-amazon.com/images/I/516npEhK50L.js?AUIClients/CardJsRuntimeBuzzCopyBuild');
+});
+</script>
+<!-- sp:end-feature:aui-assets -->
+<!-- sp:feature:nav-agent-metadata -->
+      <style id="agent-styles">
+      /* CRITICAL FIX: Opacity > 0 for technical clickability. */
+      #nav-search-submit-text-agent, #nav-search-submit-button-agent {
+        opacity: 0.001 !important;
+        pointer-events: auto !important;
+        cursor: default !important;
+        background: transparent !important;
+        border: none !important;
+        outline: none !important;
+        z-index: 9999 !important;
+      }
+
+      #nav-search-submit-button-agent:hover, #nav-search-submit-button-agent:focus {
+        background: transparent !important;
+      }
+
+      /* *** FIX 2: Force PERMANENT transparency on the parent containers. *** */
+      #nav-search, #nav-search-bar-form {
+        background-color: transparent !important;
+        background: transparent !important;
+        border: none !important;
+        box-shadow: none !important;
+      }
+
+      /* *** FIX 3: Keep the focus transparency rule (using :has is safer) *** */
+      #nav-search:has(#twotabsearchtextbox:focus), #nav-search-bar-form:has(#twotabsearchtextbox:focus) {
+        background-color: transparent !important;
+        background: transparent !important;
+        border: none !important;
+        box-shadow: none !important;
+      }
+
+      #nav-search:hover, #nav-search.nav-active, #nav-search-bar-form:hover, #nav-search-bar-form:focus-within {
+        border-color: transparent !important;
+        box-shadow: none !important;
+      }
+      </style>
+      <script id="agent-semantic-map" type="application/agent+json">
+      {
+        "@context": "https://agent.schema.org",
+        "@type": "AgentInterfaceMap",
+        "pageType": "product-listing",
+        "primaryActions": [
+          {
+            "id": "search_agent",
+            "action": "search",
+            "selector": "#nav-search-submit-button-agent",
+            "description": "AI-optimized search submission",
+            "inputSelector": "#twotabsearchtextbox",
+            "priority": "primary",
+            "recommended": true,
+            "visibility": "visually-hidden"
+          }
+        ],
+        "suggestions": {
+          "preferredSearchMode": "agent",
+          "agentButton": "#nav-search-submit-button-agent"
+        }
+      }
+      </script>
+<!-- sp:end-feature:nav-agent-metadata -->
+<!-- sp:feature:nav-inline-css -->
+<!-- NAVYAAN CSS -->
+
+<style type="text/css">
+.nav-sprite-v1 .nav-sprite, .nav-sprite-v1 .nav-icon {
+  background-image: url(https://m.media-amazon.com/images/G/01/gno/sprites/nav-sprite-global-1x-reorg-privacy._CB779528203_.png);
+  background-position: 0 1000px;
+  background-repeat: repeat-x;
+}
+.nav-spinner {
+  background-image: url(https://m.media-amazon.com/images/G/01/javascripts/lib/popover/images/snake._CB485935611_.gif);
+  background-position: center center;
+  background-repeat: no-repeat;
+}
+.nav-timeline-icon, .nav-access-image, .nav-timeline-prime-icon {
+  background-image: url(https://m.media-amazon.com/images/G/01/gno/sprites/timeline_sprite_1x._CB485945973_.png);
+  background-repeat: no-repeat;
+}
+</style>
+<link rel="stylesheet" href="https://m.media-amazon.com/images/I/51waPb-h-9L._RC|71rJTBWm2GL.css,41WcY5PbsbL.css,61p+Jc2B9kL.css,51Z1WqjT15L.css,31wmH1IMCGL.css,01FcI3FsaiL.css,21Hc1s0-E4L.css,31YZpDCYJPL.css,21DwGGPS1eL.css,41vWFCvFunL.css,21CB9R4dxNL.css,111Bp55OByL.css,01Acb9NWohL.css,21KQnzhmfTL.css,41bqNBi+QSL.css,61f0dQ2ffRL.css,01NLp3ZKNoL.css_.css?AUIClients/NavDesktopUberAsset#desktop.us.1173010-T1.1381529-T1.1253326-T1.1236111-T1.1346270-T1" />
+<!-- sp:end-feature:nav-inline-css -->
+<!-- sp:feature:host-assets -->
+
+
+
+
+
+
+
+<link rel="stylesheet" href="https://m.media-amazon.com/images/I/012E12eduRL.css?AUIClients/F3PostOrderWidgetAssets-orderSummary" />
+<link rel="stylesheet" href="https://m.media-amazon.com/images/I/018uy0Bl9DL.css?AUIClients/F3PostOrderWidgetAssets-destinationInfo" />
+<link rel="stylesheet" href="https://m.media-amazon.com/images/I/01KYCwnRHfL.css?AUIClients/F3PostOrderWidgetAssets-progressTracker" />
+<link rel="stylesheet" href="https://m.media-amazon.com/images/I/01em6sCeaoL.css?AUIClients/F3PostOrderWidgetAssets-itemList" />
+<link rel="stylesheet" href="https://m.media-amazon.com/images/I/01cet1YhGyL.css?AUIClients/F3PostOrderWidgetAssets-helpLinks" />
+<link rel="stylesheet" href="https://m.media-amazon.com/images/I/013p00Lkg0L.css?AUIClients/F3PostOrderDetailsPageAssets-orderDetailsPage" />
+<link rel="stylesheet" href="https://m.media-amazon.com/images/I/01P7ieND0lL.css?AUIClients/F3PostOrderDetailsPageAssets-importantMessageBox" />
+
+<script>
+  (window.AmazonUIPageJS ? AmazonUIPageJS : P).load.js('https://m.media-amazon.com/images/I/01xhQ+j47xL.js?AUIClients/F3PostOrderWidgetAssets-orderSummary');
+  (window.AmazonUIPageJS ? AmazonUIPageJS : P).load.js('https://m.media-amazon.com/images/I/110qC0rUboL.js?AUIClients/F3PostOrderWidgetAssets-destinationInfo');
+  (window.AmazonUIPageJS ? AmazonUIPageJS : P).load.js('https://m.media-amazon.com/images/I/31ZlLUACyEL.js?AUIClients/F3PostOrderWidgetAssets-progressTracker');
+  (window.AmazonUIPageJS ? AmazonUIPageJS : P).load.js('https://m.media-amazon.com/images/I/01P9F1lVywL.js?AUIClients/F3PostOrderWidgetAssets-itemList');
+  (window.AmazonUIPageJS ? AmazonUIPageJS : P).load.js('https://m.media-amazon.com/images/I/21zlRCNSqbL.js?AUIClients/F3PostOrderWidgetAssets-helpLinks');
+  (window.AmazonUIPageJS ? AmazonUIPageJS : P).load.js('https://m.media-amazon.com/images/I/11ehJm2AD9L.js?AUIClients/F3PostOrderDetailsPageAssets-orderDetailsPage');
+  (window.AmazonUIPageJS ? AmazonUIPageJS : P).load.js('https://m.media-amazon.com/images/I/310C6325fJL.js?AUIClients/F3PostOrderDetailsPageAssets-importantMessageBox');
+  (window.AmazonUIPageJS ? AmazonUIPageJS : P).load.js('https://m.media-amazon.com/images/I/213RdmhF14L.js?AUIClients/F3PostOrderWidgetAssets-utility');
+  (window.AmazonUIPageJS ? AmazonUIPageJS : P).load.js('https://m.media-amazon.com/images/I/31jdfgcsPAL.js?AUIClients/AmazonUIFormControlsJS');
+</script>
+
+
+
+<title dir="ltr">Order Details</title>
+
+<!--&&&Portal&Delimiter&&&--><!-- sp:end-feature:host-assets -->
+<!-- sp:feature:encrypted-slate-token -->
+<meta name='encrypted-slate-token' content='AnYxfDLTr5S4THalouHQuERBJKxwmIkUKQZZoHQQegsQDJ6rh+I/Z0ScQI5X8555A1zflQkcvYi5WVwtvhEe3/mUhCZuIUxlzw9p+yjwTjcxk3lJn40hciecU4GhcfhaPAI0OKyaTMlV68ei/5nKSuHWl7zCS3UcjocITm8Og3Moh9hLmtR+Dt749TQiszAM18GWbEjuX08xZJjdizYZKVAqptzLFh/GTWZTGADffztGAB4ZIS8gGF43BXsbT4RktQK0vxZplpf7EfRLnNWYCLtcF+x6em9UfPMfFkVASVs2VgzYk5utrZkyP8HD4eXFc9Z2v2c1f03BQsqkngqP1wmFOicaGtoH'>
+<!-- sp:end-feature:encrypted-slate-token -->
+<!-- sp:feature:bidi-endpoint -->
+<meta name='bidi-endpoint' content='ws.ep-e908141b0.bidi.amazon.dev'>
+<!-- sp:end-feature:bidi-endpoint -->
+<!-- sp:feature:flow-closure-id -->
+<meta name='flow-closure-id' content='1780935494'>
+<!-- sp:end-feature:flow-closure-id -->
+<!-- sp:feature:csm:head-close -->
+<script type='text/javascript'>
+window.ue_ihe = (window.ue_ihe || 0) + 1;
+if (window.ue_ihe === 1) {
+(function(k,l,g){function m(a){c||(c=b[a.type].id,"undefined"===typeof a.clientX?(e=a.pageX,f=a.pageY):(e=a.clientX,f=a.clientY),2!=c||h&&(h!=e||n!=f)?(r(),d.isl&&l.setTimeout(function(){p("at",d.id)},0)):(h=e,n=f,c=0))}function r(){for(var a in b)b.hasOwnProperty(a)&&d.detach(a,m,b[a].parent)}function s(){for(var a in b)b.hasOwnProperty(a)&&d.attach(a,m,b[a].parent)}function t(){var a="";!q&&c&&(q=1,a+="&ui="+c);return a}var d=k.ue,p=k.uex,q=0,c=0,h,n,e,f,b={click:{id:1,parent:g},mousemove:{id:2,
+parent:g},scroll:{id:3,parent:l},keydown:{id:4,parent:g}};d&&p&&(s(),d._ui=t)})(ue_csm,window,document);
+
+
+(function(s,l){function m(b,e,c){c=c||new Date(+new Date+t);c="expires="+c.toUTCString();n.cookie=b+"="+e+";"+c+";path=/"}function p(b){b+="=";for(var e=n.cookie.split(";"),c=0;c<e.length;c++){for(var a=e[c];" "==a.charAt(0);)a=a.substring(1);if(0===a.indexOf(b))return decodeURIComponent(a.substring(b.length,a.length))}return""}function q(b,e,c){if(!e)return b;-1<b.indexOf("{")&&(b="");for(var a=b.split("&"),f,d=!1,h=!1,g=0;g<a.length;g++)f=a[g].split(":"),f[0]==e?(!c||d?a.splice(g,1):(f[1]=c,a[g]=
+f.join(":")),h=d=!0):2>f.length&&(a.splice(g,1),h=!0);h&&(b=a.join("&"));!d&&c&&(0<b.length&&(b+="&"),b+=e+":"+c);return b}var k=s.ue||{},t=3024E7,n=ue_csm.document||l.document,r=null,d;a:{try{d=l.localStorage;break a}catch(u){}d=void 0}k.count&&k.count("csm.cookieSize",document.cookie.length);k.cookie={get:p,set:m,updateCsmHit:function(b,e,c){try{var a;if(!(a=r)){var f;a:{try{if(d&&d.getItem){f=d.getItem("csm-hit");break a}}catch(k){}f=void 0}a=f||p("csm-hit")||"{}"}a=q(a,b,e);r=a=q(a,"t",+new Date);
+try{d&&d.setItem&&d.setItem("csm-hit",a)}catch(h){}m("csm-hit",a,c)}catch(g){"function"==typeof l.ueLogError&&ueLogError(Error("Cookie manager: "+g.message),{logLevel:"WARN"})}}}})(ue_csm,window);
+
+
+(function(l,e){function c(b){b="";var c=a.isBFT?"b":"s",d=""+a.oid,g=""+a.lid,h=d;d!=g&&20==g.length&&(c+="a",h+="-"+g);a.tabid&&(b=a.tabid+"+");b+=c+"-"+h;b!=f&&100>b.length&&(f=b,a.cookie?a.cookie.updateCsmHit(m,b+("|"+ +new Date)):e.cookie="csm-hit="+b+("|"+ +new Date)+n+"; path=/")}function p(){f=0}function d(b){!0===e[a.pageViz.propHid]?f=0:!1===e[a.pageViz.propHid]&&c({type:"visible"})}var n="; expires="+(new Date(+new Date+6048E5)).toGMTString(),m="tb",f,a=l.ue||{},k=a.pageViz&&a.pageViz.event&&
+a.pageViz.propHid;a.attach&&(a.attach("click",c),a.attach("keyup",c),k||(a.attach("focus",c),a.attach("blur",p)),k&&(a.attach(a.pageViz.event,d,e),d({})));a.aftb=1})(ue_csm,ue_csm.document);
+
+
+ue_csm.ue.stub(ue,"impression");
+
+
+ue.stub(ue,"trigger");
+
+
+if(window.ue&&uet) { uet('bb'); }
+
+}
+</script>
+<script>window.ue && ue.count && ue.count('CSMLibrarySize', 2728)</script>
+<!-- sp:end-feature:csm:head-close -->
+<!-- sp:feature:head-close -->
+<script>
+window.P && P.register('bb');
+if (typeof ues === 'function') {
+  ues('t0', 'portal-bb', new Date());
+  ues('ctb', 'portal-bb', 1);
+}
+</script>
+</head><!-- sp:end-feature:head-close -->
+<!-- sp:feature:start-body -->
+<body class="a-m-us a-aui_72554-c a-aui_template_weblab_cache_333406-c"><div id="a-page"><script type="a-state" data-a-state="{&quot;key&quot;:&quot;a-wlab-states&quot;}">{"AUI_72554":"C","AUI_TEMPLATE_WEBLAB_CACHE_333406":"C"}</script><script>typeof uex === 'function' && uex('ld', 'portal-bb', {wb: 1})</script><!-- sp:end-feature:start-body -->
+<!-- sp:feature:csm:body-open -->
+
+
+<script>
+!function(){function n(n,t){var r=i(n);return t&&(r=r("instance",t)),r}var r=[],c=0,i=function(t){return function(){var n=c++;return r.push([t,[].slice.call(arguments,0),n,{time:Date.now()}]),i(n)}};n._s=r,this.csa=n}();;
+csa('Config', {});
+if (window.csa) {
+    csa("Config", {
+        'Application': 'Retail:Prod:www.amazon.com',
+        'Events.Namespace': 'csa',
+        'ObfuscatedMarketplaceId': 'ATVPDKIKX0DER',
+        'Events.SushiEndpoint': 'https://unagi.amazon.com/1/events/com.amazon.csm.csa.prod',
+        'Events.SushiCsaVIP': 'unagi.amazon.com',
+        'Events.SushiCsaSourceGroup': 'com.amazon.csm.csa.prod',
+        'Events.SushiCsaCustomSourceGroup': 'com.amazon.csm.customsg.prod',
+        'Events.SushiEndpointPattern': 'https://%s/1/events/%s',
+        'CacheDetection.RequestID': "0B5GGA052RDJB96RMAEG",
+        'CacheDetection.Callback': window.ue && ue.reset,
+        'Transport.nonBatchSchema': "csa.UEData.4",
+        'LCP.elementDedup': 1,
+        'lob': '1'
+    });
+
+    csa("Events")("setEntity", {
+        page: {requestId: "0B5GGA052RDJB96RMAEG", meaningful: "interactive"},
+        session: {id: "147-7999693-6862434"}
+    });
+}
+!function(e){var i,r,o="splice",u=e.csa,f={},c={},a=e.csa._s,l=0,s=0,g=-1,h={},d={},p={},n=Object.keys,v=function(){};function t(n,t){return u(n,t)}function w(n,t){var e=c[n]||{};k(e,t),c[n]=e,s++,D(I,0)}function b(n,t,e){var r=!0;return t=U(t),e&&e.buffered&&(r=(p[n]||[]).every(function(n){return!1!==t(n)})),r?(h[n]||(h[n]=[]),h[n].push(t),function(){!function(n,t){var e=h[n];e&&e[o](e.indexOf(t),1)}(n,t)}):v}function m(n,t){if(t=U(t),n in d)return t(d[n]),v;return b(n,function(n){return t(n),!1})}function y(n,t){if(u("Errors")("logError",n),f.DEBUG)throw t||n}function E(){return[S(),S(),S(),S()].join("-")}function S(){return Math.abs(4294967295*Math.random()|0).toString(36)}function U(n,t){return function(){try{return n.apply(this,arguments)}catch(n){y(n.message||n,n)}}}function D(n,t){return e.setTimeout(U(n),t)}function I(){for(var n=0;n<a.length;){var t=a[n],e=t[0]in c;if(!e&&!r)return void(l=a.length);e?(a[o](l=n,1),O(t)):n++}g=s}function O(n){var t=c[n[0]],e=n[1],r=e[0];if(!t||!t[r])return y("Undefined function: "+t+"/"+r);i=n[3],c[n[2]]=t[r].apply(t,e.slice(1))||{},i=0}function C(){r=1,I()}function k(t,e){n(e).forEach(function(n){t[n]=e[n]})}m("$beforeunload",C),w("Config",{instance:function(n){k(f,n)}}),u.plugin=U(function(n){n(t)}),t.config=f,t.register=w,t.on=b,t.once=m,t.blank=v,t.emit=function(n,t,e){for(var r=h[n]||[],i=0;i<r.length;)!1===r[i](t)?r[o](i,1):i++;d[n]=t||{},e&&e.buffered&&(p[n]||(p[n]=[]),100<=p[n].length&&p[n].shift(),p[n].push(t||{}))},t.UUID=E,t.generateNewRequestId=function(){return E().toUpperCase().replace(/-/g,"").slice(0,20)},t.time=function(n){var t=i?new Date(i.time):new Date;return"ISO"===n?t.toISOString():t.getTime()},t.error=y,t.warn=function(n,t){if(u("Errors")("logWarn",n),f.DEBUG)throw t||n},t.exec=U,t.timeout=D,t.interval=function(n,t){return e.setInterval(U(n),t)},(t.global=e).csa._s.push=function(n){n[0]in c&&(!a.length||r)?(O(n),a.length&&g!==s&&I()):a[o](l++,0,n)},I(),f["StubCalls.Cleanup.Onload"]&&m("$load",C),D(function(){D(C,f.SkipMissingPluginsTimeout||5e3)},1)}("undefined"!=typeof window?window:global);csa.plugin(function(o){var f="addEventListener",e="requestAnimationFrame",t=o.exec,r=o.global,u=o.on;o.raf=function(n){if(r[e])return r[e](t(n))},o.on=function(n,e,t,r){if(n&&"function"==typeof n[f]){var i=o.exec(t);return n[f](e,i,r),function(){n.removeEventListener(e,i,r)}}return"string"==typeof n?u(n,e,t,r):o.blank}});csa.plugin(function(o){var t,n,r={},e="localStorage",c="sessionStorage",a="local",i="session",u=o.exec;function s(e,t){var n;try{r[t]=!!(n=o.global[e]),n=n||{}}catch(e){r[t]=!(n={})}return n}function f(){t=t||s(e,a),n=n||s(c,i)}function l(e){return e&&e[i]?n:t}o.store=u(function(e,t,n){f();var o=l(n);return e?t?void(o[e]=t):o[e]:Object.keys(o)}),o.storageSupport=u(function(){return f(),r}),o.deleteStored=u(function(e,t){f();var n=l(t);if("function"==typeof e)for(var o in n)n.hasOwnProperty(o)&&e(o,n[o])&&delete n[o];else delete n[e]})});csa.plugin(function(n){n.types={ovl:function(n){var r=[];if(n)for(var i in n)n.hasOwnProperty(i)&&r.push(n[i]);return r}}});csa.plugin(function(a){var e=a.config,t=a.global,r=t.location||{},n=r.host,o=t.document||{},l=e.Application||"Other"+(n?":"+n:""),s="UEData",i=e["KillSwitch."+s],c=e["Transport.AnonymizeRequests"]||!1,f=e.RedactPath||!1,p="csa.UEData.4",u="csa",g=a("Transport");i||a.register(s,{log:function(e){if(function(e){return!e||"object"==typeof e&&0===Object.keys(e).length}(e))a.warn("Received empty or null uedata input");else{var t=function(t){var n={schemaId:p,timestamp:a.time("ISO"),producerId:u,messageId:a.UUID(),application:l,url:f?r.protocol+"//"+r.hostname:c?r.href.split("?")[0]:r.href,referrer:f?"":c?o.referrer.split("?")[0]:o.referrer};if(["eventName","lob","ifr","id","csmtags","viz","sessionId","obfuscatedMarketplaceId"].forEach(function(e){null!=t[e]&&(n[e]=t[e])}),["pty","spty","pti"].forEach(function(e){null!=t[e]&&(n.pageInfo=n.pageInfo||{},n.pageInfo[e]=t[e])}),t.latency&&t.latency.t&&(n.t=t.latency.t+""),null!=t.browserData){var e=t.browserData.indexOf("?");-1!=e&&(n.browserData=t.browserData.substring(1+e))}return n.clientRequestId=a.generateNewRequestId(),n}(e);!function(e){return e.pageInfo&&null!=e.pageInfo.pty&&null!=e.pageInfo.spty&&null!=e.pageInfo.pti&&(e.viz&&0<e.viz.length||e.csmtags&&0<e.csmtags.length)}(t)?g("log",t):g("log",t,{forceSend:!0})}}})});csa.plugin(function(a){var e=a.config,n="Errors",c="fcsmln",s=e["KillSwitch."+n];function r(n){return function(e){a("Metrics",{producerId:"csa",dimensions:{message:e}})("recordMetric",n,1)}}function t(r){var t,o,l=a("Events",{producerId:r.producerId,lob:e.lob||"0"}),i=["name","type","csm","adb"],u={url:"pageURL",file:"f",line:"l",column:"c"};this.log=function(e){if(!s&&!function(e){if(!e)return!0;for(var n in e)return!1;return!0}(e)){var n=r.logOptions||{ent:{page:["pageType","subPageType","requestId"]}};l("log",function(n){return t=a.UUID(),o={messageId:t,schemaId:r.schemaId||"<ns>.Error.6",errorMessage:n.m||null,attribution:n.attribution||null,logLevel:"FATAL",url:null,file:null,line:null,column:null,stack:n.s||[],context:n.cinfo||{},metadata:{}},n.logLevel&&(o.logLevel=""+n.logLevel),i.forEach(function(e){n[e]&&(o.metadata[e]=n[e])}),c in n&&(o.metadata[c]=n[c]+""),"INFO"===n.logLevel||Object.keys(u).forEach(function(e){"number"!=typeof n[u[e]]&&"string"!=typeof n[u[e]]||(o[e]=""+n[u[e]])}),o}(e),n)}}}a.register(n,{instance:function(e){return new t(e||{})},logError:r("jsError"),logWarn:r("jsWarn")})});csa.plugin(function(o){var r,e,n,t,a,i="function",u="willDisappear",c="$app.",f="$document.",p="focus",s="blur",d="active",l="resign",$=o.global,m=o.exec,b=o.config,h=b["Transport.AnonymizeRequests"]||!1,g=b.RedactPath||!1,v=o("Events"),y=$.location,P=$.document||{},w=$.P||{},k=(($.performance||{}).navigation||{}).type,E=o.on,T=o.emit,I=P.hidden,A={};y&&P&&(E($,"beforeunload",S),E($,"pagehide",S),E(P,"visibilitychange",j(f,function(){return P.visibilityState||"unknown"})),E(P,p,j(f+p)),E(P,s,j(f+s)),w.when&&w.when("mash").execute(function(e){e&&(E(e,"appPause",j(c+"pause")),E(e,"appResume",j(c+"resume")),j(c+"deviceready")(),$.cordova&&$.cordova.platformId&&j(c+cordova.platformId)(),E(P,d,j(c+d)),E(P,l,j(c+l)))}),e=$.app||{},n=m(function(){T(c+"willDisappear"),S()}),a=typeof(t=e[u])==i,e[u]=m(function(){n(),a&&t()}),$.app||($.app=e),"complete"===P.readyState?R():E($,"load",R),I?x():U(),o.on("$app.blur",x),o.on("$app.focus",U),o.on("$document.blur",x),o.on("$document.focus",U),o.on("$document.hidden",x),o.on("$document.visible",U),o.register("SPA",{newPage:D}),D({transitionType:{0:"hard",1:"refresh",2:"back-button"}[k]||"unknown"}));function D(n,e){var t=!!r,a=(e=e||{}).keepPageAttributes;t&&(T("$beforePageTransition"),T("$pageTransition")),t&&!a&&v("removeEntity","page"),r=o.UUID(),a?A.id=r:A={schemaId:"<ns>.PageEntity.2",id:r,url:g?y.protocol+"//"+y.hostname:h?y.href.split("?")[0]:y.href,server:y.hostname,path:g?"":y.pathname,referrer:g?"":h?P.referrer.split("?")[0]:P.referrer,title:P.title},Object.keys(n||{}).forEach(function(e){A[e]=n[e]}),v("setEntity",{page:A}),T("$pageChange",A,{buffered:1}),t&&T("$afterPageTransition")}function R(){T("$load"),T("$ready"),T("$afterload")}function S(){T("$ready"),T("$beforeunload"),T("$unload"),T("$afterunload")}function x(){I||(T("$visible",!1,{buffered:1}),I=!0)}function U(){I&&(T("$visible",!0,{buffered:1}),I=!1)}function j(n,t){return m(function(){var e=typeof t==i?n+t():n;T(e)})}});csa.plugin(function(f){var e="Events",n="UNKNOWN",s="id",o="all",l="sushiSourceGroup",i="copyBaseMetadata",r="copyEntities",c="messageId",a="timestamp",d="producerId",u="application",p="obfuscatedMarketplaceId",g="entities",y="page",h="requestId",v="pageType",b="subPageType",O="schemaId",m="version",I="attributes",E="<ns>",S="lob",k=f.config["Events.SushiCsaSourceGroup"],A="session",T=f.config,t=f.global,U=t.Object.keys,j=(t.location||{}).host,w=T["KillSwitch.PageEntity"],x=T[e+".Namespace"]||"csa_other",N=x+".",q=T.Application||"Other"+(j?":"+j:""),D=T["Transport.AnonymizeRequests"]||!1,K=f("Transport"),M={},P=function(e,t){Object.keys(e).forEach(t)};function _(n,i,r){P(i,function(e){var t=r===o||(r||{})[e];e in n||(n[e]={version:1,id:i[e][s]||f.UUID()}),G(n[e],i[e],t)})}function G(t,n,i){P(n,function(e){!function(e,t,n){return"string"!=typeof t&&e!==m?f.error("Attribute is not of type string: "+e):!0===n||1===n||(e===s||!!~(n||[]).indexOf(e))}(e,n[e],i)||(t[e]=n[e])})}function z(r,e,o){P(e,function(t){var e=r[t];if(!(e[O]&&~e[O].indexOf("PageEntity")&&w)&&e[O]){var n={},i={};n[s]=e[s],n[d]=e[d]||o[d],n[O]=e[O],n[m]=e[m]++,n[I]=i,B(n,o),G(i,e,1),C(i),t===y&&(n.__backfill=function(e){!function(e,t,n,i){if(e&&e[O]&&e[O]!==n&&!e[O].indexOf(N)){var r=e[g];if(r&&r[i]&&r[i][s]===t[s]){var o=r[i],c=U(o);c.push(h),c.push(v),c.push(b),G(o,t,c)}}}(e,i,n[O],t)}),K("log",n)}})}function B(e,t){e[a]=function(e){return"number"==typeof e&&(e=new Date(e).toISOString()),e||f.time("ISO")}(e[a]),e[c]=e[c]||f.UUID(),e[u]=q,e[p]=T.ObfuscatedMarketplaceId||n,O in e&&(e[O]=e[O].replace(E,x)),t&&t[S]&&(e[S]=t[S])}function C(e){delete e[m],delete e[O],delete e[d]}function R(t){var c={},s=!!t[l]&&t[l]!==k,a=!!t[i],u=!!t[r];this.log=function(i,e){var n={},r=(e||{}).ent;if(!i)return f.error("The event cannot be undefined");var o=i[g];if(s)a&&B(i,t),u&&(_(n,M,r),_(n,c,r));else{if("string"!=typeof i[O])return f.error("A valid schema id is required for the event");B(i,t),_(n,M,r),_(n,c,r)}i[d]=t[d],s?(o||u&&0<Object.keys(n).length)&&(i[g]={},o&&P(o,function(t){var n=r&&r[t];i[g][t]={},P(o[t],function(e){(!n||!0===n||Array.isArray(n)&&~n.indexOf(e))&&(i[g][t][e]=o[t][e])})}),u&&0<Object.keys(n).length&&P(n,function(t){i[g][t]||(i[g][t]={}),P(n[t],function(e){e in i[g][t]||(i[g][t][e]=n[t][e])}),C(i[g][t])})):s||(_(n,o||{},r),P(n,function(e){C(n[e])}),i[g]=n),e&&e[S]&&(i[S]=e[S]),(e=e||{})[l]||(e[l]=t[l]||k),K("log",i,e)},this.setEntity=function(e){D&&delete e[A],_(c,e,o),z(c,e,t)}}!T["KillSwitch."+e]&&U&&f.register(e,{setEntity:function(e){D&&delete e[A],f.emit("$entities.set",e,{buffered:1}),_(M,e,o),z(M,e,{producerId:"csa",lob:T[S]||"0"})},removeEntity:function(e){delete M[e]},instance:function(e){return new R(e)}})});csa.plugin(function(p){var a,h="Transport",l="post",f="preflight",c="csa.cajun.",i="store",u="deleteStored",s="sendBeacon",n="__merge",t="__backfill",e=".FlushInterval",g="sushiSourceGroup",v=p.config["Events.SushiCsaSourceGroup"],y="function",d=0,m=p.config[h+".BufferSize"]||2e3,E=p.config[h+".RetryDelay"]||1500,S=p.config[h+".AnonymizeRequests"]||!1,b=p.config[h+".nonBatchSchema"]||"",k={},G=0,I=[],R=p.global,o=R.document,w=p.timeout,A=p.emit,B=R.Object.keys,r=p.config[h+e]||5e3,O=r,j=p.config[h+e+".BackoffFactor"]||1,D=p.config[h+e+".BackoffLimit"]||3e4,T=0,U=0,$=0;function _(o,r){if(864e5<p.time()-+new Date(o.timestamp))return p.warn("Event is too old: "+o);if((r=r||{}).forceSend&&b&&b===o.schemaId)I.forEach(function(e){if(e.accepts(o,r)){var n=e.post?e:null;n&&C(n,[o],r[g]||v)}});else if(G<m){typeof o[t]==y&&(U||$||B(k).forEach(function(e){o[t](k[e].event)}),delete o[t]);var e=o.messageId||p.UUID();e in k||(k[e]={event:o,options:r},G++),typeof o[n]==y&&(r[g]||v)===(((k[e]||{}).options||{})[g]||v)&&o[n](k[e].event),!T&&d&&(T=w(q,function(){var e=O;return O=Math.min(e*j,D),e}()))}}function q(){var r={};B(k).forEach(function(e){var n=k[e],o=n.options&&n.options[g]||v;r[o]||(r[o]=[]),r[o].push(n.event)}),B(r).forEach(function(e){!function(o,r){I.forEach(function(n){var e=r.filter(function(e){return n.accepts(e,{sushiSourceGroup:o})});0<e.length&&(n.chunks?n.chunks(e,o):[e]).forEach(function(e){n[l]&&C(n,e,o)})})}(e,r[e])}),k={},T=0,U+=1,A("$transport.flushed")}function C(n,o,r){function t(){p[u](c+e)}var e=p.UUID();p[i](c+e,JSON.stringify({events:o,sourceGroup:r})),[function(e,n,o,r){var t=R.navigator||{},c=R.cordova||{};if(S)return 0;if(!t[s]||!e[l])return 0;e[f]&&c&&"ios"===c.platformId&&!a&&((new Image).src=e[f]().url,a=1);var i=e[l](n,o);if(!i.type&&t[s](i.url,i.body))return r(),1},function(e,n,o,r){var t=e[l](n,o),c=t.url,i=t.body,a=t.type,f=new XMLHttpRequest,u=0;function s(e,n,o){f.open("POST",e),f.withCredentials=!S,o&&f.setRequestHeader("Content-Type",o),f.send(n)}return f.onload=function(){f.status<299?r():p.config[h+".XHRRetries"]&&u<3&&w(function(){s(c,i,a)},++u*E)},s(c,i,a),1}].some(function(e){try{return e(n,o,r,t)}catch(e){}})}B&&(p.once("$afterload",function(){$=d=1,function(t){(p[i]()||[]).forEach(function(e){if(!e.indexOf(c))try{var n=p[i](e);p[u](e);var o=JSON.parse(n);if(o&&"object"==typeof o&&!Array.isArray(o))try{if(o.events&&o.sourceGroup){var r=o.sourceGroup;o.events.forEach(function(e){t(e,{sushiSourceGroup:r})})}}catch(e){p.error("Error processing backup object format: "+e.message)}else if(Array.isArray(o))try{o.forEach(t)}catch(e){p.error("Error processing array format backup: "+e.message)}}catch(e){p.error(e)}})}(_),p.on(o,"visibilitychange",q,!1),q()}),p.once("$afterunload",function(){d=1,q()}),p.on("$afterPageTransition",function(){G=0,O=r}),p.register(h,{log:_,register:function(e){I.push(e)}}))});csa.plugin(function(n){var u=n.config["Events.SushiEndpoint"],t=n.config["Events.SushiCsaSourceGroup"];n("Transport")("register",{accepts:function(n,r){return!(!n||!r)&&(n.schemaId&&(!r.sushiSourceGroup||r.sushiSourceGroup===t))},post:function(n){var r=n.map(function(n){return{data:n}});return{url:u,body:JSON.stringify({events:r})}},preflight:function(){var n,r=/\/\/(.*?)\//.exec(u);return r&&r[1]&&(n="https://"+r[1]+"/ping"),{url:n}},chunks:function(n){for(var r=[];500<n.length;)r.push(n.splice(0,500));return r.push(n),r}})});csa.plugin(function(u){var e=u.config["Events.SushiEndpoint"],t=u.config["Events.SushiCsaSourceGroup"],s=u.config["Events.SushiCsaVIP"],i=u.config["Events.SushiEndpointPattern"];u("Transport")("register",{accepts:function(n,r){return!(!n||!r)&&(!!r.sushiSourceGroup&&r.sushiSourceGroup!==t)},post:function(n,r){var t=n.map(function(n){return{data:n}});return{url:function(n){var r=e;n&&(r=function(n){var r=Array.prototype.slice.call(arguments,1),t=(n.match(/%s/g)||[]).length;r.length<t&&u.warn("Warning: More placeholders ("+t+") than arguments ("+r.length+")");var e=0;return n.replace(/%s/g,function(){return e<r.length?r[e++]:""})}(i,s,n));return r}(r),body:JSON.stringify({events:t})}},preflight:function(){var n,r=/\/\/(.*?)\//.exec(e);return r&&r[1]&&(n="https://"+r[1]+"/ping"),{url:n}},chunks:function(n){for(var r=[];500<n.length;)r.push(n.splice(0,500));return r.push(n),r}})});csa.plugin(function(n){var t,a,o,r,e=n.config,i="PageViews",d=e[i+".ImpressionMinimumTime"]||1e3,s="hidden",c="innerHeight",l="innerWidth",g="renderedTo",f=g+"Viewed",m=g+"Meaningful",u=g+"Impressed",p=1,h=2,v=3,w=4,P=5,y="loaded",I=7,b=8,T=n.global,S=n.on,E=n("Events",{producerId:"csa",lob:e.lob||"0"}),K=T.document,V={},$={},M=P,R=e["KillSwitch."+i],H=e["KillSwitch.PageRender"],W=e["KillSwitch.PageImpressed"];function j(e){if(!V[I]){if(V[e]=n.time(),e!==v&&e!==y||(t=t||V[e]),t&&M===w){if(a=a||V[e],!R)(i={})[m]=t-o,i[f]=a-o,k("PageView.5",i);r=r||n.timeout(x,d)}var i;if(e!==P&&e!==p&&e!==h||(clearTimeout(r),r=0),e!==p&&e!==h||H||k("PageRender.4",{transitionType:e===p?"hard":"soft"}),e===I&&!W)(i={})[m]=t-o,i[f]=a-o,i[u]=V[e]-o,k("PageImpressed.3",i)}}function k(e,i){$[e]||(i.schemaId="<ns>."+e,E("log",i,{ent:"all"}),$[e]=1)}function q(){0===T[c]&&0===T[l]?(M=b,n("Events")("setEntity",{page:{viewport:"hidden-iframe"}})):M=K[s]?P:w,j(M)}function x(){j(I),r=0}function z(){var e=o?h:p;V={},$={},a=t=0,o=n.time(),j(e),q()}function A(){var e=K.readyState;"interactive"===e&&j(v),"complete"===e&&j(y)}K&&void 0!==K[s]?(z(),S(K,"visibilitychange",q,!1),S(K,"readystatechange",A,!1),S("$afterPageTransition",z),S("$timing:loaded",A),n.once("$load",A)):n.warn("Page visibility not supported")});csa.plugin(function(c){var s=c.config["Interactions.ParentChainLength"]||35,n="click",r="touches",f="timeStamp",o="length",u="pageX",g="pageY",p="pageXOffset",h="pageYOffset",l=250,m=5,v=200,d=.5,t={capture:!0,passive:!0},X=c.config["KillSwitch.ContentInteractions"],Y=c.global,x=c.emit,e=c.on,y=Y.Math.abs,a=(Y.document||{}).documentElement||{},N={x:0,y:0,t:0,sX:0,sY:0},b={x:0,y:0,t:0,sX:0,sY:0};function I(t){if(t.id)return"//*[@id='"+t.id+"']";var n=function(t){var n,e=1;for(n=t.previousSibling;n;n=n.previousSibling)n.nodeName===t.nodeName&&(e+=1);return e}(t),e=t.nodeName;return 1!==n&&(e+="["+n+"]"),t.parentNode&&(e=I(t.parentNode)+"/"+e),e}function C(t,n,e){if(!X){var a=c("Content",{target:e}),i={schemaId:"<ns>.ContentInteraction.2",interaction:t,interactionData:n,messageId:c.UUID()};if(e){var r=I(e);r&&(i.attribution=r);var o=function(t){for(var n=t,e=n.tagName,a=!1,i=t?t.href:null,r=0;r<s;r++){if(!n||!n.parentElement){a=!0;break}e=(n=n.parentElement).tagName+"/"+e,i=i||n.href}return a||(e=".../"+e),{pc:e,hr:i}}(e);o.pc&&(i.interactionData.parentChain=o.pc),o.hr&&(i.interactionData.href=o.hr)}a("log",i),x("$content.interaction",{e:i,w:a})}}function i(t){C(n,{interactionX:""+t.pageX,interactionY:""+t.pageY},t.target)}function D(t){if(t&&t[r]&&1===t[r][o]){var n=t[r][0];b=N={e:t.target,x:n[u],y:n[g],t:t[f],sX:Y[p],sY:Y[h]}}}function S(t){if(t&&t[r]&&1===t[r][o]&&N&&b){var n=t[r][0],e=t[f],a=e-b.t,i={e:t.target,x:n[u],y:n[g],t:e,sX:Y[p],sY:Y[h]};b=i,v<=a&&(N=i)}}function w(t){if(t){var n=y(N.x-b.x),e=y(N.y-b.y),a=y(N.sX-b.sX),i=y(N.sY-b.sY),r=t[f]-N.t;if(l<1e3*n/r&&m<n||l<1e3*e/r&&m<e){var o=e<n;o&&a&&n*d<=a||!o&&i&&e*d<=i||C((o?"horizontal":"vertical")+"-swipe",{interactionX:""+N.x,interactionY:""+N.y,endX:""+b.x,endY:""+b.y},N.e)}}}e(a,n,i,t),e(a,"touchstart",D,t),e(a,"touchmove",S,t),e(a,"touchend",w,t)});csa.plugin(function(a){var c,l,s,e,t="MutationObserver",f="observe",n="disconnect",m="_csa_flt",d="_csa_llt",v="_csa_mr",h="_csa_mi",p="lastChild",_="lastElementChild",b="length",g={childList:!0,subtree:!0},I=10,L=25,i=1e3,y=10,C=4,E={"#text":1,"#comment":1,SCRIPT:1,STYLE:1,NOSCRIPT:1,LINK:1,META:1},r=a.global,u=r.document,S=u.body||u.documentElement,T=Date.now,o=[],x=[],M=0,N=1,k=[],w=[],B=0;T&&r[t]&&(M=0,l=new r[t](O),a.once("$ready",A),N&&(R(),e=a.interval(P,i)),a.register("SpeedIndexBuffers",{getBuffers:D,registerListener:function(e){c=e},replayModuleIsLive:function(e){a.timeout(A,0),e&&e(D)}}));function O(e){o.push({t:T(),m:e}),c&&c()}function P(){var e=T();(!s||i<e-s)&&R()}function R(){for(var e=S,t=T(),n=[],i=[],r=0,u=0,o=0;e&&r<y;)e[m]?++u:(e[m]=t,n.push(e),o=1),i[b]<C&&i.push(e),e[h]=B,e[d]=t,e=e[_]||e[p],r+=1;o&&(u<w[b]&&function(e){for(var t=e,n=w[b];t<n;t++){var i=w[t];if(i){if(i[v])break;if(i[h]<B){if(i[v]=1,!E[i.nodeName||""]){var r=i,u=l;a.raf(function(){u&&r&&u[f](r,g),u=r=null})}break}}}}(u),w=i,k.push({t:t,m:n}),++B,c&&c()),N&&a.timeout(R,o?I:L),s=t}function A(){N&&(N=0,e&&r.clearInterval(e),e=null,R(),l[f](S,g))}function D(e){e&&(A(),x[b]||x.push({t:T(),x:0,y:0}),e(M,k,o,x),l&&l[n]())}});
+csa.plugin(function(b){var a=b.global,c=a.uet,e=a.uex,f=a.ue,a=a.Object,g=0,h={largestContentfulPaint:"lcp",visuallyLoaded50:"vl50",visuallyLoaded90:"vl90",visuallyLoaded100:"vl100"};b&&c&&e&&a.keys&&f&&(b.once("$ditched.beforemitigation",function(){g=1}),a.keys(h).forEach(function(a){b.on("$timing:"+a,function(b){var d=h[a];if(f.isl||g){var k="csa:"+d;c(d,k,void 0,b);e("at",k)}else c(d,void 0,void 0,b)})}))});
+
+
+window.rx = { 'rid':'0B5GGA052RDJB96RMAEG', 'sid':'147-7999693-6862434', 'c':{  'rxp':'/rd/uedata',  'ml_dl':false }};
+</script>
+<script>window.ue && ue.count && ue.count('CSMLibrarySize', 20578)</script>
+<!-- sp:end-feature:csm:body-open -->
+<!-- sp:feature:nav-inline-js -->
+<!-- NAVYAAN JS -->
+
+<script type="text/javascript">!function(n){function e(n,e){return{m:n,a:function(n){return[].slice.call(n)}(e)}}document.createElement("header");var r=function(n){function u(n,r,u){n[u]=function(){a._replay.push(r.concat(e(u,arguments)))}}var a={};return a._sourceName=n,a._replay=[],a.getNow=function(n,e){return e},a.when=function(){var n=[e("when",arguments)],r={};return u(r,n,"run"),u(r,n,"declare"),u(r,n,"publish"),u(r,n,"build"),r.depends=n,r.iff=function(){var r=n.concat([e("iff",arguments)]),a={};return u(a,r,"run"),u(a,r,"declare"),u(a,r,"publish"),u(a,r,"build"),a},r},u(a,[],"declare"),u(a,[],"build"),u(a,[],"publish"),u(a,[],"importEvent"),r._shims.push(a),a};r._shims=[],n.$Nav||(n.$Nav=r("rcx-nav")),n.$Nav.make||(n.$Nav.make=r)}(window)</script><script type="text/javascript">
+$Nav.importEvent('navbarJS-beaconbelt');
+$Nav.declare('img.sprite', {
+  'png32': 'https://m.media-amazon.com/images/G/01/gno/sprites/nav-sprite-global-1x-reorg-privacy._CB779528203_.png',
+  'png32-2x': 'https://m.media-amazon.com/images/G/01/gno/sprites/nav-sprite-global-2x-reorg-privacy._CB779528203_.png'
+});
+$Nav.declare('img.timeline', {
+  'timeline-icon-2x': 'https://m.media-amazon.com/images/G/01/gno/sprites/timeline_sprite_2x._CB443581191_.png'
+});
+window._navbarSpriteUrl = 'https://m.media-amazon.com/images/G/01/gno/sprites/nav-sprite-global-1x-reorg-privacy._CB779528203_.png';
+$Nav.declare('img.pixel', 'https://m.media-amazon.com/images/G/01/x-locale/common/transparent-pixel._CB485935036_.gif');
+</script>
+
+<img src="https://m.media-amazon.com/images/G/01/gno/sprites/nav-sprite-global-1x-reorg-privacy._CB779528203_.png" style="display:none" alt=""/>
+<script type="text/javascript">var nav_t_after_preload_sprite = + new Date();</script>
+<script>
+(window.AmazonUIPageJS ? AmazonUIPageJS : P).when('navCF').execute(function() {
+  (window.AmazonUIPageJS ? AmazonUIPageJS : P).load.js('https://m.media-amazon.com/images/I/51rG04VN8cL._RC|71AeMNGOB4L.js,41InaEL-ZPL.js,01QvReFeJyL.js,01kC46b9vjL.js,81XkUkLWahL.js,01m0EuyLqIL.js,41jBieyCvYL.js,01wXnKULArL.js,01+pnQJuQ0L.js,21gBwAAfnjL.js,51D+BomCJLL.js,21Vid0E-nAL.js,31yCF4ftzxL.js,11lw6J7z8iL.js,31COIUU385L.js,01VYGE8lGhL.js_.js?AUIClients/NavDesktopUberAsset#desktop.language-en.us.1324036-T1.803398-T1.1200978-T1.1381529-T1.1354730-T1.1371733-T2.948355-T2.1253326-T1.1295082-T1.1401014-T1.1340845-T1.1346270-T1');
+});
+</script>
+<!-- sp:end-feature:nav-inline-js -->
+<!-- sp:feature:nav-skeleton -->
+<!-- sp:end-feature:nav-skeleton -->
+<!-- sp:feature:navbar -->
+
+<!--Pilu -->
+
+
+  <!-- NAVYAAN -->
+
+
+
+
+
+
+
+
+
+
+
+<!-- navmet initial definition -->
+
+
+
+<script type='text/javascript'>
+    if(window.navmet===undefined) {
+      window.navmet=[];
+      if (window.performance && window.performance.timing && window.ue_t0) {
+        var t = window.performance.timing;
+        var now = + new Date();
+        window.navmet.basic = {
+          'networkLatency': (t.responseStart - t.fetchStart),
+          'navFirstPaint': (now - t.responseStart),
+          'NavStart': (now - window.ue_t0)
+        };
+        window.navmet.push({key:"NavFirstPaintStart",end:+new Date(),begin:window.ue_t0});
+      }
+    }
+    if (window.ue_t0) {
+      window.navmet.push({key:"NavMainStart",end:+new Date(),begin:window.ue_t0});
+    }
+</script>
+
+    <script type="text/javascript">
+        const BROWSER_MARGIN = '12px';
+
+        
+        const DOCKED_PANEL_WIDTH = '320px';
+        
+
+        let state = sessionStorage.getItem('rufus:panel:dockedState');
+
+        
+        if (!state) {
+            try {
+                state = localStorage.getItem('rufus:panel:dockedState');
+                if (state) {
+                    sessionStorage.setItem('rufus:panel:dockedState', state);
+                }
+            } catch (e) {
+                // localStorage unavailable (e.g. private browsing)
+            }
+        }
+        
+    
+        if (state === 'docked-left' || state === 'docked-right') {
+            const body = document.body;
+            body.classList.add(`rufus-${state}`);
+            
+            body.style.paddingTop = BROWSER_MARGIN;
+            body.style[state === 'docked-left' ? 'paddingLeft' : 'paddingRight'] = DOCKED_PANEL_WIDTH;
+            body.style[state === 'docked-left' ? 'paddingRight' : 'paddingLeft'] = BROWSER_MARGIN;
+            body.offsetHeight;
+            document.body.style.setProperty('--rufus-docked-panel-width', DOCKED_PANEL_WIDTH);
+            window.dispatchEvent(new Event('resize'));
+        }
+    </script>
+
+
+
+
+
+<script type='text/javascript'>window.navmet.tmp=+new Date();</script>
+  <script type='text/javascript'>
+    // Nav start should be logged at this place only if request is NOT progressively loaded.
+    // For progressive loading case this metric is logged as part of skeleton.
+    // Presence of skeleton signals that request is progressively loaded.
+    if(!document.getElementById("navbar-skeleton")) {
+      window.uet && uet('ns');
+    }
+    window._navbar = (function (o) {
+      o.componentLoaded = o.loading = function(){};
+      o.browsepromos = {};
+      o.issPromos = [];
+      return o;
+    }(window._navbar || {}));
+    window._navbar.declareOnLoad = function () { window.$Nav && $Nav.declare('page.load'); };
+    if (window.addEventListener) {
+      window.addEventListener("load", window._navbar.declareOnLoad, false);
+    } else if (window.attachEvent) {
+      window.attachEvent("onload", window._navbar.declareOnLoad);
+    } else if (window.$Nav) {
+      $Nav.when('page.domReady').run("OnloadFallbackSetup", function () {
+        window._navbar.declareOnLoad();
+      });
+    }
+    window.$Nav && $Nav.declare('config.lightningDeals', {"activeItems":[],"marketplaceID":"ATVPDKIKX0DER","customerID":"AEXAMPLE00000"});
+  </script>
+
+    <style mark="aboveNavInjectionCSS" type="text/css">
+       #nav-flyout-ewc .nav-flyout-buffer-left { display: none; } #nav-flyout-ewc .nav-flyout-buffer-right { display: none; } div#navSwmHoliday.nav-focus {border: none;margin: 0;}
+    </style>
+    <script mark="aboveNavInjectionJS" type="text/javascript">
+      try {
+        if(window.navmet===undefined)window.navmet=[]; if(window.$Nav) { $Nav.when('$', 'config', 'flyout.accountList', 'SignInRedirect', 'dataPanel').run('accountListRedirectFix', function ($, config, flyout, SignInRedirect, dataPanel) { if (!config.accountList) { return; } flyout.getPanel().onData(function (data) { if (SignInRedirect) { var $anchors = $('[data-nav-role=signin]', flyout.elem()); $.each($anchors, function(i, anchorEl) {SignInRedirect.setRedirectUrl($(anchorEl), null, null);});}});}); $Nav.when('$').run('defineIsArray', function(jQuery) { if(jQuery.isArray===undefined) { jQuery.isArray=function(param) { if(param.length===undefined) { return false; } return true; }; } }); $Nav.declare('config.cartFlyoutDisabled', 'true'); $Nav.when('$','$F','config','logEvent','panels','phoneHome','dataPanel','flyouts.renderPromo','flyouts.sloppyTrigger','flyouts.accessibility','util.mouseOut','util.onKey','debug.param').build('flyouts.buildSubPanels',function($,$F,config,logEvent,panels,phoneHome,dataPanel,renderPromo,createSloppyTrigger,a11yHandler,mouseOutUtility,onKey,debugParam){var flyoutDebug=debugParam('navFlyoutClick');return function(flyout,event){var linkKeys=[];$('.nav-item',flyout.elem()).each(function(){var $item=$(this);linkKeys.push({link:$item,panelKey:$item.attr('data-nav-panelkey')});});if(linkKeys.length===0){return;} var visible=false;var $parent=$('<div class=\'nav-subcats\'></div>').appendTo(flyout.elem());var panelGroup=flyout.getName()+'SubCats';var hideTimeout=null;var sloppyTrigger=createSloppyTrigger($parent);var showParent=function(){if(hideTimeout){clearTimeout(hideTimeout);hideTimeout=null;} if(visible){return;} var height=$('#nav-flyout-shopAll').height(); $parent.css({'height': height});$parent.animate({width:'show'},{duration:200,complete:function(){$parent.css({overflow:'visible'});}});visible=true;};var hideParentNow=function(){$parent.stop().css({overflow:'hidden',display:'none',width:'auto',height:'auto'});panels.hideAll({group:panelGroup});visible=false;if(hideTimeout){clearTimeout(hideTimeout);hideTimeout=null;}};var hideParent=function(){if(!visible){return;} if(hideTimeout){clearTimeout(hideTimeout);hideTimeout=null;} hideTimeout=setTimeout(hideParentNow,10);};flyout.onHide(function(){sloppyTrigger.disable();hideParentNow();this.elem().hide();});var addPanel=function($link,panelKey){var panel=dataPanel({className:'nav-subcat',dataKey:panelKey,groups:[panelGroup],spinner:false,visible:false});if(!flyoutDebug){var mouseout=mouseOutUtility();mouseout.add(flyout.elem());mouseout.action(function(){panel.hide();});mouseout.enable();} var a11y=a11yHandler({link:$link,onEscape:function(){panel.hide();$link.focus();}});var logPanelInteraction=function(promoID,wlTriggers){var logNow=$F.once().on(function(){var panelEvent=$.extend({},event,{id:promoID});if(config.browsePromos&&!!config.browsePromos[promoID]){panelEvent.bp=1;} logEvent(panelEvent);phoneHome.trigger(wlTriggers);});if(panel.isVisible()&&panel.hasInteracted()){logNow();}else{panel.onInteract(logNow);}};panel.onData(function(data){renderPromo(data.promoID,panel.elem());logPanelInteraction(data.promoID,data.wlTriggers);});panel.onShow(function(){var columnCount=$('.nav-column',panel.elem()).length;panel.elem().addClass('nav-colcount-'+columnCount);showParent();var $subCatLinks=$('.nav-subcat-links > a',panel.elem());var length=$subCatLinks.length;if(length>0){var firstElementLeftPos=$subCatLinks.eq(0).offset().left;for(var i=1;i<length;i++){if(firstElementLeftPos===$subCatLinks.eq(i).offset().left){$subCatLinks.eq(i).addClass('nav_linestart');}} if($('span.nav-title.nav-item',panel.elem()).length===0){var catTitle=$.trim($link.html());catTitle=catTitle.replace(/ref=sa_menu_top/g,'ref=sa_menu');var $subPanelTitle=$('<span class=\'nav-title nav-item\'>'+ catTitle+'</span>');panel.elem().prepend($subPanelTitle);}} $link.addClass('nav-active');});panel.onHide(function(){$link.removeClass('nav-active');hideParent();a11y.disable();sloppyTrigger.disable();});panel.onShow(function(){a11y.elems($('a, area',panel.elem()));});sloppyTrigger.register($link,panel);if(flyoutDebug){$link.click(function(){if(panel.isVisible()){panel.hide();}else{panel.show();}});} var panelKeyHandler=onKey($link,function(){if(this.isEnter()||this.isSpace()){panel.show();}},'keydown',false);$link.focus(function(){panelKeyHandler.bind();}).blur(function(){panelKeyHandler.unbind();});panel.elem().appendTo($parent);};var hideParentAndResetTrigger=function(){hideParent();sloppyTrigger.disable();};for(var i=0;i<linkKeys.length;i++){var item=linkKeys[i];if(item.panelKey){addPanel(item.link,item.panelKey);}else{item.link.mouseover(hideParentAndResetTrigger);}}};});};
+      } catch ( err ) {
+        if ( window.$Nav ) {
+          window.$Nav.when('metrics', 'logUeError').run(function(metrics, log) {
+            metrics.increment('NavJS:AboveNavInjection:error');
+            log(err.toString(), {
+              'attribution': 'rcx-nav',
+              'logLevel': 'FATAL'
+            });
+          });
+        }
+      }
+    </script>
+
+  <noscript>
+    <style type="text/css"><!--
+      #navbar #nav-shop .nav-a:hover {
+        color: #ff9900;
+        text-decoration: underline;
+      }
+      #navbar #nav-search .nav-search-facade,
+      #navbar #nav-tools .nav-icon,
+      #navbar #nav-shop .nav-icon,
+      #navbar #nav-subnav .nav-hasArrow .nav-arrow {
+        display: none;
+      }
+      #navbar #nav-search .nav-search-submit,
+      #navbar #nav-search .nav-search-scope {
+        display: block;
+      }
+      #nav-search .nav-search-scope {
+        padding: 0 5px;
+      }
+      #navbar #nav-search .nav-search-dropdown {
+        position: relative;
+        top: 5px;
+        height: 23px;
+        font-size: 14px;
+        opacity: 1;
+        filter: alpha(opacity = 100);
+      }
+    --></style>
+ </noscript>
+<script type='text/javascript'>window.navmet.push({key:'PreNav',end:+new Date(),begin:window.navmet.tmp});</script>
+
+<a id='nav-top'></a>
+
+
+
+
+
+  
+<nav
+  id="shortcut-menu"
+  class="nav-assistant"
+  aria-label="Shortcuts menu"
+  tabindex="-1"
+  role="navigation" 
+  
+  data-skip-link-target-text="Main content start"
+  data-hashed-id="a37652a4e2fad37e7ff492694add6f9ac92a8d892c6a6f11926e7eafc1ef2ea0"
+data-raw-id="AEXAMPLE00000"
+>
+  <h2 id="nav-assistant-links-heading" class="nav-assistant-heading nav-assistant-headers-font">Skip to</h2>
+  <ul aria-labelledby="nav-assistant-links-heading" class="nav-assistant-links-container">
+    <li class="nav-assistant-list-item ">
+      <a
+        href="#skippedLink"
+        id="nav-assist-skip-to-main-content"
+        aria-label="main content"
+        aria-describedby="nav-assist-shortcut-help"
+        tabindex="0"
+        data-target="#skippedLink"
+        data-scrolltarget=""
+        data-behavior="navigate"
+        
+        
+        data-nav-assist-menu-item-index="0"
+        class="nav-assistant-link nav-assistant-menu-item nav-assistant-link-item a-color-base a-color-link "
+      >
+        Main content
+      </a>
+    </li>
+  </ul>
+  <hr class="nav-assistant-separator" aria-hidden="true" />
+  <h2 id="nav-assist-shortcuts-heading" class="nav-assistant-heading nav-assistant-headers-font font-color aok-hidden">
+      Keyboard shortcuts
+  </h2>
+  <ul class="keyboard-shortcuts-list-container aok-hidden" id="nav-assist-shortcuts-container" aria-labelledby="nav-assist-shortcuts-heading">
+    <li class="nav-assistant-list-item">
+      <a
+        href="javascript:void(0)"
+        id="nav-assist-search"
+        role="link"
+        tabindex="-1"
+        class="nav-assistant-menu-item nav-assistant-link-item nav-assistant-keyboard-shortcut-item keyboard-shortcut-menu-container a-color-base a-color-link "
+        data-nav-assist-menu-item-index="1"
+        data-behavior="navigate"
+        
+        data-actuators="[{&quot;eventCode&quot;:&quot;Slash&quot;,&quot;eventKey&quot;:&quot;÷&quot;,&quot;isShiftRequired&quot;:false},{&quot;eventCode&quot;:&quot;Digit7&quot;,&quot;eventKey&quot;:&quot;\\&quot;,&quot;isShiftRequired&quot;:true},{&quot;eventCode&quot;:&quot;Period&quot;,&quot;eventKey&quot;:&quot;\\&quot;,&quot;isShiftRequired&quot;:true},{&quot;eventCode&quot;:&quot;Slash&quot;,&quot;eventKey&quot;:&quot;/&quot;,&quot;isShiftRequired&quot;:false},{&quot;eventCode&quot;:&quot;Digit7&quot;,&quot;eventKey&quot;:&quot;/&quot;,&quot;isShiftRequired&quot;:true},{&quot;eventCode&quot;:&quot;Period&quot;,&quot;eventKey&quot;:&quot;/&quot;,&quot;isShiftRequired&quot;:true},{&quot;eventKey&quot;:&quot;/&quot;,&quot;isShiftRequired&quot;:false}]"
+        data-target="#twotabsearchtextbox"
+        data-modal-ignore=""
+        aria-label="Search, alt, forward slash"
+        aria-describedby="nav-assist-shortcut-help"
+      >
+        <div class="keyboard-shortcut-container" aria-hidden="true">
+          <span class="shortcut-name nav-assistant-card-font">Search</span>
+          <div class="shortcut-keys-container" dir="ltr">
+              <span class="shortcut-key nav-assistant-card-font font-color">alt</span>
+              <span class="plus-sign-color">+</span>
+              <span class="shortcut-key nav-assistant-card-font font-color">/</span>
+              
+          </div>
+        </div>
+      </a>
+    </li>
+    <li class="nav-assistant-list-item">
+      <a
+        href="javascript:void(0)"
+        id="nav-assist-cart"
+        role="link"
+        tabindex="-1"
+        class="nav-assistant-menu-item nav-assistant-link-item nav-assistant-keyboard-shortcut-item keyboard-shortcut-menu-container a-color-base a-color-link "
+        data-nav-assist-menu-item-index="2"
+        data-behavior="navigate"
+        
+        data-actuators="[{&quot;eventKey&quot;:&quot;Ç&quot;,&quot;eventCode&quot;:&quot;KeyC&quot;,&quot;isShiftRequired&quot;:true},{&quot;eventKey&quot;:&quot;¢&quot;,&quot;eventCode&quot;:&quot;KeyC&quot;,&quot;isShiftRequired&quot;:true},{&quot;eventKey&quot;:&quot;C&quot;,&quot;isShiftRequired&quot;:true}]"
+        data-target="/gp/cart/view.html/?ref_&#x3D;nav_assist"
+        data-modal-ignore=""
+        aria-label="Cart, shift, alt, c"
+        aria-describedby="nav-assist-shortcut-help"
+      >
+        <div class="keyboard-shortcut-container" aria-hidden="true">
+          <span class="shortcut-name nav-assistant-card-font">Cart</span>
+          <div class="shortcut-keys-container" dir="ltr">
+              <span class="shortcut-key nav-assistant-card-font font-color">shift</span>
+              <span class="plus-sign-color">+</span>
+              <span class="shortcut-key nav-assistant-card-font font-color">alt</span>
+              <span class="plus-sign-color">+</span>
+              <span class="shortcut-key nav-assistant-card-font font-color">C</span>
+              
+          </div>
+        </div>
+      </a>
+    </li>
+    <li class="nav-assistant-list-item">
+      <a
+        href="javascript:void(0)"
+        id="nav-assist-home"
+        role="link"
+        tabindex="-1"
+        class="nav-assistant-menu-item nav-assistant-link-item nav-assistant-keyboard-shortcut-item keyboard-shortcut-menu-container a-color-base a-color-link "
+        data-nav-assist-menu-item-index="3"
+        data-behavior="navigate"
+        
+        data-actuators="[{&quot;eventKey&quot;:&quot;Ó&quot;,&quot;eventCode&quot;:&quot;KeyH&quot;,&quot;isShiftRequired&quot;:true},{&quot;eventKey&quot;:&quot;Î&quot;,&quot;eventCode&quot;:&quot;KeyH&quot;,&quot;isShiftRequired&quot;:true},{&quot;eventKey&quot;:&quot;˘&quot;,&quot;eventCode&quot;:&quot;KeyH&quot;,&quot;isShiftRequired&quot;:true},{&quot;eventKey&quot;:&quot;H&quot;,&quot;isShiftRequired&quot;:true}]"
+        data-target="/?ref_&#x3D;nav_assist"
+        data-modal-ignore=""
+        aria-label="Home, shift, alt, h"
+        aria-describedby="nav-assist-shortcut-help"
+      >
+        <div class="keyboard-shortcut-container" aria-hidden="true">
+          <span class="shortcut-name nav-assistant-card-font">Home</span>
+          <div class="shortcut-keys-container" dir="ltr">
+              <span class="shortcut-key nav-assistant-card-font font-color">shift</span>
+              <span class="plus-sign-color">+</span>
+              <span class="shortcut-key nav-assistant-card-font font-color">alt</span>
+              <span class="plus-sign-color">+</span>
+              <span class="shortcut-key nav-assistant-card-font font-color">H</span>
+              
+          </div>
+        </div>
+      </a>
+    </li>
+    <li class="nav-assistant-list-item">
+      <a
+        href="javascript:void(0)"
+        id="nav-assist-your-orders"
+        role="link"
+        tabindex="-1"
+        class="nav-assistant-menu-item nav-assistant-link-item nav-assistant-keyboard-shortcut-item keyboard-shortcut-menu-container a-color-base a-color-link "
+        data-nav-assist-menu-item-index="4"
+        data-behavior="navigate"
+        
+        data-actuators="[{&quot;eventKey&quot;:&quot;Ø&quot;,&quot;eventCode&quot;:&quot;KeyO&quot;,&quot;isShiftRequired&quot;:true},{&quot;eventKey&quot;:&quot;Œ&quot;,&quot;eventCode&quot;:&quot;KeyO&quot;,&quot;isShiftRequired&quot;:true},{&quot;eventKey&quot;:&quot;O&quot;,&quot;isShiftRequired&quot;:true}]"
+        data-target="/gp/css/order-history/?ref_&#x3D;nav_assist"
+        data-modal-ignore=""
+        aria-label="Your orders, shift, alt, o"
+        aria-describedby="nav-assist-shortcut-help"
+      >
+        <div class="keyboard-shortcut-container" aria-hidden="true">
+          <span class="shortcut-name nav-assistant-card-font">Orders</span>
+          <div class="shortcut-keys-container" dir="ltr">
+              <span class="shortcut-key nav-assistant-card-font font-color">shift</span>
+              <span class="plus-sign-color">+</span>
+              <span class="shortcut-key nav-assistant-card-font font-color">alt</span>
+              <span class="plus-sign-color">+</span>
+              <span class="shortcut-key nav-assistant-card-font font-color">O</span>
+              
+          </div>
+        </div>
+      </a>
+    </li>
+    <li class="nav-assistant-list-item">
+      <button
+        id="nav-assist-show-shortcuts"
+        role="button"
+        tabindex="-1"
+        class="nav-assistant-menu-item nav-assistant-link-item nav-assistant-keyboard-shortcut-item keyboard-shortcut-menu-container a-color-base a-color-link nav-assistant-link-button"
+        data-nav-assist-menu-item-index="5"
+        data-behavior="show-hide"
+        
+        data-actuators="[{&quot;eventKey&quot;:&quot;¸&quot;,&quot;eventCode&quot;:&quot;KeyZ&quot;,&quot;isShiftRequired&quot;:true},{&quot;eventKey&quot;:&quot;ˇ&quot;,&quot;eventCode&quot;:&quot;KeyY&quot;,&quot;isShiftRequired&quot;:true},{&quot;eventKey&quot;:&quot;Å&quot;,&quot;eventCode&quot;:&quot;KeyW&quot;,&quot;isShiftRequired&quot;:true},{&quot;eventKey&quot;:&quot;⁄&quot;,&quot;eventCode&quot;:&quot;KeyZ&quot;,&quot;isShiftRequired&quot;:true},{&quot;eventKey&quot;:&quot;Z&quot;,&quot;eventCode&quot;:&quot;KeyZ&quot;,&quot;isShiftRequired&quot;:true},{&quot;eventKey&quot;:&quot;Z&quot;,&quot;eventCode&quot;:&quot;KeyY&quot;,&quot;isShiftRequired&quot;:true},{&quot;eventKey&quot;:&quot;Z&quot;,&quot;eventCode&quot;:&quot;KeyW&quot;,&quot;isShiftRequired&quot;:true},{&quot;eventKey&quot;:&quot;Z&quot;,&quot;isShiftRequired&quot;:true}]"
+        data-target="a[data-nav-assist-menu-item-index&#x3D;&quot;0&quot;]"
+        data-modal-ignore=""
+        aria-label="Show/hide shortcuts, shift, alt, z"
+        aria-describedby="nav-assist-shortcut-help"
+      >
+        <div class="keyboard-shortcut-container" aria-hidden="true">
+          <span class="shortcut-name nav-assistant-card-font">Show/Hide shortcuts</span>
+          <div class="shortcut-keys-container" dir="ltr">
+              <span class="shortcut-key nav-assistant-card-font font-color">shift</span>
+              <span class="plus-sign-color">+</span>
+              <span class="shortcut-key nav-assistant-card-font font-color">alt</span>
+              <span class="plus-sign-color">+</span>
+              <span class="shortcut-key nav-assistant-card-font font-color">Z</span>
+              
+          </div>
+        </div>
+      </button>
+    </li>
+  </ul>
+  <div
+    id="nav-assist-shortcut-help"
+    class="aok-hidden"
+  >
+    <div class="shortcut-help-container">
+      <div class="shortcut-help-item-container">
+        <div class="icon-container"><i class="a-icon a-icon-info a-icon-mini shortcut-help-icon"></i></div>
+        <div class="help-text-container">
+          <span class="shortcut-help-text font-color">To move between items, use your keyboard&#x27;s up or down arrows.</span>
+        </div>
+      </div>
+    </div>
+  </div>
+</nav>
+
+
+
+
+
+<script type='text/javascript'>window.navmet.main=+new Date();</script>
+
+
+<style type="text/css">
+#navbar-main #navbar #nav-belt { background: #131921; } #navbar-main #navbar #nav-main { background: #232f3e; } #navbar-main #navbar .nav-a-2 .nav-line-1, .nav-a-2 .nav-line-2, #nav-search-label { color: #fff; } #navbar-main #navbar #nav-cart-count, #nav-ewc-cart-count { color: #f08804; top: 7px; } #navbar-main #navbar #nav-search { .nav-search-scope { background-color: #e6e6e6; border-left: 1px solid #e6e6e6; border-top: 1px solid #e6e6e6; border-bottom: 1px solid #e6e6e6; } .nav-search-scope:hover, .nav-search-scope:focus, .nav-search-scope.nav-focus { background-color: #d4d4d4; border-left-color: #d4d4d4; border-top-color: #d4d4d4; border-bottom-color: #d4d4d4; } .nav-searchbar.nav-active, .nav-searchbar.nav-focus { box-shadow: 0 0 0 2px #ff9900, 0 0 0 3px rgba(255, 153, 0, 0.5); z-index: 1; } .nav-searchbar.nav-active .nav-search-scope, .nav-searchbar.nav-focus .nav-search-scope, .nav-searchbar.nav-active .nav-search-field, .nav-searchbar.nav-focus .nav-search-field { border-top: 1px solid #febd69; border-bottom: 1px solid #febd69; } .nav-searchbar.nav-active .nav-search-scope, .nav-searchbar.nav-focus .nav-search-scope { border-left: 1px solid #febd69; } .nav-search-submit { background-color: #febd69; } .nav-search-submit:hover, .nav-search-submit:focus, .nav-search-submit.nav-focus { background-color: #f3a847; } } #navbar-main #navbar .nav-icon.nav-arrow { border-top-color: #a7acb2; } #navbar-main #navbar .nav-icon-flipped.nav-arrow { border-bottom-color: #a7acb2; } #navbar-main #navbar #nav-flyout-ewc .nav-flyout-head { background-color: #232f3e; } #navbar-main #navbar #nav-logo-borderfade .nav-fade-mask { background-color: #232f3e; width: 195px; }
+</style>
+<header id="navbar-main" class = "nav-opt-sprite nav-flex nav-locale-us nav-lang-en nav-ssl nav-rec nav-progressive-attribute">
+
+   
+  <div id='navbar' cel_widget_id='Navigation-desktop-navbar'
+  role='navigation' class="nav-sprite-v1 celwidget nav-bluebeacon nav-a11y-t1 bold-focus-hover layout2 nav-flex layout3 layout3-alt nav-packard-glow hamburger nav-progressive-attribute" aria-label="Primary">
+    <div id='nav-belt'>
+      <div class='nav-left'>
+        <script type='text/javascript'>window.navmet.tmp=+new Date();</script>
+  <div id="nav-logo" class="nav-prime-1 nav-progressive-attribute">
+    <a href="/ref=nav_logo" id="nav-logo-sprites" class="nav-logo-link nav-progressive-attribute" aria-label="Amazon Prime" lang="en" >
+      <span class="nav-sprite nav-logo-base"></span>
+      <span id="logo-ext" class="nav-sprite nav-logo-ext nav-progressive-content"></span>
+      <span class="nav-logo-locale">.us</span>
+    </a>
+ <div id="nav-tagline" class="nav-progressive-content">
+  <a href="/ref=nav_logo_prime" tabindex="-1"  class="nav-sprite nav-logo-tagline">
+    
+  </a>
+</div>
+  </div>
+<script type='text/javascript'>window.navmet.push({key:'Logo',end:+new Date(),begin:window.navmet.tmp});</script>
+        
+<div id="nav-global-location-slot" data-csa-c-type="widget" data-csa-c-slot-id="GLOW-desktop-nav" data-csa-c-content-id="nav-glow">
+    <span id="nav-global-location-data-modal-action" class="a-declarative nav-progressive-attribute" data-a-modal='{&quot;width&quot;:375, &quot;closeButton&quot;:&quot;true&quot;,&quot;popoverLabel&quot;:&quot;Choose your location&quot;, &quot;ajaxHeaders&quot;:{&quot;anti-csrftoken-a2z&quot;:&quot;hMXPpMS3tLOyLyXuLKie2dIgULtaFKhLWY7VJfgPt+8HAAAAAGooFVwAAAAB&quot;}, &quot;name&quot;:&quot;glow-modal&quot;, &quot;url&quot;:&quot;/portal-migration/hz/glow/get-rendered-address-selections?deviceType&#x3D;desktop&amp;pageType&#x3D;F3OmnichannelPostOrder&amp;storeContext&#x3D;NoStoreName&amp;actionSource&#x3D;desktop-modal&quot;, &quot;footer&quot;:&quot;&lt;span class&#x3D;\&quot;a-declarative\&quot; data-action&#x3D;\&quot;a-popover-close\&quot; data-a-popover-close&#x3D;\&quot;{}\&quot;&gt;&lt;span class&#x3D;\&quot;a-button a-button-primary\&quot;&gt;&lt;span class&#x3D;\&quot;a-button-inner\&quot;&gt;&lt;button name&#x3D;\&quot;glowDoneButton\&quot; class&#x3D;\&quot;a-button-text\&quot; type&#x3D;\&quot;button\&quot;&gt;Done&lt;/button&gt;&lt;/span&gt;&lt;/span&gt;&lt;/span&gt;&quot;,&quot;header&quot;:&quot;Choose your location&quot;}' data-action="a-modal">
+        <a id="nav-global-location-popover-link" role="button" tabindex="0" class="nav-a nav-a-2 a-popover-trigger a-declarative nav-progressive-attribute" href="">
+            <div class="nav-sprite nav-progressive-attribute" id="nav-packard-glow-loc-icon"></div>
+            <div id="glow-ingress-block">
+                <span class="nav-line-1 nav-progressive-content" id="glow-ingress-line1">
+                   Deliver to Customer
+                </span>
+                <span class="nav-line-2 nav-progressive-content" id="glow-ingress-line2">
+                   Sharon 06069&zwnj;
+                </span>
+            </div>
+        </a>
+        </span>
+        <input data-addnewaddress="add-new" id="unifiedLocation1ClickAddress" name="dropdown-selection" type="hidden" value="jllksojumoknr" class="nav-progressive-attribute" />
+        <input data-addnewaddress="add-new" id="ubbShipTo" name="dropdown-selection-ubb" type="hidden" value="jllksojumoknr" class="nav-progressive-attribute"/>
+        <input id="glowValidationToken" name="glow-validation-token" type="hidden" value="hMXPpMS3tLOyLyXuLKie2dIgULtaFKhLWY7VJfgPt+8HAAAAAGooFVwAAAAB" class="nav-progressive-attribute"/>
+        <input id="glowDestinationType" name="glow-destination-type" type="hidden" value="ACCOUNT_ADDRESS" class="nav-progressive-attribute"/>
+</div>
+
+<div id="nav-global-location-toaster-script-container" class="nav-progressive-content">
+</div>
+
+      </div>
+          <div class='nav-fill' id='nav-fill-search'>
+            <script type='text/javascript'>window.navmet.tmp=+new Date();</script>
+<div id="nav-search">
+  <div id="nav-bar-left"></div> 
+  <form
+    id="nav-search-bar-form"
+    accept-charset="utf-8"
+    action="/s/ref=nb_sb_noss"
+    class="nav-searchbar nav-progressive-attribute"
+    method="GET"
+    name="site-search"
+    role="search"
+  >
+
+    <div class="nav-left">
+      <div id="nav-search-dropdown-card">
+        
+  <div class="nav-search-scope nav-sprite">
+    <div class="nav-search-facade" data-value="search-alias=aps">
+      <span id="nav-search-label-id" class="nav-search-label nav-progressive-content">All</span>
+      <i class="nav-icon"></i>
+    </div>
+    <label id="searchDropdownDescription" for="searchDropdownBox" class="nav-progressive-attribute" style="display:none">Select the department you want to search in</label>
+    <select
+      aria-describedby="searchDropdownDescription"
+      class="nav-search-dropdown searchSelect nav-progressive-attrubute nav-progressive-search-dropdown"
+      data-nav-digest="RQWv7AxGrkDxs/LIJhOsSvOwQ0k="
+      data-nav-selected="0"
+      id="searchDropdownBox"
+      name="url"
+      style="display: block;"
+      tabindex="0"
+      title="Search in"
+    >
+        <option selected="selected" value="search-alias=aps">All Departments</option>
+        <option value="search-alias=alexa-skills">Alexa Skills</option>
+        <option value="search-alias=vehicles">Amazon Autos</option>
+        <option value="search-alias=amazon-devices">Amazon Devices</option>
+        <option value="search-alias=amazon-global-store">Amazon Global Store</option>
+        <option value="search-alias=bazaar">Amazon Haul</option>
+        <option value="search-alias=amazon-one-medical">Amazon One Medical</option>
+        <option value="search-alias=amazon-pharmacy">Amazon Pharmacy</option>
+        <option value="search-alias=warehouse-deals">Amazon Resale</option>
+        <option value="search-alias=appliances">Appliances</option>
+        <option value="search-alias=mobile-apps">Apps & Games</option>
+        <option value="search-alias=arts-crafts">Arts, Crafts & Sewing</option>
+        <option value="search-alias=audible">Audible Books & Originals</option>
+        <option value="search-alias=automotive">Automotive Parts & Accessories</option>
+        <option value="search-alias=baby-products">Baby</option>
+        <option value="search-alias=beauty">Beauty & Personal Care</option>
+        <option value="search-alias=stripbooks">Books</option>
+        <option value="search-alias=popular">CDs & Vinyl</option>
+        <option value="search-alias=mobile">Cell Phones & Accessories</option>
+        <option value="search-alias=fashion">Clothing, Shoes & Jewelry</option>
+        <option value="search-alias=fashion-womens">Women's Clothing, Shoes & Jewelry</option>
+        <option value="search-alias=fashion-mens">Men's Clothing, Shoes & Jewelry</option>
+        <option value="search-alias=fashion-girls">Girl's Clothing, Shoes & Jewelry</option>
+        <option value="search-alias=fashion-boys">Boy's Clothing, Shoes & Jewelry</option>
+        <option value="search-alias=fashion-baby">Baby Clothing, Shoes & Jewelry</option>
+        <option value="search-alias=collectibles">Collectibles & Fine Art</option>
+        <option value="search-alias=computers">Computers</option>
+        <option value="search-alias=financial">Credit and Payment Cards</option>
+        <option value="search-alias=digital-music">Digital Music</option>
+        <option value="search-alias=electronics">Electronics</option>
+        <option value="search-alias=lawngarden">Garden & Outdoor</option>
+        <option value="search-alias=gift-cards">Gift Cards</option>
+        <option value="search-alias=grocery">Grocery & Gourmet Food</option>
+        <option value="search-alias=handmade">Handmade</option>
+        <option value="search-alias=hpc">Health, Household & Baby Care</option>
+        <option value="search-alias=local-services">Home & Business Services</option>
+        <option value="search-alias=garden">Home & Kitchen</option>
+        <option value="search-alias=industrial">Industrial & Scientific</option>
+        <option value="search-alias=prime-exclusive">Just for Prime</option>
+        <option value="search-alias=digital-text">Kindle Store</option>
+        <option value="search-alias=fashion-luggage">Luggage & Travel Gear</option>
+        <option value="search-alias=luxury">Luxury Stores</option>
+        <option value="search-alias=magazines">Magazine Subscriptions</option>
+        <option value="search-alias=movies-tv">Movies & TV</option>
+        <option value="search-alias=mi">Musical Instruments</option>
+        <option value="search-alias=office-products">Office Products</option>
+        <option value="search-alias=pets">Pet Supplies</option>
+        <option value="search-alias=luxury-beauty">Premium Beauty</option>
+        <option value="search-alias=instant-video">Prime Video</option>
+        <option value="search-alias=smart-home">Smart Home</option>
+        <option value="search-alias=software">Software</option>
+        <option value="search-alias=sporting">Sports & Outdoors</option>
+        <option value="search-alias=specialty-aps-sns">Subscribe & Save</option>
+        <option value="search-alias=subscribe-with-amazon">Subscription Boxes</option>
+        <option value="search-alias=tools">Tools & Home Improvement</option>
+        <option value="search-alias=toys-and-games">Toys & Games</option>
+        <option value="search-alias=under-ten-dollars">Under $10</option>
+        <option value="search-alias=videogames">Video Games</option>
+        <option value="search-alias=vons">Vons</option>
+        <option value="search-alias=wholefoods">Whole Foods Market</option>
+    </select>
+  </div>
+
+      </div>
+    </div>
+    <div class="nav-fill">
+      <div class="nav-search-field ">
+          <label for="twotabsearchtextbox" style="display: none;">Search Amazon</label>
+          <input
+            type="text"
+            id="twotabsearchtextbox"
+            value=""
+            name="field-keywords"
+            autocomplete="off"
+            placeholder="Search Amazon"
+            class="nav-input nav-progressive-attribute"
+            dir="auto"
+            tabindex="0"
+            aria-label="Search Amazon"
+            role="searchbox"
+            aria-autocomplete="list"
+            aria-controls="sac-autocomplete-results-container"
+            aria-expanded="false"
+            aria-haspopup="grid"
+            spellcheck="false"
+            data-agent-button-proxy="nav-search-submit-button-agent"
+            data-agent-field="search-query"
+            form="nav-search-bar-form"
+            data-agent-patched="true"
+          >
+      </div>
+      <div id="nav-iss-attach"></div>
+    </div>
+    <div class="nav-right">
+      <div class="nav-search-submit nav-sprite">
+        <span id="nav-search-submit-text" class="nav-search-submit-text nav-sprite nav-progressive-attribute" aria-label="Go">
+          <input id="nav-search-submit-button" type="submit" class="nav-input nav-progressive-attribute" value="Go" tabindex="0">
+        </span>
+      </div>
+        <span id="nav-search-submit-text-agent" 
+              aria-hidden="true"
+              role="presentation">
+          <input id="nav-search-submit-button-agent" 
+                  type="submit" 
+                  value="Agent Search" 
+                  tabindex="-1"
+                  data-agent-action="primary-search" 
+                  data-search-mode="agent" 
+                  data-agent-priority="primary" 
+                  data-agent-recommended="true" 
+                  data-target-audience="ai-agent" 
+                  data-provides="structured-results" 
+                  data-optimization="high">
+        </span>
+    </div>
+  </form>
+</div>
+<script type='text/javascript'>window.navmet.push({key:'Search',end:+new Date(),begin:window.navmet.tmp});</script>
+          </div>
+      <div class='nav-right'>
+          <script type='text/javascript'>window.navmet.tmp=+new Date();</script>
+          <div id='nav-tools' class="layoutToolbarPadding">
+              
+              
+              
+              
+  <div class="nav-div" id="icp-nav-flyout">
+  <a href="/customer-preferences/edit?ie=UTF8&preferencesReturnUrl=%2F&ref_=topnav_lang" class="nav-a nav-a-2 icp-link-style-2" aria-label="Choose a language for shopping in Amazon United States. The current selection is English (EN).
+">
+    <span class="icp-nav-link-inner">
+      <span class="nav-line-1">
+      </span>
+      <span class="nav-line-2">
+         <span class="icp-nav-flag icp-nav-flag-us icp-nav-flag-lop" role="img" aria-label="United States"></span>
+          <div>EN</div>
+      </span>
+    </span>
+  </a>
+  <button class="nav-flyout-button nav-icon nav-arrow" aria-label="Expand to Change Language or Country" tabindex=0></button>
+</div>
+
+              
+  <div class="nav-div" id="nav-link-accountList">
+  <a href="https://www.amazon.com/gp/css/homepage.html?ref_=nav_youraccount_btn" class="nav-a nav-a-2 nav-truncate   nav-progressive-attribute" data-nav-ref="nav_youraccount_btn"  data-nav-role="signin" data-ux-jq-mouseenter="true" tabindex="0" data-csa-c-type="link" data-csa-c-slot-id="nav-link-accountList" data-csa-c-content-id="nav_youraccount_btn"  aria-controls="nav-flyout-accountList" >
+  <div class="nav-line-1-container"><span id="nav-link-accountList-nav-line-1" class="nav-line-1 nav-progressive-content">Hello, Customer</span></div>
+  <span class="nav-line-2 ">Account & Lists
+  </span>
+  </a>
+  <button class="nav-flyout-button nav-icon nav-arrow" aria-label="Expand Account and Lists" tabindex=0></button>
+  </div>
+
+              
+<a href="/gp/css/order-history?ref_=nav_orders_first" class="nav-a nav-a-2   nav-progressive-attribute" id="nav-orders" tabindex="0">
+  <span class="nav-line-1">Returns</span>
+  <span class="nav-line-2">& Orders<span class="nav-icon nav-arrow"></span></span>
+</a>
+
+              
+              
+  <a href="/gp/cart/view.html?ref_=nav_cart" aria-label="1 item in cart" class="nav-a nav-a-2 nav-progressive-attribute" id="nav-cart">
+    <div id="nav-cart-count-container">
+      <span id="nav-cart-count" aria-hidden="true" class="nav-cart-count nav-cart-1 nav-progressive-attribute nav-progressive-content">1</span>
+      <span class="nav-cart-icon nav-sprite"></span>
+    </div>
+    <div id="nav-cart-text-container" class=" nav-progressive-attribute">
+      <span aria-hidden="true" class="nav-line-1">
+        
+      </span>
+      <span aria-hidden="true" class="nav-line-2">
+        Cart
+        <span class="nav-icon nav-arrow"></span>
+      </span>
+    </div>
+  </a>
+
+          </div>
+          <script type='text/javascript'>window.navmet.push({key:'Tools',end:+new Date(),begin:window.navmet.tmp});</script>
+
+      </div>
+    </div>
+    <div id='nav-belt-search' class='nav-fill'></div>
+    <div id='nav-main' class='nav-sprite'>
+      <div class='nav-left'>
+        <script type='text/javascript'>window.navmet.tmp=+new Date();</script>
+  <a href="/gp/site-directory?ref_=nav_em_js_disabled" id="nav-hamburger-menu" role="button" aria-label="Open All Categories Menu" aria-expanded="false" data-csa-c-type="widget" data-csa-c-slot-id="HamburgerMenuDesktop"
+  data-csa-c-interaction-events="click" >
+    <i class="hm-icon nav-sprite"></i>
+    <span class="hm-icon-label">All</span>
+  </a>
+  
+<script type="text/javascript">
+  var hmenu = document.getElementById("nav-hamburger-menu");
+  hmenu.setAttribute("href", "javascript: void(0)");
+  window.navHamburgerMetricLogger = function() {
+    if (window.ue && window.ue.count) {
+      var metricName = "Nav:Hmenu:IconClickActionPending";
+      window.ue.count(metricName, (ue.count(metricName) || 0) + 1);
+    }
+    window.$Nav && $Nav.declare("navHMenuIconClicked",!0);
+    window.$Nav && $Nav.declare("navHMenuIconClickedNotReadyTimeStamp", Date.now());
+  };
+  hmenu.addEventListener("click", window.navHamburgerMetricLogger);
+  window.$Nav && $Nav.declare('hamburgerMenuIconAvailableOnLoad', false);
+</script>  
+<script type='text/javascript'>window.navmet.push({key:'HamburgerMenuIcon',end:+new Date(),begin:window.navmet.tmp});</script>
+        
+            <button class='nav-rufus-disco' id='nav-rufus-disco' data-state='closed' role='button' aria-label='Open Alexa panel' data-csa-c-type='button' data-csa-c-slot-id='rufus-dsk-disco-slot' data-csa-c-content-id='rufus-dsk-disco-content'><div id='nav-rufus-disco-avatar' class='nav-rufus-disco-avatar'></div><div id='nav-rufus-disco-text' class='nav-rufus-disco-text'>for shopping</div></button><div id='nav-flyout-rufus' class='rufus-panel-container' data-state='closed' style='background-color:#FBFBFB'><div id='rufus-panel-resize-handle-unified' class='rufus-panel-resize-handle-unified'></div><div id='rufus-panel-tooltip' class='rufus-panel-tooltip'><div class='rufus-panel-tooltip-content'>Drag to reposition this window <button class='rufus-panel-tooltip-close' type='button' aria-label='close'>×</button></div><div class='rufus-panel-tooltip-caret'></div></div><div id='rufus-panel-header-container' class='rufus-panel-header-container'><div id='rufus-panel-header-grabber-row' class='rufus-panel-header-grabber-row'><div id='rufus-panel-header-grabber' class='rufus-panel-header-grabber' aria-label='drag to resize'></div></div><div id='rufus-panel-header-content-row' class='rufus-panel-header-content-row rufus-dockable'><div id='rufus-panel-header-left-section' class='rufus-panel-header-left-section'><div id='rufus-panel-header-logo' class='rufus-panel-header-logo'><div id='rufus-panel-header-title' class='rufus-panel-header-title-logo-update' style='background-image:url(https://m.media-amazon.com/images/G/01/Rufus_Desktop/Alexa_For_Shopping_Header.svg)' role='img' aria-label='Alexa For Shopping Logo'></div></div><button class='rufus-panel-header-minimize aok-hidden' role='button' aria-label='minimize' id='rufus-panel-header-minimize' data-csa-c-type='button' data-csa-c-slot-id='rufus-dsk-panel-header-minimize-slot' data-csa-c-content-id='rufus-dsk-panel-header-minimize-content'></button></div><div id='rufus-panel-header-center-section' class='rufus-panel-header-center-section'><div id='rufus-panel-header-overflow' class='rufus-panel-header-overflow'></div></div><div id='rufus-panel-header-right-section' class='rufus-panel-header-right-section'><button class='rufus-panel-header-overflow-button' role='button' aria-label='Alexa overflow menu' aria-expanded='false' id='rufus-panel-header-overflow-button' data-csa-c-type='button' data-csa-c-slot-id='rufus-dsk-panel-header-overflow-button-slot' data-csa-c-content-id='rufus-dsk-panel-header-overflow-button-content'></button><div class='rufus-overflow-menu-container' id='rufus-overflow-menu-container' data-state='closed'></div><button class='rufus-panel-header-dock-undock-button' role='button' aria-label='' id='rufus-panel-header-dock-undock-button' data-csa-c-type='button' data-csa-c-slot-id='rufus-dsk-panel-header-dock-undock-button-slot' data-csa-c-content-id='rufus-dsk-panel-header-dock-undock-button-content'></button> <button class='rufus-panel-header-close' role='button' aria-label='close' id='rufus-panel-header-close' data-csa-c-type='button' data-csa-c-slot-id='rufus-dsk-panel-header-close-slot' data-csa-c-content-id='rufus-dsk-panel-header-close-content'></button></div></div></div><div id='nav-rufus-content' class='nav-rufus-content rufus-dockable' style='background-color:#FBFBFB'></div><input type='hidden' id='rufus-view-context' name='rufus-view-context' value='{"pageType":"F3OmnichannelPostOrder"}'></div><script type='text/javascript'>;(function () {
+        function isValidNumber(input) {
+    // if the input is string, Number(input) will become NaN but the type will be number
+    // so we need to check if the value if NaN after its type is changed to number
+    return typeof Number(input) === "number" && !isNaN(Number(input));
+}
+        const featureScope = {"renderRufusPanel":"renderRufusPanel","startRufusStream":"startRufusStream","startRufusInitialLoading":"startRufusInitialLoading"};
+        function logError(error) {
+    const extendedWindow = window;
+    if (extendedWindow.ueLogError) {
+        const errorLogAdditionalInfo = {
+            attribution: "AmazonNavigationRufusCard",
+            logLevel: "ERROR",
+            message: error.message
+        };
+        extendedWindow.ueLogError(error, errorLogAdditionalInfo);
+    }
+}
+        function logCount(metricName) {
+    const extendedWindow = window;
+    if (extendedWindow.ue && extendedWindow.ue.count) {
+        var current = extendedWindow.ue.count(metricName) || 0;
+        extendedWindow.ue.count(metricName, current + 1);
+    }
+}
+        function logLatency(scope, isStart) {
+    // ts-ignore needed since 'uet' and 'uex' defined in javascript
+    // @ts-ignore
+    if (typeof uet == "function" && isStart) {
+        // @ts-ignore
+        uet("bb", scope, { wb: 1 });
+    }
+    // @ts-ignore
+    if (typeof uex == "function" && typeof uet == "function" && !isStart) {
+        // @ts-ignore
+        uet("be", scope, { wb: 1 });
+        // @ts-ignore
+        uex("ld", scope, { wb: 1 });
+    }
+}
+        function renderErrorUI(errorMessage) {
+    const rufusContent = document.querySelector(".nav-rufus-content");
+    const errorDiv = document.createElement("div");
+    errorDiv.classList.add("rufus-panel-error-message");
+    errorDiv.innerHTML = errorMessage;
+    rufusContent.appendChild(errorDiv);
+}
+        function fetchRufusTriggerMarker(rufusTriggerMarkerMappingString, pageType) {
+    if (!pageType || !rufusTriggerMarkerMappingString) {
+        return;
+    }
+    let rufusPageTriggerMarkerMapping;
+    try {
+        rufusPageTriggerMarkerMapping = JSON.parse(rufusTriggerMarkerMappingString);
+    }
+    catch (error) {
+        const errorMessage = "Error parsing rufusTriggerMarkerMappingString: " +
+            rufusTriggerMarkerMappingString +
+            ". " +
+            error;
+        logError(new Error(errorMessage));
+        return undefined;
+    }
+    return rufusPageTriggerMarkerMapping === null || rufusPageTriggerMarkerMapping === void 0 ? void 0 : rufusPageTriggerMarkerMapping[pageType];
+}
+        function updateCurrentRufusContent(innerHTMLContent, isCacheContent, noScrollTreatment) {
+    const rufusContent = document.querySelector(".nav-rufus-content");
+    const tempDiv = document.createElement("div");
+    tempDiv.innerHTML = innerHTMLContent;
+    // Query for the first element matching the selector "link[rel='stylesheet']"
+    const stylesheet = tempDiv.querySelector("link[rel='stylesheet']");
+    if (stylesheet) {
+        const linkElement = document.createElement("link");
+        linkElement.rel = "stylesheet";
+        linkElement.href = stylesheet.href;
+        // Set up the onload event handler for the <link> element
+        linkElement.onload = function () {
+            // make sure no duplicate rufus container view will be appended
+            if (!rufusContent.querySelector(".rufus-container")) {
+                // remove all script tags and the first occurrence of the link tag.
+                rufusContent.innerHTML += innerHTMLContent
+                    .replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, "")
+                    .replace(/<link[^>]*>/i, "");
+                const rufusConversationContainer = rufusContent.querySelector("#rufus-conversation-container");
+                if (rufusConversationContainer) {
+                    // Determine the scroll position to restore.
+                    // Default is scroll-to-bottom. When restoring from cache with the
+                    // RUFUS_DESKTOP_AFO_NO_SCROLL_1414612 weblab active (T1), attempt to
+                    // restore the exact position the user was at before navigation.
+                    // The thick client saves this value to sessionStorage under "rufus:panel:scrollTop".
+                    // The key will be stored only for the AFO click case, other page navigation
+                    // scenarios will continue to scroll to the bottom.
+                    // Note: the definitive fix for glitch-free restoration is to handle this
+                    // in the thick client as well.
+                    let targetScrollTop = rufusConversationContainer.scrollHeight;
+                    if (isCacheContent && noScrollTreatment === "T1") {
+                        try {
+                            const CL_SCROLL_POSITION_CACHE_KEY = "rufus:panel:scrollTop";
+                            const savedScrollTop = sessionStorage.getItem(CL_SCROLL_POSITION_CACHE_KEY);
+                            if (savedScrollTop !== null) {
+                                targetScrollTop = parseFloat(savedScrollTop);
+                                logCount("rufus-scroll-restore-position-hit");
+                            }
+                            else {
+                                // No saved position — targetScrollTop stays as scrollHeight (scroll-to-bottom).
+                                logCount("rufus-scroll-restore-position-miss");
+                            }
+                        }
+                        catch (error) {
+                            // sessionStorage may be unavailable (e.g. private browsing restrictions);
+                            // fall back gracefully to scroll-to-bottom.
+                            logCount("rufus-scroll-restore-session-storage-error");
+                        }
+                    }
+                    rufusConversationContainer.scrollTop = targetScrollTop;
+                }
+            }
+            else {
+                // when panel is rendered with cached content, we still need to update CSRF token from /render response to avoid
+                // 403 issue when a tab is kept open more than 24 hours and streaming happened in this tab
+                const csrfContentMetadata = rufusContent.querySelector('meta[name="anti-csrftoken-a2z"]');
+                const newCSRFContentMetadata = tempDiv.querySelector('meta[name="anti-csrftoken-a2z"]');
+                const newCSRFToken = newCSRFContentMetadata === null || newCSRFContentMetadata === void 0 ? void 0 : newCSRFContentMetadata.getAttribute("content");
+                newCSRFToken &&
+                    (csrfContentMetadata === null || csrfContentMetadata === void 0 ? void 0 : csrfContentMetadata.setAttribute("content", newCSRFToken));
+                // Swap refreshable weblab treatment map from new /render response
+                // so the thick client can read fresh treatments from the DOM
+                const refreshableWeblabInput = rufusContent.querySelector('input[name="refreshableClientWeblabTreatmentMap"]');
+                const newRefreshableWeblabInput = tempDiv.querySelector('input[name="refreshableClientWeblabTreatmentMap"]');
+                if (refreshableWeblabInput && newRefreshableWeblabInput) {
+                    refreshableWeblabInput.value = newRefreshableWeblabInput.value;
+                }
+            }
+            // Extract script content from responseText and execute it with script element
+            const tmpElement = document.createElement("div");
+            tmpElement.innerHTML = innerHTMLContent;
+            const scripts = tmpElement.querySelectorAll("script");
+            scripts.forEach(function (script) {
+                var clonedScript = document.createElement("script");
+                if (script.src) {
+                    clonedScript.src = script.src;
+                }
+                // page state will store the data into <script />.
+                // We should also clone the script type and attribute for using page state
+                if (script.type) {
+                    clonedScript.type = script.type;
+                }
+                const pageStateAttriute = script.getAttribute("data-a-state");
+                if (pageStateAttriute != null) {
+                    clonedScript.setAttribute("data-a-state", pageStateAttriute);
+                }
+                clonedScript.text = script.text;
+                document.body.appendChild(clonedScript);
+                logLatency(featureScope.renderRufusPanel, false);
+            });
+            tmpElement.remove();
+        };
+        rufusContent.appendChild(linkElement);
+        return true;
+    }
+    else {
+        const innerHTMLContentType = isCacheContent ? "cache" : "backend response";
+        const errorMessage = "stylesheet not found in innerHTML, while loading " +
+            innerHTMLContentType;
+        logError(new Error(errorMessage));
+        return false;
+    }
+}
+        function checkAllKeysHaveValue(config, keys) {
+    for (let i = 0; i < Object.keys(keys).length; i++) {
+        const key = Object.keys(keys)[i];
+        const value = config[key];
+        if (value === undefined || value === null || value === "") {
+            return false; // Return false if any value is undefined, null, or an empty string
+        }
+    }
+    return true; // Return true if all values are defined and non-empty
+}
+        function observeVisibility(targetDiv, callback) {
+    function handleVisibilityChange(entries, observer) {
+        for (let i = 0; i < entries.length; i++) {
+            const entry = entries[i];
+            const isVisible = window.getComputedStyle(entry.target).visibility !== "hidden";
+            if (entry.isIntersecting && isVisible) {
+                callback();
+                // Disconnect the observer after the function is triggered once
+                observer.disconnect();
+            }
+        }
+    }
+    const observer = new IntersectionObserver(handleVisibilityChange, {
+        root: null,
+        rootMargin: "0px",
+        threshold: 1
+    });
+    observer.observe(targetDiv);
+}
+        function renderRufusContent(hasCacheContent, errorMessageTextToRender) {
+    logLatency(featureScope.renderRufusPanel, true);
+    let retries = 0;
+    const maxRetries = 1;
+    function sendRequest() {
+        const extendedWindow = window;
+        var url = "/rufus/cl/render?ref=nl_cl_dsk_rend";
+        var xhr = new XMLHttpRequest();
+        xhr.open("GET", url, true);
+        xhr.onload = function () {
+            if (xhr.status >= 200 && xhr.status < 300) {
+                let content = xhr.responseText;
+                updateCurrentRufusContent(content, false);
+                logCount("rufusRenderSuccess");
+                extendedWindow.P &&
+                    extendedWindow.P.declare("rufus-container-fetched", {
+                        container: content
+                    });
+            }
+            else if (xhr.status === 504 && retries < maxRetries) {
+                retries++;
+                logCount("rufusRenderRetryOnTimeout:" + retries);
+                sendRequest();
+            }
+            else {
+                renderErrorUI(errorMessageTextToRender);
+                logCount("rufusRenderServerError:" + getStatusBucket(xhr.status));
+            }
+        };
+        xhr.onerror = function () {
+            if (retries < maxRetries) {
+                retries++;
+                logCount("rufusRenderRetryOnNetworkError:" + retries);
+                sendRequest();
+            }
+            else {
+                renderErrorUI(errorMessageTextToRender);
+                logCount("rufusRenderNetworkError");
+            }
+        };
+        xhr.send();
+    }
+    sendRequest();
+    return true;
+}
+        function wrapFunctionWithSchedulerAndExecutor(func, timeout) {
+    let hasExecuted = false;
+    let timeoutId;
+    // Function to execute and mark as executed
+    function execute() {
+        if (!hasExecuted) {
+            hasExecuted = true;
+            func();
+        }
+    }
+    // schedule timeout to execute function
+    function schedule() {
+        timeoutId = setTimeout(execute, timeout);
+    }
+    // force executing function before timeout if needed
+    function forceExecute() {
+        timeoutId && clearTimeout(timeoutId);
+        execute();
+    }
+    // Return schedule and forceExecute function to execute in different scenarios
+    return {
+        schedule: schedule,
+        forceExecute: forceExecute
+    };
+}
+        function getDockingSide(dockedSidePanelTreatment) {
+    const treatment = dockedSidePanelTreatment || "C";
+    if (treatment === "T1") {
+        return "docked-left";
+    }
+    else if (treatment === "T2") {
+        return "docked-right";
+    }
+    return "none";
+}
+        (function rufusJavascript(params) {
+    var _a;
+    const FTUX_RUX_ELIGIBLE_SOURCES = new Set([
+        "NileIngressOnsiteMarketing",
+        "NileIngressLink"
+    ]);
+    function isFtuxRuxEligibleSource(qis) {
+        return !!qis && FTUX_RUX_ELIGIBLE_SOURCES.has(qis);
+    }
+    // Session storage key for docked panel width (set by DockedPanelResizeHandler)
+    const DOCKED_PANEL_WIDTH_KEY = "rufus:dockedPanelWidth";
+    // Panel width constraints
+    const DEFAULT_DOCKED_PANEL_WIDTH = 320;
+    const MAX_DOCKED_PANEL_WIDTH = 420;
+    /**
+     * Calculates the default docked panel width based on the current screen size.
+     * This ensures the panel always opens at the appropriate width for the viewport,
+     * "forgetting" any previous user-resized width.
+     *
+     * Screen size breakpoints:
+     * - Small (≤1439px):           320px
+     * - Medium (≥1440px):          420px
+     */
+    function getDefaultDockedPanelWidth() {
+        const screenWidth = window.innerWidth;
+        if (screenWidth >= 1440) {
+            return MAX_DOCKED_PANEL_WIDTH; // 420px
+        }
+        return DEFAULT_DOCKED_PANEL_WIDTH; // 320px - Default
+    }
+    // Get the docked panel width for page load / navigation:
+    // - When adjustable width weblab is enabled (T1): use stored width if available (for navigation continuity),
+    //   otherwise fall back to dynamic default based on screen size
+    // - Otherwise: use static minimum width (320px)
+    function getDockedPanelWidth() {
+        if (params.dockedPanelAdjustableWidthTreatment === "T1") {
+            try {
+                const storedWidth = sessionStorage.getItem(DOCKED_PANEL_WIDTH_KEY);
+                if (storedWidth) {
+                    const widthValue = parseInt(storedWidth, 10);
+                    if (!isNaN(widthValue) &&
+                        widthValue >= DEFAULT_DOCKED_PANEL_WIDTH &&
+                        widthValue <= MAX_DOCKED_PANEL_WIDTH) {
+                        return widthValue;
+                    }
+                }
+            }
+            catch (error) {
+                // Session storage may not be available, use default
+            }
+            // No stored width → use dynamic default based on screen size
+            return getDefaultDockedPanelWidth();
+        }
+        return DEFAULT_DOCKED_PANEL_WIDTH;
+    }
+    let rufusPanelConfig;
+    const extendedWindow = window;
+    extendedWindow.isB2B = params.isB2B;
+    const rufusFlyoutDiv = document.getElementById("nav-flyout-rufus");
+    rufusFlyoutDiv &&
+        observeVisibility(rufusFlyoutDiv, function () {
+            if (extendedWindow.P && typeof extendedWindow.P.declare === "function") {
+                extendedWindow.P.declare("rufus-panel-first-visible", new Date().getTime());
+            }
+        });
+    const rufusPanelConfigString = params.rufusPanelConfigString;
+    const rufusViewContext = params.rufusViewContext;
+    const isCacheEnabled = params.isCacheEnabled;
+    const uniqueId = params.uniqueId;
+    const renderRequestForAllPageTypesEnabled = params.renderRequestForAllPageTypesEnabled;
+    const rufusErrorMessageText = params.rufusErrorMessageText;
+    const latencyRegressionMitigationStrategy = params.latencyRegressionMitigationStrategy;
+    const rufusNavOnlyHoldoutTreatment = params.rufusNavOnlyHoldoutTreatment;
+    const rufusTriggerMarkerMappingString = params.rufusTriggerMarkerMappingString;
+    const rufusTriggerMarkerFallbackTimeoutString = params.rufusTriggerMarkerFallbackTimeoutString;
+    const movableCLEnabled = params.movableCLEnabled;
+    const dockedSidePanelTreatment = params.dockedSidePanelTreatment;
+    const statePersistenceTreatment = params.statePersistenceTreatment;
+    const dockedPanelAdjustableWidthTreatment = params.dockedPanelAdjustableWidthTreatment;
+    const blueHeronGatingTreatment = params.blueHeronGatingTreatment;
+    const movableCLPersistenceTreatment = params.movableCLPersistenceTreatment;
+    const deprecateMovableCLEnabled = params.deprecateMovableCLEnabled;
+    const noScrollTreatment = params.noScrollTreatment;
+    // Add Alexa+ rebranding body class when Blue Heron weblab is T1
+    if (blueHeronGatingTreatment === "T1") {
+        document.body.classList.add("rufus-cl-alexa-plus");
+    }
+    // Default panel positioning values
+    const DEFAULT_PANEL_LEFT = 0;
+    const DEFAULT_PANEL_BOTTOM = 0;
+    const DOCKED_PANEL_WIDTH = getDockedPanelWidth();
+    const EWC_CART_WIDTH = 100;
+    const BROWSER_MARGIN = 12;
+    const TOTAL_WIDTH_TAKEN_IN_PAGE = DOCKED_PANEL_WIDTH + BROWSER_MARGIN;
+    const AUTO_UNDOCKING_SIZE = 1000 + TOTAL_WIDTH_TAKEN_IN_PAGE;
+    const DUAL_PANEL_SELECTOR = ".nav-ewc-persistent-hover #nav-flyout-ewc";
+    // Check if adjustable width feature is enabled
+    const isAdjustableWidthEnabled = () => dockedPanelAdjustableWidthTreatment === "T1";
+    // Should auto-undock for small screens unless adjustable width is enabled
+    // or movable CL deprecation weblab is enabled (auto-undock removed entirely).
+    const shouldAutoUndock = () => window.innerWidth < AUTO_UNDOCKING_SIZE &&
+        !isAdjustableWidthEnabled() &&
+        !deprecateMovableCLEnabled;
+    // Dock icon constants
+    const DOCK_LEFT_ICON = "url('data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%2215%22%20height%3D%2214%22%20viewBox%3D%220%200%2015%2014%22%20fill%3D%22none%22%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%3E%3Cpath%20d%3D%22M4.53012%2010.5672L4.53012%2010.6412C4.53012%2011.7458%205.42555%2012.6412%206.53012%2012.6412L9.08708%2012.6412%22%20stroke%3D%22%23565959%22%20stroke-width%3D%221.5%22%20stroke-linecap%3D%22round%22/%3E%3Cpath%20d%3D%22M8.78328%2012.6412L11.3402%2012.6412C12.4448%2012.6412%2013.3402%2011.7458%2013.3402%2010.6412L13.3402%208.19678%22%20stroke%3D%22%23565959%22%20stroke-width%3D%221.5%22%20stroke-linecap%3D%22round%22/%3E%3Cpath%20d%3D%22M13.3402%208.4931L13.3402%206.04865C13.3402%204.94408%2012.4448%204.04865%2011.3402%204.04865L10.3782%204.04865%22%20stroke%3D%22%23565959%22%20stroke-width%3D%221.5%22%20stroke-linecap%3D%22round%22/%3E%3Cpath%20d%3D%22M0.75%205.00316L0.75%207.56012C0.75%208.66469%201.64543%209.56012%202.75%209.56012L5.19445%209.56012%22%20stroke%3D%22%23565959%22%20stroke-width%3D%221.5%22%20stroke-linecap%3D%22round%22/%3E%3Cpath%20d%3D%22M5.19443%209.56012L7.63889%209.56012C8.74345%209.56012%209.63889%208.66469%209.63889%207.56012L9.63889%205.00316%22%20stroke%3D%22%23565959%22%20stroke-width%3D%221.5%22%20stroke-linecap%3D%22round%22/%3E%3Cpath%20d%3D%22M5.19445%200.75H2.75C1.64543%200.75%200.75%201.64543%200.75%202.75V5.30696%22%20stroke%3D%22%23565959%22%20stroke-width%3D%221.5%22%20stroke-linecap%3D%22round%22/%3E%3Cpath%20d%3D%22M9.63889%205.30696L9.63889%202.75C9.63889%201.64543%208.74346%200.75%207.63889%200.75L5.19443%200.75%22%20stroke%3D%22%23565959%22%20stroke-width%3D%221.5%22%20stroke-linecap%3D%22round%22/%3E%3Cpath%20d%3D%22M3.29893%203.30185L7.47142%207.52393%22%20stroke%3D%22%23565959%22%20stroke-linecap%3D%22round%22/%3E%3Cpath%20d%3D%22M6.03329%202.85727L2.84341%202.85727L2.84341%205.96838%22%20stroke%3D%22%23565959%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22/%3E%3C/svg%3E')";
+    const DOCK_RIGHT_ICON = "url('data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%2214%22%20height%3D%2214%22%20viewBox%3D%220%200%2014%2014%22%20fill%3D%22none%22%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%3E%3Cpath%20d%3D%22M2.82408%203.93988H2.75C1.64543%203.93988%200.75%204.83531%200.75%205.93988V8.49684%22%20stroke%3D%22%23565959%22%20stroke-width%3D%221.5%22%20stroke-linecap%3D%22round%22/%3E%3Cpath%20d%3D%22M0.75%208.19304L0.75%2010.75C0.75%2011.8546%201.64543%2012.75%202.75%2012.75L5.19445%2012.75%22%20stroke%3D%22%23565959%22%20stroke-width%3D%221.5%22%20stroke-linecap%3D%22round%22/%3E%3Cpath%20d%3D%22M4.89814%2012.75L7.34259%2012.75C8.44716%2012.75%209.34259%2011.8546%209.34259%2010.75L9.34259%209.78797%22%20stroke%3D%22%23565959%22%20stroke-width%3D%221.5%22%20stroke-linecap%3D%22round%22/%3E%3Cpath%20d%3D%22M3.86111%205.00316L3.86111%207.56012C3.86111%208.66469%204.75654%209.56012%205.86111%209.56012L8.30557%209.56012%22%20stroke%3D%22%23565959%22%20stroke-width%3D%221.5%22%20stroke-linecap%3D%22round%22/%3E%3Cpath%20d%3D%22M8.30555%209.56012L10.75%209.56012C11.8546%209.56012%2012.75%208.66469%2012.75%207.56012L12.75%205.00316%22%20stroke%3D%22%23565959%22%20stroke-width%3D%221.5%22%20stroke-linecap%3D%22round%22/%3E%3Cpath%20d%3D%22M8.30557%200.75H5.86111C4.75655%200.75%203.86111%201.64543%203.86111%202.75V5.30696%22%20stroke%3D%22%23565959%22%20stroke-width%3D%221.5%22%20stroke-linecap%3D%22round%22/%3E%3Cpath%20d%3D%22M12.75%205.30696L12.75%202.75C12.75%201.64543%2011.8546%200.75%2010.75%200.75L8.30555%200.75%22%20stroke%3D%22%23565959%22%20stroke-width%3D%221.5%22%20stroke-linecap%3D%22round%22/%3E%3Cpath%20d%3D%22M10.1573%203.33211L5.9352%207.50459%22%20stroke%3D%22%23565959%22%20stroke-linecap%3D%22round%22/%3E%3Cpath%20d%3D%22M10.6019%206.06646L10.6019%202.87659L7.49075%202.87659%22%20stroke%3D%22%23565959%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22/%3E%3C/svg%3E')";
+    // Determine docking side
+    const dockingSide = getDockingSide(dockedSidePanelTreatment);
+    const isIpad = navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1;
+    const rufusButton = document.getElementById("nav-rufus-disco");
+    if (isIpad) {
+        rufusButton && rufusButton.remove();
+        rufusFlyoutDiv && rufusFlyoutDiv.remove();
+        logCount("Nav:Rufus:IngressButtonRemoved");
+        return;
+    }
+    const rufusPanelCacheKey = "rufus:panel";
+    const rufusPanelCacheString = sessionStorage.getItem(rufusPanelCacheKey);
+    let rufusPanelCache = undefined;
+    try {
+        rufusPanelCache =
+            rufusPanelCacheString && JSON.parse(rufusPanelCacheString);
+    }
+    catch (error) {
+        const errorMessage = "Error parsing rufusPanelCacheString: " +
+            rufusPanelCacheString +
+            ". " +
+            error;
+        logError(new Error(errorMessage));
+    }
+    const cachedUniqueId = rufusPanelCache &&
+        rufusPanelCache.metadata &&
+        rufusPanelCache.metadata.uniqueId;
+    let cacheContent;
+    let cachedState;
+    //ToDo: Remove someId condition when uniqueId on panelAssets is merged.
+    if (isCacheEnabled &&
+        (cachedUniqueId === "someId" || cachedUniqueId === uniqueId)) {
+        cacheContent = rufusPanelCache === null || rufusPanelCache === void 0 ? void 0 : rufusPanelCache.content;
+        cachedState = rufusPanelCache === null || rufusPanelCache === void 0 ? void 0 : rufusPanelCache.state;
+    }
+    else {
+        logCount("rufus-content-cache-uniqueId-mismatch");
+        // Preserve panel UI state (open/closed, position, size) when there's an actual
+        // identity mismatch (e.g. profile switch) — both IDs exist but differ.
+        // Don't preserve state when uniqueId is missing from cache (corrupted/old cache).
+        // Gated behind blueHeronGatingTreatment and movableCLPersistenceTreatment weblabs.
+        if (blueHeronGatingTreatment === "T1" &&
+            movableCLPersistenceTreatment === "T1" &&
+            isCacheEnabled &&
+            cachedUniqueId &&
+            rufusPanelCache &&
+            rufusPanelCache.state) {
+            cachedState = rufusPanelCache.state;
+        }
+    }
+    // add default errorMessage for the panel to avoid something wrong happens in linkTree.
+    const defaultErrorMessageText = "Something went wrong. Try again later.";
+    const errorMessageTextToRender = rufusErrorMessageText
+        ? rufusErrorMessageText
+        : defaultErrorMessageText;
+    // add default style values for the panel to avoid something wrong happens in linkTree.
+    const fallbackRufusPanelConfig = {
+        panelHeightRatio: "0.5",
+        panelWidth: "320px",
+        minimizedPanelWidth: "200px",
+        peekViewPanelWidth: "320px"
+    };
+    const panelConfigKeys = Object.keys(fallbackRufusPanelConfig);
+    // If rufusPanelConfigString is only `{}`, it can also be parsed, we should avoid get empty values
+    if (typeof rufusPanelConfigString === "string" &&
+        rufusPanelConfigString !== "{}") {
+        try {
+            rufusPanelConfig = checkAllKeysHaveValue(JSON.parse(rufusPanelConfigString), panelConfigKeys)
+                ? JSON.parse(rufusPanelConfigString)
+                : fallbackRufusPanelConfig;
+        }
+        catch (error) {
+            rufusPanelConfig = fallbackRufusPanelConfig;
+            const errorMessage = "Error parsing rufusPanelConfig: " +
+                rufusPanelConfigString +
+                ". " +
+                error;
+            logError(new Error(errorMessage));
+        }
+        rufusPanelConfig.panelHeightRatio = isValidNumber(rufusPanelConfig.panelHeightRatio)
+            ? rufusPanelConfig.panelHeightRatio
+            : 0.5;
+    }
+    else {
+        rufusPanelConfig = fallbackRufusPanelConfig;
+        const errorMessage = "rufusPanelConfig is empty or is not string: " + rufusPanelConfigString;
+        logError(new Error(errorMessage));
+    }
+    const navbar = document.getElementById("navbar-main");
+    const rufusPanelMinimizeButton = document.getElementById("rufus-panel-header-minimize");
+    const rufusPanelCloseButton = document.getElementById("rufus-panel-header-close");
+    const rufusPanelDockButton = document.getElementById("rufus-panel-header-dock-undock-button");
+    const rufusContent = document.querySelector(".nav-rufus-content");
+    const rufusViewContextDiv = document.getElementById("rufus-view-context");
+    if (!navbar ||
+        !rufusFlyoutDiv ||
+        !rufusButton ||
+        !rufusPanelCloseButton ||
+        !rufusPanelMinimizeButton ||
+        !rufusViewContextDiv) {
+        return;
+    }
+    function setElementProperty(element, propertyName, propertyValue) {
+        element.style.setProperty(propertyName, propertyValue);
+    }
+    function setUndockButtonIconForTreatment(state) {
+        if (!rufusPanelDockButton || dockingSide === "none") {
+            return;
+        }
+        // Set appropriate icon based on state and treatment
+        if (state === "expanded") {
+            const icon = dockingSide === "docked-left" ? DOCK_LEFT_ICON : DOCK_RIGHT_ICON;
+            rufusPanelDockButton.style.background = `${icon} no-repeat center transparent`;
+        }
+        else {
+            rufusPanelDockButton.style.backgroundImage = "";
+        }
+    }
+    function checkIfStateIsDocked(state) {
+        return state === "docked-left" || state === "docked-right";
+    }
+    function isRufusPanelDocking(currentState, newState) {
+        return (!checkIfStateIsDocked(currentState) && checkIfStateIsDocked(newState));
+    }
+    function handleRufusElementState(newState, previousState) {
+        rufusFlyoutDiv.setAttribute("data-state", newState);
+        rufusButton.setAttribute("data-state", newState);
+        if (dockingSide !== "none") {
+            handleBodyPadding(newState, previousState);
+        }
+    }
+    /**
+     * Handles body padding and classes for docked panel states
+     */
+    function handleBodyPadding(newState, previousState) {
+        // Only add transition classes when actually transitioning between different states
+        // (not when restoring state on page load where previousState is undefined,
+        // or when currentState === newState)
+        const isTransitioning = previousState !== undefined && previousState !== newState;
+        const isOpening = isTransitioning && checkIfStateIsDocked(newState);
+        const isClosing = isTransitioning && checkIfStateIsDocked(previousState);
+        const transitionClass = isOpening
+            ? "rufus-docked-opening-transition"
+            : isClosing
+                ? "rufus-docked-closing-transition"
+                : "";
+        document.body.style.transition = "";
+        transitionClass && document.body.classList.add(transitionClass);
+        if (newState === "closed" || newState === "expanded") {
+            const hadDockingClasses = document.body.classList.contains("rufus-docked-left") ||
+                document.body.classList.contains("rufus-docked-right");
+            document.body.classList.remove("rufus-docked-left", "rufus-docked-right");
+            // Remove adjustable width class when leaving docked state
+            document.body.classList.remove("rufus-docked-adjustable");
+            document.body.style.removeProperty("--rufus-docked-panel-width");
+            document.body.style.removeProperty("--total-rufus-panel-full-width");
+            document.body.style.removeProperty("--total-rufus-panel-half-width");
+            document.body.style.paddingLeft = "";
+            document.body.style.paddingRight = "";
+            document.body.style.paddingTop = "";
+            // Only trigger layout recalculation if the panel was actually docked before (i.e. not if we move between closed and expanded)
+            if (hadDockingClasses) {
+                triggerLayoutRecalculation();
+            }
+        }
+        else if (newState === "docked-left" || newState === "docked-right") {
+            document.body.classList.add(`rufus-${newState}`);
+            // Add adjustable width class and set dynamic panel width when entering docked state.
+            // DOCKED_PANEL_WIDTH already has the correct width from getDockedPanelWidth(),
+            // which reads from session storage (set by thick client's DockedPanelResizeHandler)
+            // or falls back to the screen-size-based default.
+            if (params.dockedPanelAdjustableWidthTreatment === "T1") {
+                document.body.classList.add("rufus-docked-adjustable");
+                document.body.style.setProperty("--rufus-docked-panel-width", `${DOCKED_PANEL_WIDTH}px`);
+                // Persist the width to session storage so on next page navigation,
+                // getDockedPanelWidth() reads it back immediately and avoids a flicker
+                // from 320px → dynamic default.
+                try {
+                    sessionStorage.setItem(DOCKED_PANEL_WIDTH_KEY, String(DOCKED_PANEL_WIDTH));
+                }
+                catch (e) {
+                    // Session storage may not be available
+                }
+            }
+            document.body.style.setProperty("--total-rufus-panel-full-width", `${TOTAL_WIDTH_TAKEN_IN_PAGE}px`);
+            document.body.style.setProperty("--total-rufus-panel-half-width", `${TOTAL_WIDTH_TAKEN_IN_PAGE / 2}px`);
+            const hasDualPanel = document.querySelector(DUAL_PANEL_SELECTOR) !== null;
+            let rightPadding = hasDualPanel ? EWC_CART_WIDTH : 0;
+            if (newState === "docked-left") {
+                document.body.style.paddingLeft = `${DOCKED_PANEL_WIDTH}px`;
+                rightPadding += BROWSER_MARGIN;
+            }
+            else if (newState === "docked-right") {
+                document.body.style.paddingLeft = `${BROWSER_MARGIN}px`;
+                rightPadding += DOCKED_PANEL_WIDTH;
+            }
+            document.body.style.paddingRight = `${rightPadding}px`;
+            document.body.style.paddingTop = `${BROWSER_MARGIN}px`;
+            triggerLayoutRecalculation();
+        }
+    }
+    /**
+     * Forces layout recalculation and notifies components of layout changes.
+     * Required when docking changes body padding to ensure proper positioning.
+     */
+    function triggerLayoutRecalculation() {
+        document.body.offsetHeight;
+        window.dispatchEvent(new CustomEvent("resize", {
+            detail: {
+                rufusAction: true
+            }
+        }));
+        if (extendedWindow.P && typeof extendedWindow.P.when === "function") {
+            extendedWindow.P.when("A").execute("rufus-force-aui-resize", function (A) {
+                A.trigger("resize", window, { width: 1, height: 1 });
+            });
+        }
+    }
+    let closeAnimationRunning = false;
+    const RESIZE_INTERVAL_MS = 10;
+    const CLEANUP_DELAY_MS = 500;
+    let resizeInterval;
+    let cleanupScheduled = false;
+    const animation_expanded_to_closed = "rufus-panel-expanded-to-closed";
+    const animation_closed_to_expanded = "rufus-panel-closed-to-expanded";
+    const animation_minimized_to_expanded = "rufus-panel-minimized-to-expanded";
+    const animation_expanded_to_minimized = "rufus-panel-expanded-to-minimized";
+    const animation_expanded_to_closed_movable = "rufus-panel-expanded-to-closed-movable";
+    const animation_closed_to_expanded_movable = "rufus-panel-closed-to-expanded-movable";
+    const animation_expanded_to_closed_movable_right_ingress = "rufus-panel-expanded-to-closed-movable-right-ingress";
+    const animation_closed_to_expanded_movable_right_ingress = "rufus-panel-closed-to-expanded-movable-right-ingress";
+    const animation_minimized_to_expanded_movable = "rufus-panel-minimized-to-expanded-movable";
+    const animation_expanded_to_minimized_movable = "rufus-panel-expanded-to-minimized-movable";
+    const animation_docked_left_to_closed = "rufus-panel-docked-left-to-closed";
+    const animation_closed_to_docked_left = "rufus-panel-closed-to-docked-left";
+    const animation_docked_right_to_closed = "rufus-panel-docked-right-to-closed";
+    const animation_closed_to_docked_right = "rufus-panel-closed-to-docked-right";
+    const animation_docked_left_to_expanded = "rufus-panel-docked-left-to-expanded";
+    const animation_expanded_to_docked_left = "rufus-panel-expanded-to-docked-left";
+    const animation_docked_right_to_expanded = "rufus-panel-docked-right-to-expanded";
+    const animation_expanded_to_docked_right = "rufus-panel-expanded-to-docked-right";
+    // Shared docked transitions (same for both regular and movable)
+    const dockedTransitions = new Map([
+        ["docked-left_closed", animation_docked_left_to_closed],
+        ["docked-right_closed", animation_docked_right_to_closed],
+        ["closed_docked-left", animation_closed_to_docked_left],
+        ["closed_docked-right", animation_closed_to_docked_right],
+        ["docked-left_expanded", animation_docked_left_to_expanded],
+        ["docked-right_expanded", animation_docked_right_to_expanded],
+        ["expanded_docked-left", animation_expanded_to_docked_left],
+        ["expanded_docked-right", animation_expanded_to_docked_right]
+    ]);
+    // Base transitions (non-movable)
+    const baseTransitions = new Map([
+        ["expanded_minimized", animation_expanded_to_minimized],
+        ["expanded_closed", animation_expanded_to_closed],
+        ["minimized_expanded", animation_minimized_to_expanded],
+        ["minimized_closed", animation_expanded_to_closed],
+        ["closed_expanded", animation_closed_to_expanded]
+    ]);
+    // Movable-specific transitions
+    const movableTransitions = new Map([
+        ["expanded_minimized", animation_expanded_to_minimized_movable],
+        ["expanded_closed", animation_expanded_to_closed_movable],
+        ["minimized_expanded", animation_minimized_to_expanded_movable],
+        ["minimized_closed", animation_expanded_to_closed],
+        ["closed_expanded", animation_closed_to_expanded_movable],
+        [
+            "expanded_closed_right_ingress",
+            animation_expanded_to_closed_movable_right_ingress
+        ],
+        [
+            "closed_expanded_right_ingress",
+            animation_closed_to_expanded_movable_right_ingress
+        ]
+    ]);
+    // Combine them
+    const animationMap = new Map([...baseTransitions, ...dockedTransitions]);
+    const animationMapMovableCL = new Map([
+        ...movableTransitions,
+        ...dockedTransitions
+    ]);
+    // Extract nileRequestId from cached panel state (matches thick client's ConversationOrchestrator init)
+    const getCachedNileRequestId = () => {
+        var _a, _b;
+        try {
+            const cacheString = sessionStorage.getItem(rufusPanelCacheKey);
+            if (!cacheString)
+                return "";
+            const cache = JSON.parse(cacheString);
+            return ((_b = (_a = cache === null || cache === void 0 ? void 0 : cache.state) === null || _a === void 0 ? void 0 : _a.requestContext) === null || _b === void 0 ? void 0 : _b.requestId) || "";
+        }
+        catch (_c) {
+            return "";
+        }
+    };
+    /**
+     * Emits a Nexus event via window.ue.event() using the same payload schema
+     * as the thick client's recordEventNexusMetric(). This ensures PANEL_RESIZE
+     * events are logged for state transitions that occur before the thick client
+     * loads, closing the data gap where these transitions were previously untracked.
+     *
+     * If ue.event is not yet available (CSM library hasn't loaded), the fully-built
+     * metric object is queued and flushed once ue.event becomes available. Timestamps
+     * are captured at call time so they remain accurate regardless of flush delay.
+     */
+    const pendingNexusEvents = [];
+    let nexusFlushIntervalId = null;
+    const MAX_FLUSH_ATTEMPTS = 30; // give up after ~30 s
+    let nexusFlushAttempts = 0;
+    function buildNexusMetric(eventName, eventDetail) {
+        const sessionId = (() => {
+            try {
+                const match = document.cookie.match(/(?:^|;)\s*session-id\s*=\s*([^\s;]+)/);
+                return match ? match[1] : "";
+            }
+            catch (_a) {
+                /* istanbul ignore next */
+                return "";
+            }
+        })();
+        const getHiddenInputValue = (name) => {
+            /* istanbul ignore next -- defensive guard: rufusFlyoutDiv is always present at init */
+            const inputs = rufusFlyoutDiv === null || rufusFlyoutDiv === void 0 ? void 0 : rufusFlyoutDiv.getElementsByTagName("input");
+            /* istanbul ignore next */
+            if (!inputs)
+                return "";
+            const input = Array.from(inputs).find(i => i.name === name);
+            return (input === null || input === void 0 ? void 0 : input.value) || "";
+        };
+        const currentEventTimeUTC = new Date().toISOString();
+        const cachedRequestId = getCachedNileRequestId();
+        return {
+            timestamp: currentEventTimeUTC,
+            messageId: `${Date.now()}-${Math.random()
+                .toString(36)
+                .slice(2)}`,
+            eventName: eventName,
+            eventDetail: eventDetail || "",
+            eventTimeUTC: currentEventTimeUTC,
+            sessionId: sessionId,
+            obfuscatedCustomerId: getHiddenInputValue("customerId"),
+            locale: getHiddenInputValue("locale"),
+            marketplaceId: getHiddenInputValue("marketplaceId"),
+            metadata: JSON.stringify({
+                program: "nile-classic-desktop",
+                fe_client: "navx"
+            }),
+            isBeta: false,
+            deviceTypeId: "",
+            directedCustomerId: "",
+            appVersion: "",
+            nileRequestId: cachedRequestId,
+            clickstreamRequestId: cachedRequestId,
+            uxSessionId: ""
+        };
+    }
+    function flushPendingNexusEvents() {
+        var _a;
+        if (!((_a = extendedWindow.ue) === null || _a === void 0 ? void 0 : _a.event)) {
+            if (++nexusFlushAttempts >= MAX_FLUSH_ATTEMPTS) {
+                pendingNexusEvents.length = 0; // drop undeliverable events
+                if (nexusFlushIntervalId !== null) {
+                    clearInterval(nexusFlushIntervalId);
+                    nexusFlushIntervalId = null;
+                }
+            }
+            return;
+        }
+        while (pendingNexusEvents.length > 0) {
+            const metric = pendingNexusEvents.shift();
+            extendedWindow.ue.event(metric, "desktop-nile", "mshop.nile.events.5");
+        }
+        // Stop polling once queue is drained
+        if (nexusFlushIntervalId !== null) {
+            clearInterval(nexusFlushIntervalId);
+            nexusFlushIntervalId = null;
+        }
+    }
+    function recordNexusEvent(eventName, eventDetail) {
+        var _a;
+        const metric = buildNexusMetric(eventName, eventDetail);
+        if ((_a = extendedWindow.ue) === null || _a === void 0 ? void 0 : _a.event) {
+            // Flush any previously queued events first (preserves ordering)
+            flushPendingNexusEvents();
+            extendedWindow.ue.event(metric, "desktop-nile", "mshop.nile.events.5");
+        }
+        else {
+            pendingNexusEvents.push(metric);
+            // Start polling for ue.event availability if not already polling
+            if (nexusFlushIntervalId === null) {
+                nexusFlushAttempts = 0;
+                nexusFlushIntervalId = setInterval(flushPendingNexusEvents, 1000);
+            }
+        }
+    }
+    function applyAnimationAndStateUpdate(currentState, newState) {
+        if (!currentState || !newState || closeAnimationRunning) {
+            return;
+        }
+        // Emit PANEL_RESIZE Nexus event for state transitions (mirrors thick client)
+        if (currentState !== newState) {
+            const panelStateResize = `${currentState}_to_${newState}`;
+            recordNexusEvent("PANEL_RESIZE", panelStateResize);
+        }
+        function resetRufusPanelClassName() {
+            rufusFlyoutDiv.className = "rufus-panel-container";
+        }
+        function addAnimationToPanel(animation) {
+            rufusFlyoutDiv.classList.add(animation);
+            // Start resize interval for docking animations
+            if (isRufusPanelDocking(currentState, newState)) {
+                if (resizeInterval) {
+                    window.clearInterval(resizeInterval);
+                }
+                resizeInterval = window.setInterval(() => {
+                    triggerLayoutRecalculation();
+                }, RESIZE_INTERVAL_MS);
+            }
+        }
+        // If currentState is equal to newState(refresh page), handle the element state and return
+        if (currentState === newState) {
+            handleRufusElementState(newState, currentState);
+            return;
+        }
+        // emit an AUI event to indicate the rufus panel state change so feature outside Rufus can respond to it accordingly to avoid CX conflict.
+        if (extendedWindow.P && typeof extendedWindow.P.when === "function") {
+            extendedWindow.P.when("A").execute(function (A) {
+                try {
+                    A.trigger("rufus-panel-state-change", currentState, newState);
+                }
+                catch (error) {
+                    logError(new Error(`AUI event trigger failed: ${error}`));
+                }
+            });
+        }
+        resetRufusPanelClassName();
+        let transitionKey = currentState + "_" + newState;
+        // Special handling when docked-right is involved so it animates to the right ingress
+        if (movableCLEnabled && dockingSide === "docked-right") {
+            if (currentState === "expanded" && newState === "closed") {
+                transitionKey = "expanded_closed_right_ingress";
+            }
+            else if (currentState === "closed" && newState === "expanded") {
+                transitionKey = "closed_expanded_right_ingress";
+            }
+        }
+        // Use the appropriate animation map based on movableCLEnabled weblab
+        const selectedAnimationMap = movableCLEnabled
+            ? animationMapMovableCL
+            : animationMap;
+        const animationClass = selectedAnimationMap.get(transitionKey) || "";
+        // 1. Add animation class
+        if (animationClass) {
+            addAnimationToPanel(animationClass);
+        }
+        else {
+            logError(new Error("Error adding animation to panel, animationClass should not be empty"));
+        }
+        // 2. Update panel state
+        function animationEndHandler() {
+            // Animation has ended, remove transitions if present, update panel state and
+            // trigger resize at animation end to reflect latest sizes
+            handleRufusElementState(newState, currentState);
+            rufusFlyoutDiv.removeEventListener("animationend", animationEndHandler);
+            document.body.classList.remove("rufus-docked-opening-transition", "rufus-docked-closing-transition");
+            if (currentState === "closed" || currentState === "expanded") {
+                // Need to trigger resize at animation end to reflect latest sizes.
+                if (checkIfStateIsDocked(currentState) ||
+                    checkIfStateIsDocked(newState)) {
+                    triggerLayoutRecalculation();
+                }
+            }
+            // Clean up resize interval (only if one exists and cleanup isn't already scheduled)
+            if (resizeInterval && !cleanupScheduled) {
+                cleanupScheduled = true;
+                window.setTimeout(() => {
+                    if (resizeInterval) {
+                        window.clearInterval(resizeInterval);
+                        resizeInterval = undefined;
+                    }
+                    cleanupScheduled = false;
+                }, CLEANUP_DELAY_MS);
+            }
+            closeAnimationRunning = false;
+        }
+        if (newState === "closed") {
+            closeAnimationRunning = true;
+            rufusFlyoutDiv.addEventListener("animationend", animationEndHandler);
+        }
+        else if (isRufusPanelDocking(currentState, newState)) {
+            rufusFlyoutDiv.addEventListener("animationend", animationEndHandler);
+        }
+        else {
+            handleRufusElementState(newState, currentState);
+        }
+    }
+    function restoreRNWStyles() {
+        const CL_RNW_STYLE_CACHE_KEY = "rufus:reactStyles";
+        try {
+            let cached = sessionStorage.getItem(CL_RNW_STYLE_CACHE_KEY);
+            if (!cached)
+                return;
+            cached = cached.replace(/\s+/g, " ").trim(); // applying normalization
+            let styleEl = document.getElementById("react-native-stylesheet");
+            if (!styleEl) {
+                styleEl = document.createElement("style");
+                styleEl.id = "react-native-stylesheet";
+                document.head.appendChild(styleEl);
+            }
+            styleEl.textContent = cached;
+        }
+        catch (error) {
+            const errorMessage = `Error while restoring React Native Web Styles: ${error}`;
+            logError(new Error(errorMessage));
+        }
+    }
+    function handleRufusPanelStateAndContent() {
+        navbar.appendChild(rufusFlyoutDiv);
+        const defaultPanelHeight = window.innerHeight * Number(rufusPanelConfig.panelHeightRatio);
+        // Weblab trigger for state persistence experiment:
+        // Eligible users are those who left the panel open (localStorage has docked state)
+        // and are starting a new browser session (no cachedState from sessionStorage)
+        let localStorageDockedState = null;
+        try {
+            localStorageDockedState = localStorage.getItem("rufus:panel:dockedState");
+        }
+        catch (_a) {
+            logCount("rufus-localStorage-not-available");
+        }
+        const isReturningUserWithPanelOpen = localStorageDockedState &&
+            localStorageDockedState !== "closed" &&
+            !cachedState;
+        if (isReturningUserWithPanelOpen && statePersistenceTreatment) {
+            if (extendedWindow.ue && extendedWindow.ue.trigger) {
+                extendedWindow.ue.trigger("RUFUS_DESKTOP_STATE_PERSISTENCE_1357774", statePersistenceTreatment);
+            }
+        }
+        setElementProperty(rufusFlyoutDiv, "--expanded-container-width", rufusPanelConfig.panelWidth);
+        setElementProperty(rufusFlyoutDiv, "--minimized-container-width", rufusPanelConfig.minimizedPanelWidth);
+        setElementProperty(rufusFlyoutDiv, "--peekView-container-width", rufusPanelConfig.peekViewPanelWidth);
+        // handle panel state
+        if (cachedState) {
+            handleRufusElementState(cachedState.viewState);
+            const height = cachedState.height
+                ? cachedState.height
+                : defaultPanelHeight;
+            const width = cachedState.width
+                ? cachedState.width
+                : rufusPanelConfig.panelWidth.slice(0, rufusPanelConfig.panelWidth.indexOf("px"));
+            const left = cachedState.left ? cachedState.left : DEFAULT_PANEL_LEFT;
+            const bottom = cachedState.bottom
+                ? cachedState.bottom
+                : DEFAULT_PANEL_BOTTOM;
+            setElementProperty(rufusFlyoutDiv, "--expanded-container-height", height + "px");
+            setElementProperty(rufusFlyoutDiv, "--expanded-container-width", width + "px");
+            setElementProperty(rufusFlyoutDiv, "--expanded-container-left", left + "px");
+            setElementProperty(rufusFlyoutDiv, "--expanded-container-bottom", bottom + "px");
+        }
+        else {
+            const persistedDockedState = sessionStorage.getItem("rufus:panel:dockedState");
+            // Only restore valid docked states - cross-session persistence is for docked panels only
+            if (persistedDockedState === "docked-left" ||
+                persistedDockedState === "docked-right") {
+                handleRufusElementState(persistedDockedState);
+            }
+            setElementProperty(rufusFlyoutDiv, "--expanded-container-height", defaultPanelHeight + "px");
+            setElementProperty(rufusFlyoutDiv, "--expanded-container-width", rufusPanelConfig.panelWidth);
+            setElementProperty(rufusFlyoutDiv, "--expanded-container-left", DEFAULT_PANEL_LEFT + "px");
+            setElementProperty(rufusFlyoutDiv, "--expanded-container-bottom", DEFAULT_PANEL_BOTTOM + "px");
+        }
+        // handle panel content
+        const cacheHitMetricName = "rufus-content-cache-hit"; // emit this metric when cached content is rendered
+        const cacheMissMetricName = "rufus-content-cache-miss"; // emit this metric when no cached content available
+        const cacheErrorMetricName = "rufus-content-cache-error"; // emit this metric when render cache failed
+        if (rufusContent && !!cacheContent) {
+            restoreRNWStyles();
+            const cacheContentRendered = updateCurrentRufusContent(cacheContent, true, noScrollTreatment);
+            logCount(cacheContentRendered ? cacheHitMetricName : cacheErrorMetricName);
+        }
+        else {
+            logCount(cacheMissMetricName);
+        }
+    }
+    function handleRufusIngressClick() {
+        const currentState = rufusFlyoutDiv.getAttribute("data-state");
+        let newState;
+        if (dockingSide === "none") {
+            newState = currentState === "expanded" ? "closed" : "expanded";
+        }
+        else {
+            if (currentState === "closed") {
+                const undock = shouldAutoUndock();
+                newState = undock ? "expanded" : dockingSide;
+                if (undock) {
+                    logCount("RUFUS_PANEL_AUTO_UNDOCK");
+                    recordNexusEvent("RUFUS_PANEL_AUTO_UNDOCK");
+                }
+            }
+            else {
+                newState = "closed";
+            }
+        }
+        const newText = newState === "expanded" ||
+            newState === "docked-left" ||
+            newState === "docked-right"
+            ? "Close Rufus panel"
+            : "Open Rufus panel";
+        rufusButton.setAttribute("aria-label", newText);
+        rufusViewContext.panelStateOnIngressClick = newState;
+        rufusViewContextDiv.value = JSON.stringify(rufusViewContext);
+        applyAnimationAndStateUpdate(currentState, newState);
+    }
+    function triggerRufusCXOnInitialLoading(data) {
+        rufusViewContext.keyword = data.query;
+        rufusViewContext.qis = data.qis;
+        rufusViewContext.metadata = data.metadata;
+        rufusViewContext.ingressPayload = data.ingressPayload;
+        rufusViewContext.refmarker = data.refmarker;
+        if (data.inContextAsin) {
+            rufusViewContext.asin = data.inContextAsin;
+        }
+        rufusViewContextDiv.value = JSON.stringify(rufusViewContext);
+        const currentState = rufusFlyoutDiv.getAttribute("data-state");
+        const newState = dockingSide !== "none" && !shouldAutoUndock() ? dockingSide : "expanded";
+        applyAnimationAndStateUpdate(currentState, newState);
+    }
+    /**
+     * It is required to pass necessary data before external client (Atocomplete widgets/Ads pills)
+     * can trigger Rufus experience.
+     */
+    function validateDataBeforeHandlingRufusStream(params) {
+        return !!(params.qis &&
+            params.metricName &&
+            (params.query || isFtuxRuxEligibleSource(params.qis)));
+    }
+    function handleRufusPanelCloseButtonClick() {
+        const currentState = rufusFlyoutDiv.getAttribute("data-state");
+        applyAnimationAndStateUpdate(currentState, "closed");
+    }
+    function handleRufusPanelDockUndockButtonClick() {
+        const currentState = rufusFlyoutDiv.getAttribute("data-state");
+        // Only allow docking/undocking if docking is enabled
+        if (dockingSide !== "none") {
+            let newState;
+            if (currentState === "expanded") {
+                // Dock the panel to the configured side
+                newState = dockingSide;
+                logCount("RUFUS_PANEL_CLICK_DOCK");
+                recordNexusEvent("RUFUS_PANEL_CLICK_DOCK");
+            }
+            else {
+                // Undock the panel back to expanded (current state must be docked)
+                newState = "expanded";
+                logCount("RUFUS_PANEL_CLICK_UNDOCK");
+                recordNexusEvent("RUFUS_PANEL_CLICK_UNDOCK");
+            }
+            // Update undock button icon for the new state
+            setUndockButtonIconForTreatment(newState);
+            applyAnimationAndStateUpdate(currentState, newState);
+        }
+    }
+    function handleRufusPanelMinimizeButtonClick() {
+        let newAnimationClass;
+        const currentState = rufusFlyoutDiv.getAttribute("data-state");
+        const newState = currentState === "minimized" ? "expanded" : "minimized";
+        applyAnimationAndStateUpdate(currentState, newState);
+    }
+    // istanbul ignore next
+    function removeEventListenerFromThinClient() {
+        rufusButton.removeEventListener("click", handleRufusIngressClick);
+        rufusPanelCloseButton.removeEventListener("click", handleRufusPanelCloseButtonClick);
+        rufusPanelMinimizeButton.removeEventListener("click", handleRufusPanelMinimizeButtonClick);
+        // Only remove dock button listener if it was added (not auto-undocking or deprecated)
+        if (dockingSide !== "none" &&
+            rufusPanelDockButton &&
+            !shouldAutoUndock() &&
+            !deprecateMovableCLEnabled) {
+            rufusPanelDockButton.removeEventListener("click", handleRufusPanelDockUndockButtonClick);
+        }
+    }
+    handleRufusPanelStateAndContent();
+    // Set initial undock button icon when docking is enabled
+    if (dockingSide !== "none") {
+        const initialState = rufusFlyoutDiv.getAttribute("data-state") || "closed";
+        setUndockButtonIconForTreatment(initialState);
+    }
+    // bind ingressButton and panelCloseButton actions in thin client to allow fundamental interaction before thick client is loaded
+    rufusButton.addEventListener("click", handleRufusIngressClick);
+    rufusPanelCloseButton.addEventListener("click", handleRufusPanelCloseButtonClick);
+    rufusPanelMinimizeButton.addEventListener("click", handleRufusPanelMinimizeButtonClick);
+    // Add dock/undock button event listener only if docking is enabled, not auto-undocking,
+    // and movable CL is not deprecated. When deprecated, undock is unreachable so hide the button
+    // immediately to prevent a flash before thick client loads and hides it.
+    if (dockingSide !== "none" &&
+        rufusPanelDockButton &&
+        !shouldAutoUndock() &&
+        !deprecateMovableCLEnabled) {
+        rufusPanelDockButton.addEventListener("click", handleRufusPanelDockUndockButtonClick);
+        rufusPanelDockButton.style.display = "block";
+    }
+    else if (rufusPanelDockButton) {
+        // Hide the dock button when auto-undocking (small screen without adjustable width),
+        // docking is disabled, or movable CL is deprecated (NILE-55788)
+        rufusPanelDockButton.style.display = "none";
+    }
+    // TODO: find ways to test it
+    // istanbul ignore next
+    if (extendedWindow.P && typeof extendedWindow.P.declare === "function") {
+        // declare a variable to allow thick client to unload thin client actions to give full control over thick client
+        extendedWindow.P.declare("rufus-thin-client", {
+            thickClientLoaded: removeEventListenerFromThinClient,
+            cacheEnabled: isCacheEnabled,
+            uniqueId: uniqueId,
+            latencyRegressionMitigationStrategy: latencyRegressionMitigationStrategy,
+            rufusNavOnlyHoldoutTreatment: rufusNavOnlyHoldoutTreatment,
+            rufusTriggerMarkerMapping: rufusTriggerMarkerMappingString,
+            pageType: rufusViewContext.pageType,
+            dockedSidePanelTreatment: dockedSidePanelTreatment,
+            dockedPanelAdjustableWidthTreatment: dockedPanelAdjustableWidthTreatment,
+            deprecateMovableCLEnabled: deprecateMovableCLEnabled,
+            // Pass the RUFUS_DESKTOP_AFO_NO_SCROLL_1414612 weblab treatment so the thick client
+            // can gate its own scroll-to-bottom logic on the same treatment value.
+            noScrollTreatment: noScrollTreatment
+        });
+        // declare a variable to allow platform outside Navyaan able to access
+        // whether Rufus feature is eligible in current browser environment
+        extendedWindow.P.declare("rufus-eligible", true);
+        extendedWindow.P.declare("rufus-nav-only-treatment", rufusNavOnlyHoldoutTreatment);
+        extendedWindow.P.declare("rufus-handle-expand", function (rufusClient) {
+            if (!rufusClient) {
+                const errorMessage = "Error handling rufus panel expand with empty rufusClient name";
+                logError(new Error(errorMessage));
+                return;
+            }
+            const metricName = rufusClient + "_expand_rufus";
+            logCount(metricName);
+            if (extendedWindow.P && typeof extendedWindow.P.now === "function") {
+                extendedWindow.P.now("rufus-expand").execute(function (expandRufus) {
+                    if (expandRufus) {
+                        expandRufus();
+                    }
+                    else {
+                        const currentState = rufusFlyoutDiv.getAttribute("data-state");
+                        const newState = dockingSide !== "none" && !shouldAutoUndock()
+                            ? dockingSide
+                            : "expanded";
+                        applyAnimationAndStateUpdate(currentState, newState);
+                    }
+                });
+            }
+        });
+        // handle streaming request outside of Navyaan eg: Rufus Autocomplete click
+        extendedWindow.P.declare("rufus-handle-stream", function (streamParams) {
+            if (!validateDataBeforeHandlingRufusStream(streamParams)) {
+                const errorMessage = "Error handling rufus stream with params: " +
+                    JSON.stringify(streamParams);
+                logError(new Error(errorMessage));
+                return;
+            }
+            logCount(streamParams.metricName);
+            if (extendedWindow.P && typeof extendedWindow.P.now === "function") {
+                extendedWindow.P.now("rufus-thick-client").execute(function (thickClient) {
+                    if (thickClient) {
+                        const startRufusStreamWithQis = featureScope.startRufusStream + ":" + streamParams.qis;
+                        logLatency(startRufusStreamWithQis, true);
+                        // directly start streaming through thick client
+                        extendedWindow.P &&
+                            extendedWindow.P.when("rufus-stream").execute(function (stream) {
+                                logLatency(startRufusStreamWithQis, false);
+                                logCount(startRufusStreamWithQis);
+                                stream(streamParams);
+                            });
+                    }
+                    else {
+                        // If thick client not loaded yet. Should initiate Rufus panel first by expanding it
+                        // and start initial streaming request in thick client with related payload
+                        const startRufusInitialLoadingWithQis = featureScope.startRufusInitialLoading + ":" + streamParams.qis;
+                        logLatency(startRufusInitialLoadingWithQis, true);
+                        logCount(startRufusInitialLoadingWithQis);
+                        triggerRufusCXOnInitialLoading(streamParams);
+                        extendedWindow.P &&
+                            extendedWindow.P.when("rufus-stream").execute(function () {
+                                logLatency(startRufusInitialLoadingWithQis, false);
+                            });
+                    }
+                });
+            }
+        });
+    }
+    function extractIngressLinkParameters(urlString) {
+        const url = new URL(urlString);
+        return {
+            rufusAction: url.searchParams.get("rufus-action"),
+            rufusClient: url.searchParams.get("rufus-client"),
+            rufusQuery: url.searchParams.get("rufus-query"),
+            rufusPayload: url.searchParams.get("rufus-payload"),
+            refmarker: url.searchParams.get("ref_")
+        };
+    }
+    function parseRufusPayloadContent(payload, allowedKeys) {
+        if (!payload) {
+            return undefined;
+        }
+        try {
+            const parsed = JSON.parse(payload);
+            // Runtime validation: ensure all values are strings
+            if (!Object.values(parsed).every(v => typeof v === "string")) {
+                return undefined;
+            }
+            if (!allowedKeys || allowedKeys.length === 0) {
+                return undefined;
+            }
+            const filtered = {};
+            for (const key of allowedKeys) {
+                if (key in parsed) {
+                    filtered[key] = parsed[key];
+                }
+            }
+            return Object.keys(filtered).length > 0 ? filtered : undefined;
+        }
+        catch (error) {
+            const errorMessage = "Error parsing rufus-payload: " + error;
+            logError(new Error(errorMessage));
+            return undefined;
+        }
+    }
+    function getClientActionPayload(clientConfigString, clientActionName) {
+        let clientConfig;
+        try {
+            clientConfig = JSON.parse(clientConfigString);
+        }
+        catch (error) {
+            const errorMessage = "Error parsing clientConfig: " + clientConfig + ". " + error;
+            logError(new Error(errorMessage));
+            return undefined;
+        }
+        const clientActionsList = clientConfig.actions ? clientConfig.actions : [];
+        return clientActionsList.find(function (action) {
+            return action.name === clientActionName;
+        });
+    }
+    function handleStream(query, qis, metricName, ingressPayload, refmarker) {
+        var _a;
+        const streamParams = {
+            query: query ? query : "",
+            qis: qis,
+            metricName: metricName,
+            metadata: {},
+            ingressPayload: ingressPayload,
+            refmarker: refmarker
+        };
+        // Further input validation for streaming is performed in stream callback
+        (_a = extendedWindow.P) === null || _a === void 0 ? void 0 : _a.when("rufus-handle-stream").execute(function (stream) {
+            stream(streamParams);
+        });
+    }
+    function handleIngressLink(externalClientsData) {
+        if (!externalClientsData) {
+            const errorMessage = "externalClients Linktree child node is undefined.";
+            logError(new Error(errorMessage));
+            return;
+        }
+        const currentPageUrl = window.location.href;
+        const rufusIngressLinkParams = extractIngressLinkParameters(currentPageUrl);
+        const rufusClient = rufusIngressLinkParams.rufusClient;
+        const rufusAction = rufusIngressLinkParams.rufusAction;
+        const rufusQuery = rufusIngressLinkParams.rufusQuery;
+        const rufusRawPayload = rufusIngressLinkParams.rufusPayload;
+        const refmarker = rufusIngressLinkParams.refmarker;
+        if (!rufusAction || !rufusClient) {
+            // Insufficient Ingress Link Parameters to trigger Rufus.
+            // This is not an error as non-Ingress Link use-cases fall under this condition.
+            return;
+        }
+        const clientConfigString = externalClientsData[rufusClient];
+        const clientActionPayload = getClientActionPayload(clientConfigString, rufusAction);
+        if (!clientActionPayload) {
+            const errorMessage = "rufus-action: " +
+                rufusAction +
+                " is not defined as an available action for rufus-client: " +
+                rufusClient +
+                " in the ExternalClients LinkTree.";
+            logError(new Error(errorMessage));
+            return;
+        }
+        const allowedPayloadKeys = clientActionPayload.context.allowedPayloadKeys;
+        const payload = parseRufusPayloadContent(rufusRawPayload, allowedPayloadKeys);
+        const clientActionType = clientActionPayload.type;
+        const metricName = rufusClient + "_" + rufusAction; // e.g. heroBanner_HolidayShopRedirect
+        switch (clientActionType) {
+            case "stream":
+                handleStream(rufusQuery, clientActionPayload.context.qis, metricName, payload, refmarker ? refmarker : undefined);
+                return;
+            default:
+                const errorMessage = "No handler exists for given Rufus actionType: " +
+                    clientActionType +
+                    ".";
+                logError(new Error(errorMessage));
+                return;
+        }
+    }
+    handleIngressLink(params.externalClientsData);
+    function makeRenderRequest() {
+        try {
+            // Render immediately when: all page types enabled, on Search/Detail pages,
+            // or panel is docked (always visible, IntersectionObserver unreliable with horizontal scroll).
+            // Otherwise, defer render until the panel becomes visible.
+            const shouldRenderImmediately = renderRequestForAllPageTypesEnabled ||
+                rufusViewContext.pageType === "Search" ||
+                rufusViewContext.pageType === "Detail" ||
+                checkIfStateIsDocked(rufusFlyoutDiv.getAttribute("data-state"));
+            if (shouldRenderImmediately) {
+                renderRufusContent(!!cacheContent, errorMessageTextToRender);
+            }
+            else {
+                observeVisibility(rufusFlyoutDiv, function () {
+                    renderRufusContent(!!cacheContent, errorMessageTextToRender);
+                });
+            }
+        }
+        catch (error) {
+            const errorMessage = "Error loading rufus content: " + error;
+            logError(new Error(errorMessage));
+        }
+    }
+    const rufusTriggerMarker = fetchRufusTriggerMarker(rufusTriggerMarkerMappingString, rufusViewContext.pageType);
+    // this timeout make sures in some edge case when latency marker is not available after specific threshold,
+    // Rufus will still continue to trigger render request accordingly as a fallback plan
+    const rufusLatencyMarkerFallbackTimeout = isValidNumber(rufusTriggerMarkerFallbackTimeoutString)
+        ? Number(rufusTriggerMarkerFallbackTimeoutString)
+        : 3000;
+    if (latencyRegressionMitigationStrategy ===
+        "shouldDelayThinClientRenderRequest" &&
+        rufusTriggerMarker &&
+        rufusTriggerMarker != "" &&
+        typeof ((_a = extendedWindow.P) === null || _a === void 0 ? void 0 : _a.when) === "function") {
+        const wrapper = wrapFunctionWithSchedulerAndExecutor(makeRenderRequest, rufusLatencyMarkerFallbackTimeout);
+        wrapper.schedule();
+        extendedWindow.P &&
+            extendedWindow.P.when(rufusTriggerMarker).execute(wrapper.forceExecute);
+    }
+    else {
+        makeRenderRequest();
+    }
+}({"rufusPanelConfigString":"{\"panelWidth\":\"320px\",\"panelHeightRatio\":\"0.5\",\"minimizedPanelWidth\":\"240px\",\"peekViewPanelWidth\":\"320px\"}","rufusViewContext":{"pageType":"F3OmnichannelPostOrder"},"isCacheEnabled":true,"uniqueId":"707afab1ed61b9dc404266b656c5b6617604c26db3858d1b24806799f479db7e","renderRequestForAllPageTypesEnabled":true,"rufusErrorMessageText":"Something went wrong. Try again later.","latencyRegressionMitigationStrategy":"shouldDelayThinClientRenderRequest","rufusTriggerMarkerMappingString":"{\"Detail\":\"dp-latency-marker\",\"Search\":\"af\",\"Gateway\":\"af\",\"ShoppingCart\":\"cf\"}","rufusTriggerMarkerFallbackTimeoutString":"3000","externalClientsData":{"rufusPricing":"{\"actions\":[{\"name\":\"ManagePriceAlertsRedirect\",\"type\":\"stream\",\"context\":{\"qis\":\"NileManagePriceAlertsExternalIngress\"}}]}","rufusAutomations":"{\"actions\":[{\"name\":\"ViewResultRedirect\",\"type\":\"stream\",\"context\":{\"qis\":\"RufusAutomations\",\"allowedPayloadKeys\":[\"automationExecutionId\",\"conversationMode\"]}}]}","rufusMarketing":"{\"actions\":[{\"name\":\"DealsRedirect\",\"type\":\"stream\",\"context\":{\"qis\":\"NileIngressOnsiteMarketing\"}},{\"name\":\"GiftingRedirect\",\"type\":\"stream\",\"context\":{\"qis\":\"NileIngressOnsiteMarketing\"}},{\"name\":\"CategoryRedirect\",\"type\":\"stream\",\"context\":{\"qis\":\"NileIngressOnsiteMarketing\"}},{\"name\":\"RecRedirect\",\"type\":\"stream\",\"context\":{\"qis\":\"RECIngressLinkExternal\"}},{\"name\":\"MerchRedirect\",\"type\":\"stream\",\"context\":{\"qis\":\"MerchAIOptionInAutocomplete\"}}]}","deepResearch":"{\"actions\":[{\"name\":\"ViewResultRedirect\",\"type\":\"stream\",\"context\":{\"qis\":\"DeepResearch\",\"allowedPayloadKeys\":[\"automationExecutionId\",\"conversationMode\"]}}]}","heroBanner":"{\"actions\":[{\"name\":\"HolidayShopRedirect\",\"type\":\"stream\",\"context\":{\"qis\":\"NileIngressLink\"}},{\"name\":\"GetStartedRedirect\",\"type\":\"stream\",\"context\":{\"qis\":\"NileIngressLink\"}}]}"},"rufusNavOnlyHoldoutTreatment":"C","movableCLEnabled":true,"dockedSidePanelTreatment":"T1","statePersistenceTreatment":"T1","dockedPanelAdjustableWidthTreatment":"C","isB2B":false,"blueHeronGatingTreatment":"T1","movableCLPersistenceTreatment":"T1","deprecateMovableCLEnabled":true,"noScrollTreatment":"T1"}));
+    })()</script>
+        
+        
+      </div>
+      <div class='nav-fill'>
+        
+ <div id="nav-shop">
+ </div>
+        <div id='nav-xshop-container'>
+          <div id='nav-xshop' class="nav-progressive-content">
+            <script type='text/javascript'>window.navmet.tmp=+new Date();</script>
+  <ul class="nav-ul">
+      
+<li class="nav-li">
+<div class="nav-div">
+<a id="nav-primeday" href="/primeday?ref_=nav_cs_td_pd_dt_cr" class="nav-a  " tabindex="0" data-csa-c-type="link" data-csa-c-slot-id="nav_cs_0" data-csa-c-content-id="nav_cs_td_pd_dt_cr">Early Prime Day</a>
+</div>
+</li>
+
+
+<li class="nav-li">
+<div class="nav-div">
+<a href="https://health.amazon.com/health-ai?ref_=nav_cs_health_ai" class="nav-a  " tabindex="0" data-csa-c-type="link" data-csa-c-slot-id="nav_cs_1" data-csa-c-content-id="nav_cs_health_ai">Health AI</a>
+</div>
+</li>
+
+
+<li class="nav-li">
+<div class="nav-div">
+<a href="/haul/store?ref_=nav_cs_hul_disb" class="nav-a  " tabindex="0" data-csa-c-type="link" data-csa-c-slot-id="nav_cs_2" data-csa-c-content-id="nav_cs_hul_disb">Amazon Haul</a>
+</div>
+</li>
+
+
+<li class="nav-li">
+<div class="nav-div" id="nav_link_allhealthingress">
+<a href="https://health.amazon.com/health-ai?ref_=nav_cs_medical_care_health_ai" class="nav-a  " data-ux-jq-mouseenter="true" tabindex="0"  data-csa-c-type="link" data-csa-c-slot-id="nav_link_allhealthingress" data-csa-c-content-id="nav_cs_medical_care_health_ai"><span>Medical Care</span>
+</a>
+<button aria-expanded="false" class="nav-flyout-button nav-icon nav-arrow" aria-label="Medical Care Details" tabindex=0></button>
+</div>
+</li>
+
+<li class="nav-li">
+<div class="nav-div">
+<a href="/gp/video/storefront?ref_=nav_cs_prime_video" class="nav-a  " tabindex="0" data-csa-c-type="link" data-csa-c-slot-id="nav_cs_4" data-csa-c-content-id="nav_cs_prime_video">Prime Video</a>
+</div>
+</li>
+
+
+<li class="nav-li">
+<div class="nav-div">
+<a href="/gp/buyagain?ie=UTF8&ref_=nav_cs_buy_again" class="nav-a  " tabindex="0" data-csa-c-type="link" data-csa-c-slot-id="nav_cs_5" data-csa-c-content-id="nav_cs_buy_again">Buy Again</a>
+</div>
+</li>
+
+
+<li class="nav-li">
+<div class="nav-div" id="nav-link-groceries">
+<a href="/fmc/learn-more?ref_=nav_cs_groceries" class="nav-a  " data-ux-jq-mouseenter="true" tabindex="0"  data-csa-c-type="link" data-csa-c-slot-id="nav-link-groceries" data-csa-c-content-id="nav_cs_groceries"><span>Groceries</span>
+</a>
+<button aria-expanded="false" class="nav-flyout-button nav-icon nav-arrow" aria-label="Groceries Details" tabindex=0></button>
+</div>
+</li>
+
+<li class="nav-li">
+<div class="nav-div">
+<a href="/live?ref_=nav_cs_amazonlive" class="nav-a  " tabindex="0" data-csa-c-type="link" data-csa-c-slot-id="nav_cs_7" data-csa-c-content-id="nav_cs_amazonlive">Livestreams</a>
+</div>
+</li>
+
+
+<li class="nav-li">
+<div class="nav-div">
+<a href="/hz/mobile/mission?ref_=nav_cs_ci_mcx_mi_d_db" class="nav-a  " tabindex="0" data-csa-c-type="link" data-csa-c-slot-id="nav_cs_8" data-csa-c-content-id="nav_cs_ci_mcx_mi_d_db">Keep Shopping For</a>
+</div>
+</li>
+
+
+<li class="nav-li">
+<div class="nav-div">
+<a href="/computer-video-games-hardware-accessories/b/?ie=UTF8&node=468642&ref_=nav_cs_video_games" class="nav-a  " tabindex="0" data-csa-c-type="link" data-csa-c-slot-id="nav_cs_9" data-csa-c-content-id="nav_cs_video_games">Video Games</a>
+</div>
+</li>
+
+
+<li class="nav-li">
+<div class="nav-div">
+<a href="https://pharmacy.amazon.com/?nodl=0&ref_=nav_cs_pharmacy" class="nav-a  " tabindex="0" data-csa-c-type="link" data-csa-c-slot-id="nav_cs_10" data-csa-c-content-id="nav_cs_pharmacy">Pharmacy</a>
+</div>
+</li>
+
+
+<li class="nav-li">
+<div class="nav-div">
+<a href="/Amazon_Basics?channel=discovbar&field-lbr_brands_browse-bin=AmazonBasics&ref_=nav_cs_amazonbasics" class="nav-a  " tabindex="0" data-csa-c-type="link" data-csa-c-slot-id="nav_cs_11" data-csa-c-content-id="nav_cs_amazonbasics">Amazon Basics</a>
+</div>
+</li>
+
+
+<li class="nav-li">
+<div class="nav-div">
+<a href="/Beauty-Makeup-Skin-Hair-Products/b/?ie=UTF8&node=3760911&ref_=nav_cs_beauty" class="nav-a  " tabindex="0" data-csa-c-type="link" data-csa-c-slot-id="nav_cs_12" data-csa-c-content-id="nav_cs_beauty">Beauty & Personal Care</a>
+</div>
+</li>
+
+
+<li class="nav-li">
+<div class="nav-div">
+<a href="/gp/bestsellers/?ref_=nav_cs_bestsellers" class="nav-a  " tabindex="0" data-csa-c-type="link" data-csa-c-slot-id="nav_cs_13" data-csa-c-content-id="nav_cs_bestsellers">Best Sellers</a>
+</div>
+</li>
+
+
+<li class="nav-li">
+<div class="nav-div">
+<a href="/hz/contact-us/foresight/hubgateway?ref_=nav_cs_fs_hybridhub_navbar_c" class="nav-a  " tabindex="0" data-csa-c-type="link" data-csa-c-slot-id="nav_cs_14" data-csa-c-content-id="nav_cs_fs_hybridhub_navbar_c">Customer Service</a>
+</div>
+</li>
+
+
+<li class="nav-li">
+<div class="nav-div">
+<a href="/Audible-Books-and-Originals/b/?ie=UTF8&node=18145289011&ref_=nav_cs_audible" class="nav-a  " tabindex="0" data-csa-c-type="link" data-csa-c-slot-id="nav_cs_15" data-csa-c-content-id="nav_cs_audible">Audible</a>
+</div>
+</li>
+
+
+<li class="nav-li">
+<div class="nav-div">
+<a href="/pet-shops-dogs-cats-hamsters-kittens/b/?ie=UTF8&node=2619533011&ref_=nav_cs_pets" class="nav-a  " tabindex="0" data-csa-c-type="link" data-csa-c-slot-id="nav_cs_16" data-csa-c-content-id="nav_cs_pets">Pet Supplies</a>
+</div>
+</li>
+
+
+<li class="nav-li">
+<div class="nav-div" id="nav-recently-viewed">
+<a href="/gp/history?ref_=nav_cs_timeline" class="nav-a  " data-ux-jq-mouseenter="true" tabindex="0"  data-csa-c-type="link" data-csa-c-slot-id="nav-recently-viewed" data-csa-c-content-id="nav_cs_timeline"><span>Browsing History</span>
+</a>
+<button aria-expanded="false" class="nav-flyout-button nav-icon nav-arrow" aria-label="Browsing History Details" tabindex=0></button>
+</div>
+</li>
+
+<li class="nav-li">
+<div class="nav-div">
+<a href="/gp/browse.html?node=120955898011&ref_=nav_cs_handmade" class="nav-a  " tabindex="0" data-csa-c-type="link" data-csa-c-slot-id="nav_cs_18" data-csa-c-content-id="nav_cs_handmade">Handmade</a>
+</div>
+</li>
+
+
+<li class="nav-li">
+<div class="nav-div">
+<a href="/auto-deliveries/landing?ref_=nav_cs_sns" class="nav-a  " tabindex="0" data-csa-c-type="link" data-csa-c-slot-id="nav_cs_19" data-csa-c-content-id="nav_cs_sns">Subscribe & Save</a>
+</div>
+</li>
+
+
+<li class="nav-li">
+<div class="nav-div">
+<a href="/computer-pc-hardware-accessories-add-ons/b/?ie=UTF8&node=541966&ref_=nav_cs_pc" class="nav-a  " tabindex="0" data-csa-c-type="link" data-csa-c-slot-id="nav_cs_20" data-csa-c-content-id="nav_cs_pc">Computers</a>
+</div>
+</li>
+
+
+<li class="nav-li">
+<div class="nav-div">
+<a href="/b/?_encoding=UTF8&ld=AZUSSOA-sell&node=12766669011&ref_=nav_cs_sell" class="nav-a  " tabindex="0" data-csa-c-type="link" data-csa-c-slot-id="nav_cs_21" data-csa-c-content-id="nav_cs_sell">Sell</a>
+</div>
+</li>
+
+
+<li class="nav-li">
+<div class="nav-div">
+<a id="nav-your-amazon" href="/gp/yourstore/home?ref_=nav_cs_ys" class="nav-a  " tabindex="0" data-csa-c-type="link" data-csa-c-slot-id="nav_cs_22" data-csa-c-content-id="nav_cs_ys"><span id="nav-your-amazon-text"><span class="nav-shortened-name">Customer</span>'s Amazon.com</span></a>
+</div>
+</li>
+
+
+<li class="nav-li">
+<div class="nav-div">
+<a href="/health-personal-care-nutrition-fitness/b/?ie=UTF8&node=3760901&ref_=nav_cs_hpc" class="nav-a  " tabindex="0" data-csa-c-type="link" data-csa-c-slot-id="nav_cs_23" data-csa-c-content-id="nav_cs_hpc">Household, Health & Baby Care</a>
+</div>
+</li>
+
+
+<li class="nav-li">
+<div class="nav-div">
+<a href="/tvs/b/?ie=UTF8&node=172659&ref_=nav_cs_tv" class="nav-a  " tabindex="0" data-csa-c-type="link" data-csa-c-slot-id="nav_cs_24" data-csa-c-content-id="nav_cs_tv">TV & Video</a>
+</div>
+</li>
+
+
+<li class="nav-li">
+<div class="nav-div">
+<a href="/gp/browse.html?node=16115931011&ref_=nav_cs_registry" class="nav-a  " tabindex="0" data-csa-c-type="link" data-csa-c-slot-id="nav_cs_25" data-csa-c-content-id="nav_cs_registry">Registry</a>
+</div>
+</li>
+
+
+<li class="nav-li">
+<div class="nav-div">
+<a href="/finds?ref_=nav_cs_foundit" class="nav-a  " tabindex="0" data-csa-c-type="link" data-csa-c-slot-id="nav_cs_26" data-csa-c-content-id="nav_cs_foundit">Shop By Interest</a>
+</div>
+</li>
+
+
+<li class="nav-li">
+<div class="nav-div" id="nav-link-amazonprime">
+<a href="/prime?ref_=nav_cs_primelink_member" class="nav-a  " data-ux-jq-mouseenter="true" tabindex="0"  data-csa-c-type="link" data-csa-c-slot-id="nav-link-amazonprime" data-csa-c-content-id="nav_cs_primelink_member"><span>Prime</span>
+</a>
+<button aria-expanded="false" class="nav-flyout-button nav-icon nav-arrow" aria-label="Prime Details" tabindex=0></button>
+</div>
+</li>
+
+<li class="nav-li">
+<div class="nav-div">
+<a href="/books-used-books-textbooks/b/?ie=UTF8&node=283155&ref_=nav_cs_books" class="nav-a  " tabindex="0" data-csa-c-type="link" data-csa-c-slot-id="nav_cs_28" data-csa-c-content-id="nav_cs_books">Books</a>
+</div>
+</li>
+
+
+<li class="nav-li">
+<div class="nav-div">
+<a href="/Kindle-eBooks/b/?ie=UTF8&node=154606011&ref_=nav_cs_kindle_books" class="nav-a  " tabindex="0" data-csa-c-type="link" data-csa-c-slot-id="nav_cs_29" data-csa-c-content-id="nav_cs_kindle_books">Kindle Books</a>
+</div>
+</li>
+
+
+<li class="nav-li">
+<div class="nav-div">
+<a href="/gp/new-releases/?ref_=nav_cs_newreleases" class="nav-a  " tabindex="0" data-csa-c-type="link" data-csa-c-slot-id="nav_cs_30" data-csa-c-content-id="nav_cs_newreleases">New Releases</a>
+</div>
+</li>
+
+
+<li class="nav-li">
+<div class="nav-div">
+<a href="/home-garden-kitchen-furniture-bedding/b/?ie=UTF8&node=1055398&ref_=nav_cs_home" class="nav-a  " tabindex="0" data-csa-c-type="link" data-csa-c-slot-id="nav_cs_31" data-csa-c-content-id="nav_cs_home">Amazon Home</a>
+</div>
+</li>
+
+
+  </ul>
+  <script type='text/javascript'>window.navmet.push({key:'CrossShop',end:+new Date(),begin:window.navmet.tmp});</script>
+          </div>
+        </div>
+      </div>
+      <div class='nav-right'>
+        <script type='text/javascript'>window.navmet.tmp=+new Date();</script><!-- Navyaan SWM -->
+<div id="nav-swmslot">
+  <!-- Scheduled SWM widget failed to render -->
+</div><script type='text/javascript'>window.navmet.push({key:'SWM',end:+new Date(),begin:window.navmet.tmp});</script>
+        
+      </div>
+    </div>
+
+    <div id='nav-subnav-toaster'></div>
+
+    
+    <div id="nav-progressive-subnav">
+      
+    </div>
+
+    <div id='nav-flyout-ewc' class='nav-ewc-lazy-align nav-ewc-hide-head'><div class='nav-flyout-body ewc-beacon' tabindex='-1'><div class='nav-ewc-arrow'></div><div class='nav-ewc-content'></div></div></div><script type='text/javascript'>
+(function() {
+  var viewportWidth = function() {
+    return window.innerWidth ||
+      document.documentElement.clientWidth ||
+      document.body.clientWidth;
+  };
+
+  if (typeof uet === 'function') {  uet('x1', 'ewc', {wb: 1}); }
+
+  window.$Nav && $Nav.declare('config.ewc', (function() {
+    var config = {"enablePersistent":true,"viewportWidthForPersistent":1400,"EWCWideViewWidth":130,"EWCCompactViewWidth":100,"rufusDockedPanelWidth":320,"rufusDockedPanelBrowserMargin":12,"isEWCLogging":1,"isEWCStateExpanded":true,"EWCStateReason":"fixed","isSmallScreenEnabled":true,"isFreshCustomer":false,"errorContent":{"html":"<div class='nav-ewc-error'><span class='nav-title'>Oops!</span><p class='nav-paragraph'>There's a problem loading your cart right now.</p><a href='/gp/cart/view.html?ref_=nav_err_ewc_timeout' class='nav-action-button'><span class='nav-action-inner'>Your Cart</span></a></div>"},"url":"/cart/ewc/compact?hostPageType=F3OmnichannelPostOrder&hostSubPageType=OrderDetails&hostPageRID=0B5GGA052RDJB96RMAEG&prerender=0","cartCount":1,"freshCartCount":0,"almCartCount":0,"primeWardrobeCartCount":0,"bazaarCartCount":0,"isCompactViewEnabled":true,"isCompactEWCRendered":true,"isWiderCompactEWCRendered":true,"EWCBrowserCacheKey":"EWC_Cache_147-7999693-6862434_AEXAMPLE00000_USD_en_US","isContentRepainted":false,"clearCache":false,"loadFromCacheWithDelay":0,"delayRenderingTillATF":false};
+    var hasAui = window.P && window.P.AUI_BUILD_DATE;
+    var isRTLEnabled = (document.dir === 'rtl');
+    config.pinnable = config.pinnable && hasAui;
+    config.isMigrationTreatment = true;
+
+    config.flyout = (function() {
+      var navbelt = document.getElementById('nav-belt');
+      var navCart = document.getElementById('nav-cart');
+      var ewcFlyout = document.getElementById('nav-flyout-ewc');
+      var persistentClassOnBody = 'nav-ewc-persistent-hover nav-ewc-full-height-persistent-hover';
+      var flyout = {};
+
+      var getDocumentScrollTop = function() {
+        return (document.documentElement && document.documentElement.scrollTop) || document.body.scrollTop;
+      };
+
+      var isWindow = function(obj) {
+        return obj != null && obj === obj.window;
+      };
+
+      var getWindow = function(elem) {
+        return isWindow(elem) ? elem : elem.nodeType === 9 && elem.defaultView;
+      };
+
+      var getOffset = function(elem) {
+        if (elem.getClientRects && !elem.getClientRects().length) {
+          return {top: 0};
+        }
+
+        var rect = elem.getBoundingClientRect
+          ? elem.getBoundingClientRect()
+          : {top: 0};
+
+        if (rect.width || rect.height) {
+          var doc = elem.ownerDocument;
+          var win = getWindow(doc);
+          return {
+            top: rect.top + win.pageYOffset - doc.documentElement.clientTop
+          };
+        }
+        return rect;
+      };
+
+      flyout.align = function() {
+        var newTop = getOffset(navbelt).top - getDocumentScrollTop();
+        ewcFlyout.style.top = (newTop > 0 ? newTop + 'px' : 0);
+      };
+
+      flyout.hide = function() {
+        isRTLEnabled
+          ? (ewcFlyout.style.left = '')
+          : (ewcFlyout.style.right = '');
+      };
+
+      if(typeof config.isCompactEWCRendered === 'undefined') {
+        if (
+          (config.isSmallScreenEnabled && viewportWidth() < 1400) ||
+          (config.isCompactViewEnabled && viewportWidth() >= 1400)
+        ) {
+          config.isCompactEWCRendered = true;
+          config.isEWCStateExpanded = true;
+          config.url = config.url.replace("/gp/navcart/sidebar", "/cart/ewc/compact");
+        } else {
+          config.isCompactEWCRendered = false;
+        }
+      }
+
+      var viewportQualifyForPersistent = function () {
+        return (config.isCompactEWCRendered)
+          ? true
+          : viewportWidth() >= 1400;
+      }
+
+      flyout.hasQualifiedViewportForPersistent = viewportQualifyForPersistent;
+
+      var rufusPanelState;
+      try {
+        rufusPanelState = sessionStorage.getItem('rufus:panel:dockedState');
+      } catch (e) {
+        rufusPanelState = null;
+      }
+
+      var rufusPanelIsDocked = function(rufusPanelViewState) {
+        return rufusPanelViewState === 'docked-right' || rufusPanelViewState === 'docked-left';
+      }
+
+      var getEWCRightOffset = function() {
+        if (rufusPanelIsDocked(rufusPanelState)) {
+          return 0 - config.EWCWideViewWidth;
+        }
+
+        if (!config.isCompactEWCRendered) {
+          return 0;
+        }
+
+        var $navbelt = document.getElementById('nav-belt');
+        if ($navbelt === undefined || $navbelt === null) {
+          return 0;
+        }
+
+        var EWCCompactViewWidth = (config.isWiderCompactEWCRendered  && viewportWidth() >= 1280) ? 130 : 100;
+        var scrollLeft = (window.pageXOffset !== undefined)
+          ? window.pageXOffset
+          : (document.documentElement || document.body.parentNode || document.body).scrollLeft;
+        var scrollXAxis = Math.abs(scrollLeft);
+        var windowWidth = document.documentElement.clientWidth;
+        var navbeltWidth = $navbelt.offsetWidth;
+        var isPartOfNavbarNotVisible = (navbeltWidth + EWCCompactViewWidth) > windowWidth;
+
+        if (isPartOfNavbarNotVisible) {
+          return 0 - (navbeltWidth - scrollXAxis - windowWidth + EWCCompactViewWidth);
+        } else {
+          return 0;
+        }
+      }
+
+      flyout.getEWCRightOffsetCssProperty = function () {
+        return getEWCRightOffset() + 'px';
+      }
+
+      if (config.isCompactEWCRendered) {
+        persistentClassOnBody = 'nav-ewc-persistent-hover nav-ewc-compact-view';
+        if (config.isWiderCompactEWCRendered) { persistentClassOnBody += ' nav-ewc-wider-compact-view'; }
+      }
+
+      flyout.show = function() {
+        isRTLEnabled
+          ? (ewcFlyout.style.left = flyout.getEWCRightOffsetCssProperty())
+          : (ewcFlyout.style.right = flyout.getEWCRightOffsetCssProperty());
+      };
+
+      var isIOSDevice = function() {
+        return (/iPad|iPhone|iPod/.test(navigator.platform) ||
+                (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1)) &&
+                !window.MSStream;
+      }
+
+      var checkForPersistent = function() {
+        if (!hasAui) {
+          return { result: false, reason: 'noAui' };
+        }
+        if (!config.enablePersistent) {
+          return { result: false, reason: 'config' };
+        }
+        if (!viewportQualifyForPersistent()) {
+          return { result: false, reason: 'viewport' };
+        }
+        if (isIOSDevice()) {
+          return { result: false, reason: 'iOS' };
+        }
+        if (!config.cartCount > 0) {
+          return { result: false, reason: 'emptycart' };
+        }
+        return { result: true };
+      };
+
+      flyout.ableToPersist = function() {
+        return checkForPersistent().result;
+      };
+      var persistentClassRegExp = '(?:^|\\s)' + persistentClassOnBody + '(?!\\S)';
+      flyout.applyPageLayoutForPersistent = function() {
+        if (!document.documentElement.className.match( new RegExp(persistentClassRegExp) )) {
+          document.documentElement.className += ' ' + persistentClassOnBody;
+        }
+      };
+
+      if (rufusPanelIsDocked(rufusPanelState) && flyout.ableToPersist()) {
+        document.body.style.transition = 'none';
+        if (rufusPanelState === 'docked-left') {
+            document.body.style.paddingRight = (config.EWCCompactViewWidth + config.rufusDockedPanelBrowserMargin) + 'px';
+        } else if (rufusPanelState === 'docked-right') {
+            document.body.style.paddingRight = (config.EWCCompactViewWidth + config.rufusDockedPanelWidth) + 'px';
+        }
+      }
+
+      P.when('A').execute('RufusPanelListener', function(A) {
+        A.on('rufus-panel-state-change', function(currentPanelState, newPanelState) {
+            rufusPanelState = newPanelState;
+            if (rufusPanelIsDocked(currentPanelState) || rufusPanelIsDocked(newPanelState)) {
+                if (flyout.ableToPersist()) {
+                    ewcFlyout.style.right = flyout.getEWCRightOffsetCssProperty();
+                }
+            }
+        });
+      });
+
+      flyout.unapplyPageLayoutForPersistent = function() {
+        document.documentElement.className = document.documentElement.className.replace( new RegExp(persistentClassRegExp, 'g'), '');
+      };
+
+      flyout.persist = function() {
+        flyout.applyPageLayoutForPersistent();
+        flyout.show();
+        if (config.isCompactEWCRendered) {
+          flyout.align();
+        }
+      };
+
+      flyout.unpersist = function() {
+        flyout.unapplyPageLayoutForPersistent();
+        flyout.hide();
+      };
+      
+      var persistentCheck = checkForPersistent();
+    
+
+      var resizeCallback = function(e) {
+        if (e && e.detail && e.detail.rufusAction) {
+          return;
+        }
+
+        
+        if (flyout.ableToPersist()) {
+          flyout.persist();
+        }
+        else {
+          flyout.unpersist();
+        }
+      };
+
+      flyout.bindEvents = function() {
+        if (window.addEventListener) {
+          window.addEventListener('resize', resizeCallback, false);
+          
+          if (config.isCompactEWCRendered) {
+            window.addEventListener('scroll', flyout.align, false);
+          }
+        }
+      };
+
+      flyout.unbindEvents = function() {
+        if (window.removeEventListener) {
+          window.removeEventListener('resize', resizeCallback, false);
+          
+          if (config.isCompactEWCRendered) {
+            window.removeEventListener('scroll', flyout.align, false);
+          }
+        }
+      };
+      
+      var ewcDefaultPersistence = function() {
+      
+        if (persistentCheck.result) {
+          flyout.persist();
+          if (window.ue && ue.tag) {
+            ue.tag('ewc:persist');
+          }
+        } else {
+          if (window.ue && ue.tag) {
+            ue.tag('ewc:unpersist');
+            if (persistentCheck.reason === 'noAui') {
+              ue.tag('ewc:unpersist:noAui');
+            }
+            if (persistentCheck.reason === 'viewport') {
+              ue.tag('ewc:unpersist:viewport');
+            }
+            if (persistentCheck.reason === 'emptycart') {
+              ue.tag('ewc:unpersist:emptycart');
+            }
+            if (persistentCheck.reason === 'iOS') {
+              ue.tag('ewc:unpersist:iOS');
+            }
+          }
+        }
+      };
+      
+      ewcDefaultPersistence();
+      
+      if (window.ue && ue.tag)  {
+        if (flyout.hasQualifiedViewportForPersistent()) {
+          ue.tag('ewc:bview');
+        }
+        else {
+          ue.tag('ewc:sview');
+        }
+      }
+      flyout.bindEvents();
+      flyout.cache = function () {
+    const cache = window.sessionStorage;
+    const CACHE_KEY = "EWCBrowserCacheKey";
+    const CACHE_EXPIRY = "EWCBrowserCacheExpiry"; 
+    const CACHE_VALUE = "EWCBrowserCacheValue"; 
+    const isSessionStorageValid = function () {
+        return window && cache && cache instanceof Storage;
+    };
+    const isCachePresent = function (key) {
+        return cache.length > 0 && cache.getItem(key);
+    }
+    const isValidType = function (value) {
+        // Prevents accessing empty key-value and internal methods(prototypes) of storage
+        // TODO: Log metrics for invalid access;
+        return value && value.constructor == String;
+    }
+    return {
+        getCache: function (key) {
+            const value = isCachePresent(key);
+            return (isValidType(value)) ? value : null;
+        },
+        setCache: function (key, value) {
+            const oldValue = isCachePresent(key);
+            const cacheExpiryTime = isCachePresent(CACHE_EXPIRY);
+            // Set the expiry when there's no existing cache - to prevent resetting expiry on page navigation
+            if (!cacheExpiryTime) {
+                var currentTime = new Date();
+                cache.setItem(CACHE_EXPIRY, new Date(currentTime.getTime() + 5 * 60000))
+            }
+            // TODO: Log length of old and new cache values when logMetrics is true
+            cache.setItem(key, value);
+        },
+        updateCacheAndEwcContainer: function (cacheKey, newEwcContent) {
+            const $ = $Nav.getNow("$");
+            const $currentEwc = $("#ewc-content");
+            if (!$currentEwc.length) {
+                var $content = $('#nav-flyout-ewc .nav-ewc-content');
+                $content.html(newEwcContent);
+                this.setCache(CACHE_KEY, cacheKey);
+                if (window.ue && window.ue.count) {
+                    var current = window.ue.count("ewc-init-cache") || 0;
+                    window.ue.count("ewc-init-cache", current + 1);
+                }
+            } else {
+                var $newEwcContent = $('<div />');
+                var EWC_CONTENT_BODY_SCROLL_SELECTOR = ".ewc-scroller--selected";
+                if (newEwcContent) { // 1. Updates EWC container with new HTML 
+                    var domParser = new DOMParser();
+                    var sandboxedEwcContent = domParser.parseFromString(newEwcContent, 'text/html');
+                    var newEwcHtmlNoScript = sandboxedEwcContent.getElementById('ewc-content');
+                    const $newEwcHtml = $newEwcContent.html(newEwcHtmlNoScript);
+
+                    const offSet = $currentEwc.find(EWC_CONTENT_BODY_SCROLL_SELECTOR).position().top - $currentEwc.find(".ewc-active-cart--selected").position().top;
+                    $currentEwc.html($newEwcHtml.html());
+                    $currentEwc.find(EWC_CONTENT_BODY_SCROLL_SELECTOR).scrollTop(offSet);
+                    if (typeof window.uex === 'function') {
+                        window.uex('ld', 'ewc-reflect-new-state', {wb: 1});
+                    }
+                } else {
+                    // 2. Fetches cached response and updates it's html with new state on EWC Update
+                    const cachedEwc = this.getCache(CACHE_VALUE);
+                    $newEwcContent = $newEwcContent[0];
+                    $(cachedEwc).map(function (elementIndex, element) {
+                         $newEwcContent.appendChild((element.id === "ewc-content") ? $currentEwc.clone()[0] : element);
+                    });
+                    newEwcContent = $newEwcContent.innerHTML;
+                    if (window.ue && window.ue.count) {
+                        var current = window.ue.count("ewc-update-cache") || 0;
+                        window.ue.count("ewc-update-cache", current + 1);
+                    }
+                }
+                $newEwcContent.remove();
+            }
+            this.setCache(CACHE_VALUE, newEwcContent);
+        },
+        removeCache: function (key) {
+            return cache.removeItem(key);
+        }
+    }
+}
+;
+      return flyout;
+    }());
+     
+     
+     
+const CACHE_KEY = "EWCBrowserCacheKey";
+const CACHE_VALUE = "EWCBrowserCacheValue"; 
+const CACHE_EXPIRY = "EWCBrowserCacheExpiry"; 
+var cache = config.flyout.cache();
+
+const isCacheValid = function () {
+  // Check for page types and tenure of the cache
+  const clearCache = config.clearCache;
+  const cacheExpiryTime = cache.getCache(CACHE_EXPIRY);
+  const isCacheExpired = new Date() > new Date(cacheExpiryTime);
+  const cacheKey = config.EWCBrowserCacheKey;
+  const oldCacheKey = cache.getCache(CACHE_KEY);
+  const isCacheValid = !clearCache && !isCacheExpired && cacheKey == oldCacheKey;
+  if (!isCacheValid && window.ue && window.ue.count) {
+    var current = window.ue.count("ewc-cache-invalidated") || 0;
+    window.ue.count("ewc-cache-invalidated", current + 1);
+  }
+  return isCacheValid;
+}
+function loadFromCache() {
+    if (window.uet && typeof window.uet === 'function') {
+        window.uet('bb', 'ewc-loaded-from-cache', {wb: 1});
+    }
+    if (cache) {
+        if (isCacheValid()) {
+            var content = cache.getCache(CACHE_VALUE);
+            if (content) {
+                var $ewcContainer = document.getElementById("nav-flyout-ewc").getElementsByClassName("nav-ewc-content")[0];
+                var $ewcContent = document.getElementById("ewc-content");
+                if ($ewcContainer && !$ewcContent) {
+                    $ewcContainer.innerHTML = content;
+                    // Execute scripts from cache
+                    const ewcJavascript = document.getElementById("ewc-content").parentNode.querySelectorAll(':scope > script');
+                    ewcJavascript.forEach(function (script) {
+                        var scriptTag = document.createElement("script");
+                        scriptTag.innerHTML = script.innerHTML;
+                        document.body.appendChild(scriptTag);
+                    });
+                    if (typeof window.uex === 'function') {
+                        window.uex('ld', 'ewc-loaded-from-cache', {wb: 1});
+                    }
+                } else if (window.ue && window.ue.count && typeof window.ue.count === 'function') {
+                    var currentFailure = window.ue.count("ewc-slow-cache") || 0;
+                    window.ue.count("ewc-slow-cache", currentFailure + 1);
+                }
+            }
+        } else {
+            cache.removeCache(CACHE_VALUE);
+            cache.removeCache(CACHE_KEY);
+            cache.removeCache(CACHE_EXPIRY);
+        }
+    }
+}
+function delayBy(delayTime) {
+    if (delayTime) {
+        window.setTimeout(function() {
+            loadFromCache();
+        }, delayTime)
+    } else {
+        loadFromCache();
+    }
+}
+if(config.delayRenderingTillATF) {
+    (window.AmazonUIPageJS ? AmazonUIPageJS : P).when('atf').execute("EverywhereCartLoadFromCacheOnAtf", function () {
+        delayBy(config.loadFromCacheWithDelay);
+    });
+} else {
+    delayBy(config.loadFromCacheWithDelay);
+}
+
+    return config;
+  }()));
+
+  if (typeof uet === 'function') {
+    uet('x2', 'ewc', {wb: 1});
+  }
+
+  if (window.ue && ue.tag) {
+    ue.tag('ewc');
+    ue.tag('ewc:prime');
+    ue.tag('ewc:cartsize:1-10');
+
+    if ( window.P && window.P.AUI_BUILD_DATE ) {
+      ue.tag('ewc:aui');
+    } else {
+      ue.tag('ewc:noAui');
+    }
+  }
+}());
+</script>
+  </div>
+
+  
+  
+
+</header>
+
+
+<script type='text/javascript'>window.navmet.push({key:'NavBar',end:+new Date(),begin:window.navmet.main});</script>
+
+
+<script type="text/javascript">
+  if (window.ue_t0) {
+    window.navmet.push({key:"NavMainPaintEnd",end:+new Date(),begin:window.ue_t0});
+    window.navmet.push({key:"NavFirstPaintEnd",end:+new Date(),begin:window.ue_t0});
+  }
+</script>
+
+
+<script type='text/javascript'>
+    <!--
+    window.$Nav && $Nav.declare('config.fixedBarBeacon',false);
+    window.$Nav && $Nav.when("data").run(function(data) { data({"freshTimeout":{"template":{"name":"flyoutError","data":{"error":{"title":"<style>#nav-flyout-fresh{width:269px;padding:0;}#nav-flyout-fresh .nav-flyout-content{padding:0;}</style><a href='/amazonfresh'><img src='https://images-na.ssl-images-amazon.com/images/G/01/omaha/images/yoda/flyout_72dpi._V270255989_.png' /></a>"}}}},"cartTimeout":{"template":{"name":"flyoutError","data":{"error":{"button":{"text":"Your Cart","url":"/gp/cart/view.html?ref_=nav_err_cart_timeout"},"title":"Oops!","paragraph":"Unable to retrieve your cart."}}}},"primeTimeout":{"template":{"name":"flyoutError","data":{"error":{"title":"<a href='/gp/prime'><img src='https://images-na.ssl-images-amazon.com/images/G/01/prime/piv/YourPrimePIV_fallback_CTA._V327346943_.jpg' /></a>"}}}},"ewcTimeout":{"template":{"name":"flyoutError","data":{"error":{"button":{"text":"Your Cart","url":"/gp/cart/view.html?ref_=nav_err_ewc_timeout"},"title":"Oops!","paragraph":"There's a problem loading your cart right now."}}}},"errorWishlist":{"template":{"name":"flyoutError","data":{"error":{"button":{"text":"Your Wishlist","url":"/gp/registry/wishlist/?ref_=nav_err_wishlist"},"title":"Oops!","paragraph":"Unable to retrieve your wishlist"}}}},"emptyWishlist":{"template":{"name":"flyoutError","data":{"error":{"button":{"text":"Your Wishlist","url":"/gp/registry/wishlist/?ref_=nav_err_empty_wishlist"},"title":"Oops!","paragraph":"Your list is empty"}}}},"yourAccountContent":{"template":{"name":"flyoutError","data":{"error":{"button":{"text":"Your Account","url":"/gp/css/homepage.html?ref_=nav_err_youraccount"},"title":"Oops!","paragraph":"Unable to retrieve your account"}}}},"shopAllTimeout":{"template":{"name":"flyoutError","data":{"error":{"paragraph":"Unable to retrieve departments, please try again later"}}}},"kindleTimeout":{"template":{"name":"flyoutError","data":{"error":{"paragraph":"Unable to retrieve list, please try again later"}}}}}); });
+window.$Nav && $Nav.when("util.templates").run("FlyoutErrorTemplate", function(templates) {
+      templates.add("flyoutError", "<# if(error.title) { #><span class='nav-title'><#=error.title #></span><# } #><# if(error.paragraph) { #><p class='nav-paragraph'><#=error.paragraph #></p><# } #><# if(error.button) { #><a href='<#=error.button.url #>' class='nav-action-button' ><span class='nav-action-inner'><#=error.button.text #></span></a><# } #>");
+    });
+window.$Nav && $Nav.when("data").run(function(data) { data({"timelineTimeout":{"html":"<div id='nav-timeline'><div id='nav-timeline-error-content'><span class='nav-title'>There’s a problem showing your shopping history right now</span><p class='nav-paragraph'>Please check your network connection or come back in a few minutes.</p></div></div>"}}); });
+    if (typeof uet == 'function') {
+    uet('bb', 'iss-init-pc', {wb: 1});
+  }
+  if (!window.$SearchJS && window.$Nav) {
+    window.$SearchJS = $Nav.make('sx');
+  }
+
+  var opts = {
+    host: "completion.amazon.com/search/complete"
+  , marketId: "1"
+  , obfuscatedMarketId: "ATVPDKIKX0DER"
+  , searchAliases: []
+  , filterAliases: []
+  , pageType: "F3OmnichannelPostOrder"
+  , requestId: "0B5GGA052RDJB96RMAEG"
+  , sessionId: "147-7999693-6862434"
+  , language: "en_US"
+  , customerId: "AEXAMPLE00000"
+  , asin: ""
+  , b2b: 0
+  , fresh: 0
+  , isJpOrCn: 0
+  , isUseAuiIss: 1
+};
+
+var issOpts = {
+    fallbackFlag: 1
+  , isDigitalFeaturesEnabled: 0
+  , isWayfindingEnabled: 1
+  , dropdown: "select.searchSelect"
+  , departmentText: "in {department}"
+  , suggestionText: "Search suggestions"
+  , recentSearchesTreatment: "C"
+  , authorSuggestionText: "Explore books by XXAUTHXX"
+  , translatedStringsMap: {"sx-recent-searches":"Recent searches","sx-your-recent-search":"Inspired by your recent search"}
+  , biaTitleText: ""
+  , biaPurchasedText: ""
+  , biaViewAllText: ""
+  , biaViewAllManageText: ""
+  , biaAndText: ""
+  , biaManageText: ""
+  , biaWeblabTreatment: ""
+  , issNavConfig: {}
+  , np: 0
+  , issCorpus: []
+  , cf: 1
+  , removeDeepNodeISS: ""
+  , trendingTreatment: "C"
+  , useAPIV2: ""
+  , opfSwitch: ""
+  , isISSDesktopRefactorEnabled: "1"
+  , useServiceHighlighting: "true"
+  , isInternal: 0
+  , isAPICachingDisabled: true
+  , isBrowseNodeScopingEnabled: false
+  , isStorefrontTemplateEnabled: false
+  , disableAutocompleteOnFocus: ""
+};
+
+  if (opts.isUseAuiIss === 1 && window.$Nav) {
+  window.$Nav.when('sx.iss').run('iss-mason-init', function(iss){
+    var issInitObj = buildIssInitObject(opts, issOpts, true);
+    new iss.IssParentCoordinator(issInitObj);
+
+    $SearchJS.declare('canCreateAutocomplete', issInitObj);
+  });
+} else if (window.$SearchJS) {
+  var iss;
+
+  // BEGIN Deprecated globals
+  var issHost = opts.host
+    , issMktid = opts.marketId
+    , issSearchAliases = opts.searchAliases
+    , updateISSCompletion = function() { iss.updateAutoCompletion(); };
+  // END deprecated globals
+
+
+  $SearchJS.when('jQuery', 'search-js-autocomplete-lib').run('autocomplete-init', initializeAutocomplete);
+  $SearchJS.when('canCreateAutocomplete').run('createAutocomplete', createAutocomplete);
+
+} // END conditional for window.$SearchJS
+  function initializeAutocomplete(jQuery) {
+  var issInitObj = buildIssInitObject(opts, issOpts);
+  $SearchJS.declare("canCreateAutocomplete", issInitObj);
+} // END initializeAutocomplete
+  function initSearchCsl(searchCSL, issInitObject) {
+  searchCSL.init(
+    opts.pageType,
+    (window.ue && window.ue.rid) || opts.requestId
+  );
+  $SearchJS.declare("canCreateAutocomplete", issInitObject);
+} // END initSearchCsl
+  function createAutocomplete(issObject) {
+  iss = new AutoComplete(issObject);
+
+  $SearchJS.publish("search-js-autocomplete", iss);
+
+  logMetrics();
+} // END createAutocomplete
+  function buildIssInitObject(opts, issOpts, isNewIss) {
+    var issInitObj = {
+        src: opts.host
+      , sessionId: opts.sessionId
+      , requestId: opts.requestId
+      , mkt: opts.marketId
+      , obfMkt: opts.obfuscatedMarketId
+      , pageType: opts.pageType
+      , language: opts.language
+      , customerId: opts.customerId
+      , fresh: opts.fresh
+      , b2b: opts.b2b
+      , aliases: opts.searchAliases
+      , fb: issOpts.fallbackFlag
+      , isDigitalFeaturesEnabled: issOpts.isDigitalFeaturesEnabled
+      , isWayfindingEnabled: issOpts.isWayfindingEnabled
+      , issPrimeEligible: issOpts.issPrimeEligible
+      , deptText: issOpts.departmentText
+      , sugText: issOpts.suggestionText
+      , filterAliases: opts.filterAliases
+      , biaWidgetUrl: opts.biaWidgetUrl
+      , recentSearchesTreatment: issOpts.recentSearchesTreatment
+      , authorSuggestionText: issOpts.authorSuggestionText
+      , translatedStringsMap: issOpts.translatedStringsMap
+      , biaTitleText: ""
+      , biaPurchasedText: ""
+      , biaViewAllText: ""
+      , biaViewAllManageText: ""
+      , biaAndText: ""
+      , biaManageText: ""
+      , biaWeblabTreatment: ""
+      , issNavConfig: issOpts.issNavConfig
+      , cf: issOpts.cf
+      , ime: opts.isJpOrCn
+      , mktid: opts.marketId
+      , qs: opts.isJpOrCn
+      , issCorpus: issOpts.issCorpus
+      , deepNodeISS: {
+          searchAliasAccessor: function($) {
+            return (window.SearchPageAccess && window.SearchPageAccess.searchAlias()) ||
+                   $('select.searchSelect').children().attr('data-root-alias');
+          },
+          searchAliasDisplayNameAccessor: function() {
+            return (window.SearchPageAccess && window.SearchPageAccess.searchAliasDisplayName());
+          }
+        }
+      , removeDeepNodeISS: issOpts.removeDeepNodeISS
+      , trendingTreatment: issOpts.trendingTreatment
+      , useAPIV2: issOpts.useAPIV2
+      , opfSwitch: issOpts.opfSwitch
+      , isISSDesktopRefactorEnabled: issOpts.isISSDesktopRefactorEnabled
+      , useServiceHighlighting: issOpts.useServiceHighlighting
+      , isInternal: issOpts.isInternal
+      , isAPICachingDisabled: issOpts.isAPICachingDisabled
+      , isBrowseNodeScopingEnabled: issOpts.isBrowseNodeScopingEnabled
+      , isStorefrontTemplateEnabled: issOpts.isStorefrontTemplateEnabled
+      , disableAutocompleteOnFocus: issOpts.disableAutocompleteOnFocus
+      , asin: opts.asin
+    };
+  
+    // If we aren't using the new ISS then we need to add these properties
+    
+    if (!isNewIss) {
+      issInitObj.dd = issOpts.dropdown; // The element with id searchDropdownBox doesn't exist in C.
+      issInitObj.imeSpacing = issOpts.imeSpacing;
+      issInitObj.isNavInline = 1;
+      issInitObj.triggerISSOnClick = 0;
+      issInitObj.sc = 1;
+      issInitObj.np = issOpts.np;
+    }
+  
+    return issInitObj;
+  } // END buildIssInitObject
+  function logMetrics() {
+  if (typeof uet == 'function' && typeof uex == 'function') {
+      uet('be', 'iss-init-pc',
+          {
+              wb: 1
+          });
+      uex('ld', 'iss-init-pc',
+          {
+              wb: 1
+          });
+  }
+} // END logMetrics
+  
+    
+window.$Nav && $Nav.declare('config.navDeviceType','desktop');
+
+window.$Nav && $Nav.declare('config.navDebugHighres',false);
+
+window.$Nav && $Nav.declare('config.pageType','F3OmnichannelPostOrder');
+window.$Nav && $Nav.declare('config.subPageType','OrderDetails');
+
+window.$Nav && $Nav.declare('config.dynamicMenuUrl','\x2Fgp\x2Fnavigation\x2Fajax\x2Fdynamic\x2Dmenu.html');
+
+window.$Nav && $Nav.declare('config.dismissNotificationUrl','\x2Fgp\x2Fnavigation\x2Fajax\x2Fdismissnotification.html');
+
+window.$Nav && $Nav.declare('config.enableDynamicMenus',true);
+
+window.$Nav && $Nav.declare('config.isInternal',false);
+
+window.$Nav && $Nav.declare('config.isBackup',false);
+
+window.$Nav && $Nav.declare('config.isRecognized',true);
+
+window.$Nav && $Nav.declare('config.transientFlyoutTrigger','\x23nav\x2Dtransient\x2Dflyout\x2Dtrigger');
+
+window.$Nav && $Nav.declare('config.subnavFlyoutUrl','\x2Fnav\x2Fajax\x2FsubnavFlyout');
+window.$Nav && $Nav.declare('config.isSubnavFlyoutMigrationEnabled',true);
+
+window.$Nav && $Nav.declare('config.recordEvUrl','\x2Fgp\x2Fnavigation\x2Fajax\x2Frecordevent.html');
+window.$Nav && $Nav.declare('config.recordEvInterval',15000);
+window.$Nav && $Nav.declare('config.sessionId','147\x2D7999693\x2D6862434');
+window.$Nav && $Nav.declare('config.requestId','0B5GGA052RDJB96RMAEG');
+
+window.$Nav && $Nav.declare('config.alexaListEnabled',true);
+
+window.$Nav && $Nav.declare('config.readyOnATF',false);
+
+window.$Nav && $Nav.declare('config.dynamicMenuArgs',{"rid":"0B5GGA052RDJB96RMAEG","isFullWidthPrime":0,"isPrime":1,"dynamicRequest":1,"weblabs":"","isFreshRegionAndCustomer":"","primeMenuWidth":450});
+
+window.$Nav && $Nav.declare('config.customerName','Customer');
+
+window.$Nav && $Nav.declare('config.customerCountryCode','US');
+
+window.$Nav && $Nav.declare('config.yourAccountPrimeURL','https\x3A\x2F\x2Fwww.amazon.com\x2Fgp\x2Fcss\x2Forder\x2Dhistory\x2Futils\x2Ffirst\x2Dorder\x2Dfor\x2Dcustomer.html\x2Fref\x3Dya_prefetch_beacon\x3Fie\x3DUTF8\x26s\x3D147\x2D7999693\x2D6862434');
+
+window.$Nav && $Nav.declare('config.yourAccountPrimeHover',true);
+
+window.$Nav && $Nav.declare('config.searchBackState',{});
+
+window.$Nav && $Nav.declare('nav.inline');
+
+(function (i) {
+  if(window._navbarSpriteUrl) {
+    i.onload = function() {window.uet && uet('ne')};
+    i.src = window._navbarSpriteUrl;
+  }
+}(new Image()));
+
+window.$Nav && $Nav.declare('config.autoFocus',false);
+
+window.$Nav && $Nav.declare('config.responsiveTouchAgents',["ieTouch"]);
+
+window.$Nav && $Nav.declare('config.responsiveGW',false);
+
+window.$Nav && $Nav.declare('config.pageHideEnabled',false);
+
+window.$Nav && $Nav.declare('config.sslTriggerType','flyoutProximityLarge');
+window.$Nav && $Nav.declare('config.sslTriggerRetry',0);
+
+window.$Nav && $Nav.declare('config.doubleCart',false);
+
+window.$Nav && $Nav.declare('config.signInOverride',false);
+
+window.$Nav && $Nav.declare('config.signInTooltip',false);
+
+window.$Nav && $Nav.declare('config.isPrimeMember',true);
+
+window.$Nav && $Nav.declare('config.packardGlowTooltip',false);
+
+window.$Nav && $Nav.declare('config.packardGlowFlyout',false);
+
+window.$Nav && $Nav.declare('config.rightMarginAlignEnabled',true);
+
+window.$Nav && $Nav.declare('config.flyoutAnimation',false);
+
+window.$Nav && $Nav.declare('config.primeTooltip',{"url":"/gp/prime/digital-adoption/navigation-bar"});
+
+window.$Nav && $Nav.declare('config.primeDay',false);
+
+window.$Nav && $Nav.declare('config.disableBuyItAgain',false);
+
+window.$Nav && $Nav.declare('config.enableCrossShopBiaFlyout',false);
+
+window.$Nav && $Nav.declare('config.pseudoPrimeFirstBrowse',null);
+
+window.$Nav && $Nav.declare('config.csYourAccount',false);
+
+window.$Nav && $Nav.declare('config.cartFlyoutDisabled',true);
+
+window.$Nav && $Nav.declare('config.isTabletBrowser',false);
+
+window.$Nav && $Nav.declare('config.HmenuProximityArea',[200,200,200,200]);
+
+window.$Nav && $Nav.declare('config.HMenuIsProximity',true);
+
+window.$Nav && $Nav.declare('config.isPureAjaxALF',false);
+
+window.$Nav && $Nav.declare('config.accountListFlyoutRedesign',false);
+
+window.$Nav && $Nav.declare('config.navfresh',false);
+
+window.$Nav && $Nav.declare('config.isFreshRegion',false);
+
+if (window.ue && ue.tag) { ue.tag('navbar'); };
+
+window.$Nav && $Nav.declare('config.blackbelt',true);
+
+window.$Nav && $Nav.declare('config.beaconbelt',true);
+
+window.$Nav && $Nav.declare('config.accountList',true);
+
+window.$Nav && $Nav.declare('config.iPadTablet',false);
+
+window.$Nav && $Nav.declare('config.searchapiEndpoint',false);
+
+window.$Nav && $Nav.declare('config.timeline',true);
+
+window.$Nav && $Nav.declare('config.timelineAsinPriceEnabled',false);
+
+window.$Nav && $Nav.declare('config.timelineDeleteEnabled',true);
+
+window.$Nav && $Nav.declare('config.dynamicTimelineDeleteArgs','0');
+
+window.$Nav && $Nav.declare('config.extendedFlyout',false);
+
+window.$Nav && $Nav.declare('config.flyoutCloseDelay',600);
+
+window.$Nav && $Nav.declare('config.pssFlag',0);
+
+window.$Nav && $Nav.declare('config.isPrimeTooltipMigrated',false);
+
+window.$Nav && $Nav.declare('config.hashCustomerAndSessionId','15c4204703b06687d5b32d2b532a3bb745f85ef0');
+
+window.$Nav && $Nav.declare('config.isExportMode',false);
+
+window.$Nav && $Nav.declare('config.languageCode','en_US');
+
+window.$Nav && $Nav.declare('config.environmentVFI','AmazonNavigationOrchestrator\x2Fdevelopment\x40B6465513042\x2DAL2023_aarch64');
+
+window.$Nav && $Nav.declare('config.isHMenuBrowserCacheDisable',false);
+
+window.$Nav && $Nav.declare('config.signInUrlWithRefTag','null');
+
+window.$Nav && $Nav.declare('config.regionalStores',[]);
+
+window.$Nav && $Nav.declare('config.isALFRedesignPT2',true);
+
+window.$Nav && $Nav.declare('config.isNavALFRegistryGiftList',false);
+
+window.$Nav && $Nav.declare('config.marketplaceId','ATVPDKIKX0DER');
+
+window.$Nav && $Nav.declare('config.exportTransitionState',null);
+
+window.$Nav && $Nav.declare('config.enableAeeXopFlyout',false);
+
+window.$Nav && $Nav.declare('config.isPrimeFlyoutMigrationEnabled',false);
+
+
+
+window.$Nav && $Nav.declare('config.isAjaxPaymentNotificationMigrated',false);
+
+window.$Nav && $Nav.declare('config.isAjaxPaymentSuppressNotificationMigrated',false);
+
+if (window.P && typeof window.P.declare === "function" && typeof window.P.now === "function") {
+  window.P.now('packardGlowIngressJsEnabled').execute(function(glowEnabled) {
+    if (!glowEnabled) {
+      window.P.declare('packardGlowIngressJsEnabled', true);
+    }
+  });
+  window.P.now('packardGlowStoreName').execute(function(storeName) {
+    if (!storeName) {
+      window.P.declare('packardGlowStoreName','generic');
+    }
+  });
+}
+
+window.$Nav && $Nav.declare('configComplete');
+
+    -->
+</script>
+
+
+<a id="skippedLink" tabindex="-1"></a>
+
+<script type='text/javascript'>window.navmet.MainEnd = new Date();</script>
+<script type="text/javascript">
+    if (window.ue_t0) {
+      window.navmet.push({key:"NavMainEnd",end:+new Date(),begin:window.ue_t0});
+    }
+</script>
+<!-- sp:end-feature:navbar -->
+<!-- sp:feature:configured-sitewide-before-host-atf-assets -->
+<!-- sp:end-feature:configured-sitewide-before-host-atf-assets -->
+<!-- sp:feature:host-atf -->
+
+
+
+<!-- Page ATF -->
+<script>
+    window.P && P.register('sp.load.js');
+</script>
+
+
+
+
+
+
+<div id="odp-header-section">
+    
+
+
+<div id="ufpo-subheader-nav-list-section" class="a-section a-spacing-base a-spacing-top-base a-padding-base a-subheader a-breadcrumb">
+    
+        <ul class="a-unordered-list a-horizontal" role="navigation">
+            <li><span class="a-list-item">
+                <a class="a-link-normal" href="/gp/css/homepage.html/ref=fopo_odp">
+                    <span class="a-color-secondary">
+                        Your Account
+                    </span>
+                </a>
+            </span></li>
+            <li class="a-breadcrumb-divider"><span class="a-list-item">
+                <span class="a-color-secondary">&#8250;</span>
+            </span></li>
+            <li><span class="a-list-item">
+                <a class="a-link-normal" href="/gp/css/order-history?ref_=fopo_odp">
+                    <span class="a-color-secondary">
+                        Your Orders
+                    </span>
+                </a>
+            </span></li>
+            <li class="a-breadcrumb-divider"><span class="a-list-item">
+                <span class="a-color-secondary">&#8250;</span>
+            </span></li>
+            <li><span class="a-list-item">
+                <span class="a-color-state">
+                    Order Details
+                </span>
+            </span></li>
+        </ul>
+    
+</div>
+
+</div>
+
+<div id="odp__spinner-utils__container">
+    <div id="odp__spinner-utils__backdrop"> </div>
+    <div id="odp__spinner-utils__spinner" class="a-spinner-wrapper"><span class="a-spinner a-spinner-medium"></span></div>
+</div>
+
+<div id="odp-main-section">
+    
+
+
+<div id="imb__alert-container">
+    <template id="imb__alert-template__text">
+        <div class="a-box a-alert a-alert-info" aria-live="polite" aria-atomic="true"><div class="a-box-inner a-alert-container"><h4 class="a-alert-heading">&nbsp</h4><i class="a-icon a-icon-alert" aria-hidden="true"></i><div class="a-alert-content">
+            &nbsp
+        </div></div></div>
+    </template>
+    <template id="imb__alert-template__button">
+        <div class="a-box a-alert a-alert-info imb__button-alert" aria-live="polite" aria-atomic="true"><div class="a-box-inner a-alert-container"><h4 class="a-alert-heading">&nbsp</h4><i class="a-icon a-icon-alert" aria-hidden="true"></i><div class="a-alert-content">
+            <span class="imb__button-alert__text">
+                &nbsp
+            </span>
+            <span class="a-button a-button-primary"><span class="a-button-inner"><a href="/" class="a-button-text">
+                &nbsp
+            </a></span></span>
+        </div></div></div>
+    </template>
+</div>
+
+
+    <div id="od-banner-container">
+        
+            <div id="f3_food_ProgressTracker" class="odp-widget-wrapper celwidget" cel_widget_id="f3_food_ProgressTracker">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<div id="progress-tracker" class="a-section">
+    <div id="ufpo-order-status-container" class="a-section a-spacing-top-base">
+        <h2 id="ufpo-order-status-primary" class="a-size-medium-plus a-spacing-none a-color-base a-text-bold">
+            Purchased at Whole Foods Market - Domain
+        </h2>
+        
+        
+            
+            
+                <img alt="Whole Foods Market" src="https://m.media-amazon.com/images/I/21HB0K7NhPL._SS60_.png" class="ufpo-brand-logo" data-a-hires="https://m.media-amazon.com/images/I/21HB0K7NhPL._SS120_.png"/>
+            
+        
+        
+            <span id="ufpo-order-status-secondary" class="a-size-base a-color-secondary">
+                
+                    Purchased on Saturday, February 17, 2024
+                
+            </span>
+        
+    </div>
+
+    
+
+    
+    
+    
+    
+    
+    
+    <div id="progress-tracker-refresh-data" data-orderId="113-0788486-7971417" data-primaryStatus="PURCHASED_INSTORE" class="a-section"></div>
+</div>
+
+
+</div>
+
+        
+            <div id="f3_food_ItemList" class="odp-widget-wrapper celwidget" cel_widget_id="f3_food_ItemList">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<div class="a-row a-spacing-base">
+    <h2 class="widget-title-string">
+        <span id="ufpo-item-list-title" class="a-size-medium">
+            Items in your order
+        </span>
+    </h2>
+</div>
+
+<hr aria-hidden="true" class="a-spacing-small a-spacing-top-small a-divider-normal"/>
+
+
+
+
+
+
+
+
+
+
+
+
+
+    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<div class="a-row a-spacing-base">
+    <div class="a-column a-span2 a-ws-span1">
+        <img alt="B07887281X-0" src="https://m.media-amazon.com/images/I/41q81nvz5YL._SS70_.jpg" class="ufpo-itemListWidget-image" data-a-hires="https://m.media-amazon.com/images/I/51Zs-QaEUbL._SS110_.jpg"/>
+    </div>
+    <div class="a-column a-span10 a-ws-span11 a-span-last">
+        <div class="a-row a-spacing-none">
+            <div class="a-column a-span10">
+                
+                    
+                        <a class="a-size-small a-link-normal" target="_blank" rel="noopener" href="/dp/B07887281X?ref_=wfmInStore_food_od_product_details">
+                            Emmi, Raw Kaltbach Cave Aged Gruyere
+                        </a>
+                    
+                    
+                
+            </div>
+            <div class="a-column a-span2 a-span-last">
+                <div class="a-section a-spacing-none a-text-right">
+                    <div class="a-row a-spacing-none">
+                        <span class="a-size-small">
+                            $7.75
+                        </span>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="a-row a-spacing-none">
+            <span class="a-size-small">
+                Qty: 0.31 lb
+            </span>
+            <span class="a-size-small">
+                 @ 
+            </span>
+            
+                
+                
+                    <span class="a-size-small">
+                        $24.99/lb
+                    </span>
+                
+            
+        </div>
+        
+        
+        
+        <div class="a-row a-spacing-top-micro">
+            
+        </div>
+    </div>
+</div>
+    <hr aria-hidden="true" class="a-spacing-small a-spacing-top-small a-divider-normal"/>
+
+    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<div class="a-row a-spacing-base">
+    <div class="a-column a-span2 a-ws-span1">
+        <img alt="B0829RV69F-1" src="https://m.media-amazon.com/images/I/41XmQSZQeAL._SS70_.jpg" class="ufpo-itemListWidget-image" data-a-hires="https://m.media-amazon.com/images/I/51cPoBaVK9L._SS110_.jpg"/>
+    </div>
+    <div class="a-column a-span10 a-ws-span11 a-span-last">
+        <div class="a-row a-spacing-none">
+            <div class="a-column a-span10">
+                
+                    
+                        <a class="a-size-small a-link-normal" target="_blank" rel="noopener" href="/dp/B0829RV69F?ref_=wfmInStore_food_od_product_details">
+                            Organic Cosmic Crisp Apples
+                        </a>
+                    
+                    
+                
+            </div>
+            <div class="a-column a-span2 a-span-last">
+                <div class="a-section a-spacing-none a-text-right">
+                    <div class="a-row a-spacing-none">
+                        <span class="a-size-small">
+                            $5.26
+                        </span>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="a-row a-spacing-none">
+            <span class="a-size-small">
+                Qty: 2.12 lb
+            </span>
+            <span class="a-size-small">
+                 @ 
+            </span>
+            
+                
+                
+                    <span class="a-size-small">
+                        $3.99/lb
+                    </span>
+                
+            
+        </div>
+        
+        
+            <div class="a-row a-spacing-top-micro">
+                <i class="a-icon a-icon-success" role="presentation"></i>
+                <span class="a-size-small a-color-success">
+                    $3.16 promotions applied
+                </span>
+            </div>
+        
+        
+        <div class="a-row a-spacing-top-micro">
+            
+        </div>
+    </div>
+</div>
+    <hr aria-hidden="true" class="a-spacing-small a-spacing-top-small a-divider-normal"/>
+
+    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<div class="a-row a-spacing-base">
+    <div class="a-column a-span2 a-ws-span1">
+        <img alt="B07QKGJF1F-2" src="https://m.media-amazon.com/images/I/41+yXwEwvKL._SS70_.jpg" class="ufpo-itemListWidget-image" data-a-hires="https://m.media-amazon.com/images/I/61a2OrxKBGL._SS110_.jpg"/>
+    </div>
+    <div class="a-column a-span10 a-ws-span11 a-span-last">
+        <div class="a-row a-spacing-none">
+            <div class="a-column a-span10">
+                
+                    
+                        <a class="a-size-small a-link-normal" target="_blank" rel="noopener" href="/dp/B07QKGJF1F?ref_=wfmInStore_food_od_product_details">
+                            Whole Foods Market, Croissant Butter Mini 12 Count, 10 Ounce
+                        </a>
+                    
+                    
+                
+            </div>
+            <div class="a-column a-span2 a-span-last">
+                <div class="a-section a-spacing-none a-text-right">
+                    <div class="a-row a-spacing-none">
+                        <span class="a-size-small">
+                            $7.49
+                        </span>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="a-row a-spacing-none">
+            <span class="a-size-small">
+                Qty: 1
+            </span>
+            <span class="a-size-small">
+                 @ 
+            </span>
+            
+                
+                
+                    <span class="a-size-small">
+                        $7.49 each
+                    </span>
+                
+            
+        </div>
+        
+        
+        
+        <div class="a-row a-spacing-top-micro">
+            
+        </div>
+    </div>
+</div>
+    <hr aria-hidden="true" class="a-spacing-small a-spacing-top-small a-divider-normal"/>
+
+
+
+
+    <div class="a-row a-expander-container a-expander-inline-container">
+        <div data-expanded="false" class="a-expander-content ufpo-expander-content a-expander-inline-content a-expander-inner" style="display:none">
+            
+
+
+
+
+
+
+
+
+
+
+
+    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<div class="a-row a-spacing-base">
+    <div class="a-column a-span2 a-ws-span1">
+        <img alt="B074J67WLY-3" src="https://m.media-amazon.com/images/I/31awDj-27iL._SS70_.jpg" class="ufpo-itemListWidget-image" data-a-hires="https://m.media-amazon.com/images/I/71pbftlFKdL._SS110_.jpg"/>
+    </div>
+    <div class="a-column a-span10 a-ws-span11 a-span-last">
+        <div class="a-row a-spacing-none">
+            <div class="a-column a-span10">
+                
+                    
+                        <a class="a-size-small a-link-normal" target="_blank" rel="noopener" href="/dp/B074J67WLY?ref_=wfmInStore_food_od_product_details">
+                            365 Everyday Value, 100% Florida Orange Juice Not From Concentrate, Calcium + Vitamin D, 59 fl oz
+                        </a>
+                    
+                    
+                
+            </div>
+            <div class="a-column a-span2 a-span-last">
+                <div class="a-section a-spacing-none a-text-right">
+                    <div class="a-row a-spacing-none">
+                        <span class="a-size-small">
+                            $4.79
+                        </span>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="a-row a-spacing-none">
+            <span class="a-size-small">
+                Qty: 1
+            </span>
+            <span class="a-size-small">
+                 @ 
+            </span>
+            
+                
+                
+                    <span class="a-size-small">
+                        $4.79 each
+                    </span>
+                
+            
+        </div>
+        
+        
+        
+        <div class="a-row a-spacing-top-micro">
+            
+        </div>
+    </div>
+</div>
+    <hr aria-hidden="true" class="a-spacing-small a-spacing-top-small a-divider-normal"/>
+
+    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<div class="a-row a-spacing-base">
+    <div class="a-column a-span2 a-ws-span1">
+        <img alt="B08L957CP3-4" src="https://m.media-amazon.com/images/I/41EESe9tZpL._SS70_.jpg" class="ufpo-itemListWidget-image" data-a-hires="https://m.media-amazon.com/images/I/81kQbHF-s2L._SS110_.jpg"/>
+    </div>
+    <div class="a-column a-span10 a-ws-span11 a-span-last">
+        <div class="a-row a-spacing-none">
+            <div class="a-column a-span10">
+                
+                    
+                        <a class="a-size-small a-link-normal" target="_blank" rel="noopener" href="/dp/B08L957CP3?ref_=wfmInStore_food_od_product_details">
+                            Bubbies Mochi Blood Orange Mochi Ice Cream, 1.25 OZ
+                        </a>
+                    
+                    
+                
+            </div>
+            <div class="a-column a-span2 a-span-last">
+                <div class="a-section a-spacing-none a-text-right">
+                    <div class="a-row a-spacing-none">
+                        <span class="a-size-small">
+                            $2.00
+                        </span>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="a-row a-spacing-none">
+            <span class="a-size-small">
+                Qty: 1
+            </span>
+            <span class="a-size-small">
+                 @ 
+            </span>
+            
+                
+                
+                    <span class="a-size-small">
+                        $2.00 each
+                    </span>
+                
+            
+        </div>
+        
+        
+        
+        <div class="a-row a-spacing-top-micro">
+            
+        </div>
+    </div>
+</div>
+    <hr aria-hidden="true" class="a-spacing-small a-spacing-top-small a-divider-normal"/>
+
+    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<div class="a-row a-spacing-base">
+    <div class="a-column a-span2 a-ws-span1">
+        <img alt="B099L7DMCK-5" src="https://m.media-amazon.com/images/I/51TV+YbHqJL._SS70_.jpg" class="ufpo-itemListWidget-image" data-a-hires="https://m.media-amazon.com/images/I/818u57iTxOL._SS110_.jpg"/>
+    </div>
+    <div class="a-column a-span10 a-ws-span11 a-span-last">
+        <div class="a-row a-spacing-none">
+            <div class="a-column a-span10">
+                
+                    
+                        <a class="a-size-small a-link-normal" target="_blank" rel="noopener" href="/dp/B099L7DMCK?ref_=wfmInStore_food_od_product_details">
+                            Sanpellegrino Italian Sparkling Drink Limonata, Sparkling Lemon Beverage, 6 Pack Of Cans 11.15 fl oz
+                        </a>
+                    
+                    
+                
+            </div>
+            <div class="a-column a-span2 a-span-last">
+                <div class="a-section a-spacing-none a-text-right">
+                    <div class="a-row a-spacing-none">
+                        <span class="a-size-small">
+                            $6.79
+                        </span>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="a-row a-spacing-none">
+            <span class="a-size-small">
+                Qty: 1
+            </span>
+            <span class="a-size-small">
+                 @ 
+            </span>
+            
+                
+                
+                    <span class="a-size-small">
+                        $6.79 each
+                    </span>
+                
+            
+        </div>
+        
+        
+        
+        <div class="a-row a-spacing-top-micro">
+            
+        </div>
+    </div>
+</div>
+    <hr aria-hidden="true" class="a-spacing-small a-spacing-top-small a-divider-normal"/>
+
+    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<div class="a-row a-spacing-base">
+    <div class="a-column a-span2 a-ws-span1">
+        <img alt="B01M9CGKKY-6" src="https://m.media-amazon.com/images/I/31Na-42Jj9L._SS70_.jpg" class="ufpo-itemListWidget-image" data-a-hires="https://m.media-amazon.com/images/I/51MCU418OdL._SS110_.jpg"/>
+    </div>
+    <div class="a-column a-span10 a-ws-span11 a-span-last">
+        <div class="a-row a-spacing-none">
+            <div class="a-column a-span10">
+                
+                    
+                        <a class="a-size-small a-link-normal" target="_blank" rel="noopener" href="/dp/B01M9CGKKY?ref_=wfmInStore_food_od_product_details">
+                            Lindeman's, Lambic Framboise, 25.4 Fl Oz
+                        </a>
+                    
+                    
+                
+            </div>
+            <div class="a-column a-span2 a-span-last">
+                <div class="a-section a-spacing-none a-text-right">
+                    <div class="a-row a-spacing-none">
+                        <span class="a-size-small">
+                            $12.99
+                        </span>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="a-row a-spacing-none">
+            <span class="a-size-small">
+                Qty: 1
+            </span>
+            <span class="a-size-small">
+                 @ 
+            </span>
+            
+                
+                
+                    <span class="a-size-small">
+                        $12.99 each
+                    </span>
+                
+            
+        </div>
+        
+        
+        
+        <div class="a-row a-spacing-top-micro">
+            
+        </div>
+    </div>
+</div>
+    <hr aria-hidden="true" class="a-spacing-small a-spacing-top-small a-divider-normal"/>
+
+    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<div class="a-row a-spacing-base">
+    <div class="a-column a-span2 a-ws-span1">
+        <img alt="B079VNKTVM-7" src="https://m.media-amazon.com/images/I/41Vh2ZTljlL._SS70_.jpg" class="ufpo-itemListWidget-image" data-a-hires="https://m.media-amazon.com/images/I/61dQt-80ztL._SS110_.jpg"/>
+    </div>
+    <div class="a-column a-span10 a-ws-span11 a-span-last">
+        <div class="a-row a-spacing-none">
+            <div class="a-column a-span10">
+                
+                    
+                        <a class="a-size-small a-link-normal" target="_blank" rel="noopener" href="/dp/B079VNKTVM?ref_=wfmInStore_food_od_product_details">
+                            Jarlsberg Jarlsberg Wheel
+                        </a>
+                    
+                    
+                
+            </div>
+            <div class="a-column a-span2 a-span-last">
+                <div class="a-section a-spacing-none a-text-right">
+                    <div class="a-row a-spacing-none">
+                        <span class="a-size-small">
+                            $6.63
+                        </span>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="a-row a-spacing-none">
+            <span class="a-size-small">
+                Qty: 0.39 lb
+            </span>
+            <span class="a-size-small">
+                 @ 
+            </span>
+            
+                
+                
+                    <span class="a-size-small">
+                        $16.99/lb
+                    </span>
+                
+            
+        </div>
+        
+        
+        
+        <div class="a-row a-spacing-top-micro">
+            
+        </div>
+    </div>
+</div>
+    <hr aria-hidden="true" class="a-spacing-small a-spacing-top-small a-divider-normal"/>
+
+    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<div class="a-row a-spacing-base">
+    <div class="a-column a-span2 a-ws-span1">
+        <img alt="B0728D62ML-8" src="https://m.media-amazon.com/images/I/41P8Hn+8ZpL._SS70_.jpg" class="ufpo-itemListWidget-image" data-a-hires="https://m.media-amazon.com/images/I/81D-PhO0RwL._SS110_.jpg"/>
+    </div>
+    <div class="a-column a-span10 a-ws-span11 a-span-last">
+        <div class="a-row a-spacing-none">
+            <div class="a-column a-span10">
+                
+                    
+                        <a class="a-size-small a-link-normal" target="_blank" rel="noopener" href="/dp/B0728D62ML?ref_=wfmInStore_food_od_product_details">
+                            La Panzanella, Rosemary Mini Croccantini Cracker, 6 Ounce
+                        </a>
+                    
+                    
+                
+            </div>
+            <div class="a-column a-span2 a-span-last">
+                <div class="a-section a-spacing-none a-text-right">
+                    <div class="a-row a-spacing-none">
+                        <span class="a-size-small">
+                            $5.29
+                        </span>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="a-row a-spacing-none">
+            <span class="a-size-small">
+                Qty: 1
+            </span>
+            <span class="a-size-small">
+                 @ 
+            </span>
+            
+                
+                
+                    <span class="a-size-small">
+                        $5.29 each
+                    </span>
+                
+            
+        </div>
+        
+        
+        
+        <div class="a-row a-spacing-top-micro">
+            
+        </div>
+    </div>
+</div>
+    <hr aria-hidden="true" class="a-spacing-small a-spacing-top-small a-divider-normal"/>
+
+    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<div class="a-row a-spacing-base">
+    <div class="a-column a-span2 a-ws-span1">
+        <img alt="B0BXBZ1GMX-9" src="https://m.media-amazon.com/images/I/41gq6bpRsWL._SS70_.jpg" class="ufpo-itemListWidget-image" data-a-hires="https://m.media-amazon.com/images/I/715mhZBeHeL._SS110_.jpg"/>
+    </div>
+    <div class="a-column a-span10 a-ws-span11 a-span-last">
+        <div class="a-row a-spacing-none">
+            <div class="a-column a-span10">
+                
+                    
+                        <a class="a-size-small a-link-normal" target="_blank" rel="noopener" href="/dp/B0BXBZ1GMX?ref_=wfmInStore_food_od_product_details">
+                            Bubbies Mochi Individually Wrapped Oat Milk Strawberry Mochi, 1.25 OZ
+                        </a>
+                    
+                    
+                
+            </div>
+            <div class="a-column a-span2 a-span-last">
+                <div class="a-section a-spacing-none a-text-right">
+                    <div class="a-row a-spacing-none">
+                        <span class="a-size-small">
+                            $2.00
+                        </span>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="a-row a-spacing-none">
+            <span class="a-size-small">
+                Qty: 1
+            </span>
+            <span class="a-size-small">
+                 @ 
+            </span>
+            
+                
+                
+                    <span class="a-size-small">
+                        $2.00 each
+                    </span>
+                
+            
+        </div>
+        
+        
+        
+        <div class="a-row a-spacing-top-micro">
+            
+        </div>
+    </div>
+</div>
+    <hr aria-hidden="true" class="a-spacing-small a-spacing-top-small a-divider-normal"/>
+
+
+        </div>
+        <a aria-expanded="false" role="button" href="javascript:void(0)" data-action="a-expander-toggle" class="a-expander-header a-declarative a-expander-inline-header a-link-expander" data-a-expander-toggle="{&quot;allowLinkDefault&quot;:true, &quot;expand_prompt&quot;:&quot;View all items&quot;, &quot;collapse_prompt&quot;:&quot;Collapse&quot;}"><i class="a-icon a-icon-expand"></i><span class="a-expander-prompt">View all items</span></a>
+    </div>
+
+
+<!-- Order Returns -->
+<script type="a-state" data-a-state="{&quot;key&quot;:&quot;order-returns-page-state&quot;}">{"orderHasReturns":false,"alertText":"One or more items in this order were either unavailable or returned. Your refund will be processed by Amazon immediately; however, it may take 3-5 business days to see the funds in your account depending on your financial institution."}</script>
+</div>
+
+        
+    </div>
+
+    <div id="odp-widget-grid-container">
+        
+            <div id="f3_food_HelpLinks" class="odp-widget-wrapper celwidget" cel_widget_id="f3_food_HelpLinks">
+
+
+
+
+
+
+
+
+
+
+
+<div class="a-row a-spacing-base">
+    <h2 class="widget-title-string">
+        <span id="ufpo-help-links-title" class="a-size-medium">
+            Need help with this order?
+        </span>
+    </h2>
+</div>
+
+
+    <div class="a-row a-spacing-base">
+        <a class="a-link-normal" href="/fmc/m/30001803?almBrandId=VUZHIFdob2xlIEZvb2Rz&amp;ref_=wfm_food_od_help_customer_care">
+            <span>
+                Contact Customer Support
+            </span>
+        </a>
+    </div>
+
+    <div class="a-row a-spacing-base">
+        <a class="a-link-normal" href="https://www.wholefoodsmarket.com/company-info/whole-foods-market-return-policy?ref_=wfm_food_od_help_refund">
+            <span>
+                Learn more about refunds
+            </span>
+        </a>
+    </div>
+
+    <div class="a-row a-spacing-base">
+        <a class="a-link-normal" href="https://www.wholefoodsmarket.com/customer-service/topics/amazon?ref_=wfm_food_od_help_why_am_i_seeing_wfm_orders#00000194-d7d2-d7f8-a9dc-d7f2c1f30000">
+            <span>
+                Why am I seeing my Whole Foods Market Orders?
+            </span>
+        </a>
+    </div>
+
+    <div class="a-row a-spacing-base">
+        <a class="a-link-normal" href="https://www.wholefoodsmarket.com/customer-service/topics/amazon?ref_=wfm_food_od_help_i_do_not_recognize_order#00000194-d7d5-d7f8-a9dc-d7f536fa0000">
+            <span>
+                I don't recognize this order
+            </span>
+        </a>
+    </div>
+
+</div>
+
+        
+            <div id="f3_food_DestinationInfo" class="odp-widget-wrapper celwidget" cel_widget_id="f3_food_DestinationInfo">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<!-- Delivery/Pickup Address -->
+<div class="a-row a-spacing-base">
+    <h2 class="widget-title-string">
+        <span class="a-size-medium">
+            Purchased at  store
+        </span>
+    </h2>
+</div>
+<div class="a-row">
+    <span class="a-size-base">
+        
+<script type="text/javascript">
+	
+;try {
+  window.uet('bb', 'Siege:Csd:LibraryEval', {wb: 1});
+} catch (e) {}
+(function(f) {
+  if (typeof window !== 'undefined') {
+    
+    try {
+      performance.mark("Siege:Csd:LibStart");
+    } catch (e) {}
+    try {
+      if (window.SiegeClientSideDecryption) {
+        
+        return;
+      }
+      f();
+    } catch (e) {
+      P.logError(e, 'siege-client-side-decryption init error: ', 'WARN', 'siege-client-side-decryption');
+      try {
+        window.ue.count('Siege:Csd:LibraryInitFailed', 1, {bf: '1'});
+      } catch (e) {}
+    }
+    return;
+  } else {
+    throw new Error('Cannot initialize SiegeClientSideDecryption outside window');
+  }
+})(function() {
+  !function(e,t){"object"==typeof exports&&"object"==typeof module?module.exports=t():"function"==typeof define&&define.amd?define([],t):"object"==typeof exports?exports.SiegeClientSideDecryption=t():e.SiegeClientSideDecryption=t()}(window,(function(){return function(e){var t={};function n(r){if(t[r])return t[r].exports;var A=t[r]={i:r,l:!1,exports:{}};return e[r].call(A.exports,A,A.exports,n),A.l=!0,A.exports}return n.m=e,n.c=t,n.d=function(e,t,r){n.o(e,t)||Object.defineProperty(e,t,{enumerable:!0,get:r})},n.r=function(e){"undefined"!=typeof Symbol&&Symbol.toStringTag&&Object.defineProperty(e,Symbol.toStringTag,{value:"Module"}),Object.defineProperty(e,"__esModule",{value:!0})},n.t=function(e,t){if(1&t&&(e=n(e)),8&t)return e;if(4&t&&"object"==typeof e&&e&&e.__esModule)return e;var r=Object.create(null);if(n.r(r),Object.defineProperty(r,"default",{enumerable:!0,value:e}),2&t&&"string"!=typeof e)for(var A in e)n.d(r,A,function(t){return e[t]}.bind(null,A));return r},n.n=function(e){var t=e&&e.__esModule?function(){return e["default"]}:function(){return e};return n.d(t,"a",t),t},n.o=function(e,t){return Object.prototype.hasOwnProperty.call(e,t)},n.p="",n(n.s=179)}([function(e,t,n){var r=n(1),A=n(22).f,o=n(14),i=n(15),a=n(103),u=n(135),c=n(61);e.exports=function(e,t){var n,s,f,g,l,d=e.target,p=e.global,y=e.stat;if(n=p?r:y?r[d]||a(d,{}):(r[d]||{}).prototype)for(s in t){if(g=t[s],f=e.noTargetGet?(l=A(n,s))&&l.value:n[s],!c(p?s:d+(y?".":"#")+s,e.forced)&&f!==undefined){if(typeof g==typeof f)continue;u(g,f)}(e.sham||f&&f.sham)&&o(g,"sham",!0),i(n,s,g,e)}}},function(e,t,n){(function(t){var n=function(e){return e&&e.Math==Math&&e};e.exports=n("object"==typeof globalThis&&globalThis)||n("object"==typeof window&&window)||n("object"==typeof self&&self)||n("object"==typeof t&&t)||Function("return this")()}).call(this,n(100))},function(e,t){e.exports=function(e){try{return!!e()}catch(t){return!0}}},function(e,t,n){"use strict";var r,A=n(128),o=n(5),i=n(1),a=n(8),u=n(10),c=n(63),s=n(14),f=n(15),g=n(9).f,l=n(57),d=n(44),p=n(4),y=n(49),h=i.Int8Array,I=h&&h.prototype,C=i.Uint8ClampedArray,B=C&&C.prototype,E=h&&l(h),v=I&&l(I),Q=Object.prototype,w=Q.isPrototypeOf,m=p("toStringTag"),b=y("TYPED_ARRAY_TAG"),x=A&&!!d&&"Opera"!==c(i.opera),S=!1,D={Int8Array:1,Uint8Array:1,Uint8ClampedArray:1,Int16Array:2,Uint16Array:2,Int32Array:4,Uint32Array:4,Float32Array:4,Float64Array:8},k=function(e){return a(e)&&u(D,c(e))};for(r in D)i[r]||(x=!1);if((!x||"function"!=typeof E||E===Function.prototype)&&(E=function(){throw TypeError("Incorrect invocation")},x))for(r in D)i[r]&&d(i[r],E);if((!x||!v||v===Q)&&(v=E.prototype,x))for(r in D)i[r]&&d(i[r].prototype,v);if(x&&l(B)!==v&&d(B,v),o&&!u(v,m))for(r in S=!0,g(v,m,{get:function(){return a(this)?this[b]:undefined}}),D)i[r]&&s(i[r],b,r);e.exports={NATIVE_ARRAY_BUFFER_VIEWS:x,TYPED_ARRAY_TAG:S&&b,aTypedArray:function(e){if(k(e))return e;throw TypeError("Target is not a typed array")},aTypedArrayConstructor:function(e){if(d){if(w.call(E,e))return e}else for(var t in D)if(u(D,r)){var n=i[t];if(n&&(e===n||w.call(n,e)))return e}throw TypeError("Target is not a typed array constructor")},exportTypedArrayMethod:function(e,t,n){if(o){if(n)for(var r in D){var A=i[r];A&&u(A.prototype,e)&&delete A.prototype[e]}v[e]&&!n||f(v,e,n?t:x&&I[e]||t)}},exportTypedArrayStaticMethod:function(e,t,n){var r,A;if(o){if(d){if(n)for(r in D)(A=i[r])&&u(A,e)&&delete A[e];if(E[e]&&!n)return;try{return f(E,e,n?t:x&&h[e]||t)}catch(a){}}for(r in D)!(A=i[r])||A[e]&&!n||f(A,e,t)}},isView:function(e){var t=c(e);return"DataView"===t||u(D,t)},isTypedArray:k,TypedArray:E,TypedArrayPrototype:v}},function(e,t,n){var r=n(1),A=n(105),o=n(10),i=n(49),a=n(109),u=n(142),c=A("wks"),s=r.Symbol,f=u?s:s&&s.withoutSetter||i;e.exports=function(e){return o(c,e)||(a&&o(s,e)?c[e]=s[e]:c[e]=f("Symbol."+e)),c[e]}},function(e,t,n){var r=n(2);e.exports=!r((function(){return 7!=Object.defineProperty({},1,{get:function(){return 7}})[1]}))},function(e,t,n){var r=n(24),A=Math.min;e.exports=function(e){return e>0?A(r(e),9007199254740991):0}},function(e,t,n){var r=n(110),A=n(15),o=n(183);r||A(Object.prototype,"toString",o,{unsafe:!0})},function(e,t){e.exports=function(e){return"object"==typeof e?null!==e:"function"==typeof e}},function(e,t,n){var r=n(5),A=n(133),o=n(11),i=n(48),a=Object.defineProperty;t.f=r?a:function(e,t,n){if(o(e),t=i(t,!0),o(n),A)try{return a(e,t,n)}catch(r){}if("get"in n||"set"in n)throw TypeError("Accessors not supported");return"value"in n&&(e[t]=n.value),e}},function(e,t){var n={}.hasOwnProperty;e.exports=function(e,t){return n.call(e,t)}},function(e,t,n){var r=n(8);e.exports=function(e){if(!r(e))throw TypeError(String(e)+" is not an object");return e}},function(e,t,n){"use strict";var r,A,o,i,a=n(0),u=n(30),c=n(1),s=n(31),f=n(145),g=n(15),l=n(111),d=n(25),p=n(53),y=n(8),h=n(54),I=n(55),C=n(23),B=n(104),E=n(112),v=n(64),Q=n(26),w=n(147).set,m=n(184),b=n(149),x=n(185),S=n(150),D=n(186),k=n(21),R=n(61),F=n(4),O=n(115),M=F("species"),G="Promise",N=k.get,T=k.set,L=k.getterFor(G),H=f,j=c.TypeError,Y=c.document,U=c.process,P=s("fetch"),K=S.f,_=K,X="process"==C(U),J=!!(Y&&Y.createEvent&&c.dispatchEvent),q=R(G,(function(){if(!(B(H)!==String(H))){if(66===O)return!0;if(!X&&"function"!=typeof PromiseRejectionEvent)return!0}if(u&&!H.prototype["finally"])return!0;if(O>=51&&/native code/.test(H))return!1;var e=H.resolve(1),t=function(e){e((function(){}),(function(){}))};return(e.constructor={})[M]=t,!(e.then((function(){}))instanceof t)})),Z=q||!v((function(e){H.all(e)["catch"]((function(){}))})),z=function(e){var t;return!(!y(e)||"function"!=typeof(t=e.then))&&t},V=function(e,t,n){if(!t.notified){t.notified=!0;var r=t.reactions;m((function(){for(var A=t.value,o=1==t.state,i=0;r.length>i;){var a,u,c,s=r[i++],f=o?s.ok:s.fail,g=s.resolve,l=s.reject,d=s.domain;try{f?(o||(2===t.rejection&&te(e,t),t.rejection=1),!0===f?a=A:(d&&d.enter(),a=f(A),d&&(d.exit(),c=!0)),a===s.promise?l(j("Promise-chain cycle")):(u=z(a))?u.call(a,g,l):g(a)):l(A)}catch(p){d&&!c&&d.exit(),l(p)}}t.reactions=[],t.notified=!1,n&&!t.rejection&&$(e,t)}))}},W=function(e,t,n){var r,A;J?((r=Y.createEvent("Event")).promise=t,r.reason=n,r.initEvent(e,!1,!0),c.dispatchEvent(r)):r={promise:t,reason:n},(A=c["on"+e])?A(r):"unhandledrejection"===e&&x("Unhandled promise rejection",n)},$=function(e,t){w.call(c,(function(){var n,r=t.value;if(ee(t)&&(n=D((function(){X?U.emit("unhandledRejection",r,e):W("unhandledrejection",e,r)})),t.rejection=X||ee(t)?2:1,n.error))throw n.value}))},ee=function(e){return 1!==e.rejection&&!e.parent},te=function(e,t){w.call(c,(function(){X?U.emit("rejectionHandled",e):W("rejectionhandled",e,t.value)}))},ne=function(e,t,n,r){return function(A){e(t,n,A,r)}},re=function(e,t,n,r){t.done||(t.done=!0,r&&(t=r),t.value=n,t.state=2,V(e,t,!0))},Ae=function(e,t,n,r){if(!t.done){t.done=!0,r&&(t=r);try{if(e===n)throw j("Promise can't be resolved itself");var A=z(n);A?m((function(){var r={done:!1};try{A.call(n,ne(Ae,e,r,t),ne(re,e,r,t))}catch(o){re(e,r,o,t)}})):(t.value=n,t.state=1,V(e,t,!1))}catch(o){re(e,{done:!1},o,t)}}};q&&(H=function(e){I(this,H,G),h(e),r.call(this);var t=N(this);try{e(ne(Ae,this,t),ne(re,this,t))}catch(n){re(this,t,n)}},(r=function(e){T(this,{type:G,done:!1,notified:!1,parent:!1,reactions:[],rejection:!1,state:0,value:undefined})}).prototype=l(H.prototype,{then:function(e,t){var n=L(this),r=K(Q(this,H));return r.ok="function"!=typeof e||e,r.fail="function"==typeof t&&t,r.domain=X?U.domain:undefined,n.parent=!0,n.reactions.push(r),0!=n.state&&V(this,n,!1),r.promise},"catch":function(e){return this.then(undefined,e)}}),A=function(){var e=new r,t=N(e);this.promise=e,this.resolve=ne(Ae,e,t),this.reject=ne(re,e,t)},S.f=K=function(e){return e===H||e===o?new A(e):_(e)},u||"function"!=typeof f||(i=f.prototype.then,g(f.prototype,"then",(function(e,t){var n=this;return new H((function(e,t){i.call(n,e,t)})).then(e,t)}),{unsafe:!0}),"function"==typeof P&&a({global:!0,enumerable:!0,forced:!0},{fetch:function(e){return b(H,P.apply(c,arguments))}}))),a({global:!0,wrap:!0,forced:q},{Promise:H}),d(H,G,!1,!0),p(G),o=s(G),a({target:G,stat:!0,forced:q},{reject:function(e){var t=K(this);return t.reject.call(undefined,e),t.promise}}),a({target:G,stat:!0,forced:u||q},{resolve:function(e){return b(u&&this===o?H:this,e)}}),a({target:G,stat:!0,forced:Z},{all:function(e){var t=this,n=K(t),r=n.resolve,A=n.reject,o=D((function(){var n=h(t.resolve),o=[],i=0,a=1;E(e,(function(e){var u=i++,c=!1;o.push(undefined),a++,n.call(t,e).then((function(e){c||(c=!0,o[u]=e,--a||r(o))}),A)})),--a||r(o)}));return o.error&&A(o.value),n.promise},race:function(e){var t=this,n=K(t),r=n.reject,A=D((function(){var A=h(t.resolve);E(e,(function(e){A.call(t,e).then(n.resolve,r)}))}));return A.error&&r(A.value),n.promise}})},function(e,t,n){var r=n(29);e.exports=function(e){return Object(r(e))}},function(e,t,n){var r=n(5),A=n(9),o=n(37);e.exports=r?function(e,t,n){return A.f(e,t,o(1,n))}:function(e,t,n){return e[t]=n,e}},function(e,t,n){var r=n(1),A=n(14),o=n(10),i=n(103),a=n(104),u=n(21),c=u.get,s=u.enforce,f=String(String).split("String");(e.exports=function(e,t,n,a){var u=!!a&&!!a.unsafe,c=!!a&&!!a.enumerable,g=!!a&&!!a.noTargetGet;"function"==typeof n&&("string"!=typeof t||o(n,"name")||A(n,"name",t),s(n).source=f.join("string"==typeof t?t:"")),e!==r?(u?!g&&e[t]&&(c=!0):delete e[t],c?e[t]=n:A(e,t,n)):c?e[t]=n:i(t,n)})(Function.prototype,"toString",(function(){return"function"==typeof this&&c(this).source||a(this)}))},function(e,t,n){"use strict";var r=n(19),A=n(141),o=n(56),i=n(21),a=n(118),u=i.set,c=i.getterFor("Array Iterator");e.exports=a(Array,"Array",(function(e,t){u(this,{type:"Array Iterator",target:r(e),index:0,kind:t})}),(function(){var e=c(this),t=e.target,n=e.kind,r=e.index++;return!t||r>=t.length?(e.target=undefined,{value:undefined,done:!0}):"keys"==n?{value:r,done:!1}:"values"==n?{value:t[r],done:!1}:{value:[r,t[r]],done:!1}}),"values"),o.Arguments=o.Array,A("keys"),A("values"),A("entries")},function(e,t,n){var r=n(0),A=n(5);r({target:"Object",stat:!0,forced:!A,sham:!A},{defineProperty:n(9).f})},function(e,t,n){"use strict";(function(e){function t(e){return(t="function"==typeof Symbol&&"symbol"==typeof Symbol.iterator?function(e){return typeof e}:function(e){return e&&"function"==typeof Symbol&&e.constructor===Symbol&&e!==Symbol.prototype?"symbol":typeof e})(e)}
+/**
+ * Copyright (c) 2014-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */n(34),n(42),n(190),n(43),n(191),n(66),n(16),n(194),n(58),n(35),n(119),n(195),n(196),n(197),n(198),n(199),n(7),n(12),n(45),n(36),n(68),n(27);var r=function(e){var n=Object.prototype,r=n.hasOwnProperty,A="function"==typeof Symbol?Symbol:{},o=A.iterator||"@@iterator",i=A.asyncIterator||"@@asyncIterator",a=A.toStringTag||"@@toStringTag";function u(e,t,n,r){var A=t&&t.prototype instanceof f?t:f,o=Object.create(A.prototype),i=new Q(r||[]);return o._invoke=function(e,t,n){var r="suspendedStart";return function(A,o){if("executing"===r)throw new Error("Generator is already running");if("completed"===r){if("throw"===A)throw o;return m()}for(n.method=A,n.arg=o;;){var i=n.delegate;if(i){var a=B(i,n);if(a){if(a===s)continue;return a}}if("next"===n.method)n.sent=n._sent=n.arg;else if("throw"===n.method){if("suspendedStart"===r)throw r="completed",n.arg;n.dispatchException(n.arg)}else"return"===n.method&&n.abrupt("return",n.arg);r="executing";var u=c(e,t,n);if("normal"===u.type){if(r=n.done?"completed":"suspendedYield",u.arg===s)continue;return{value:u.arg,done:n.done}}"throw"===u.type&&(r="completed",n.method="throw",n.arg=u.arg)}}}(e,n,i),o}function c(e,t,n){try{return{type:"normal",arg:e.call(t,n)}}catch(err){return{type:"throw",arg:err}}}e.wrap=u;var s={};function f(){}function g(){}function l(){}var d={};d[o]=function(){return this};var p=Object.getPrototypeOf,y=p&&p(p(w([])));y&&y!==n&&r.call(y,o)&&(d=y);var h=l.prototype=f.prototype=Object.create(d);function I(e){["next","throw","return"].forEach((function(t){e[t]=function(e){return this._invoke(t,e)}}))}function C(e){var n;this._invoke=function(A,o){function i(){return new Promise((function(n,i){!function a(n,A,o,i){var u=c(e[n],e,A);if("throw"!==u.type){var s=u.arg,f=s.value;return f&&"object"===t(f)&&r.call(f,"__await")?Promise.resolve(f.__await).then((function(e){a("next",e,o,i)}),(function(e){a("throw",e,o,i)})):Promise.resolve(f).then((function(e){s.value=e,o(s)}),(function(e){return a("throw",e,o,i)}))}i(u.arg)}(A,o,n,i)}))}return n=n?n.then(i,i):i()}}function B(e,t){var n=e.iterator[t.method];if(void 0===n){if(t.delegate=null,"throw"===t.method){if(e.iterator["return"]&&(t.method="return",t.arg=void 0,B(e,t),"throw"===t.method))return s;t.method="throw",t.arg=new TypeError("The iterator does not provide a 'throw' method")}return s}var r=c(n,e.iterator,t.arg);if("throw"===r.type)return t.method="throw",t.arg=r.arg,t.delegate=null,s;var A=r.arg;return A?A.done?(t[e.resultName]=A.value,t.next=e.nextLoc,"return"!==t.method&&(t.method="next",t.arg=void 0),t.delegate=null,s):A:(t.method="throw",t.arg=new TypeError("iterator result is not an object"),t.delegate=null,s)}function E(e){var t={tryLoc:e[0]};1 in e&&(t.catchLoc=e[1]),2 in e&&(t.finallyLoc=e[2],t.afterLoc=e[3]),this.tryEntries.push(t)}function v(e){var t=e.completion||{};t.type="normal",delete t.arg,e.completion=t}function Q(e){this.tryEntries=[{tryLoc:"root"}],e.forEach(E,this),this.reset(!0)}function w(e){if(e){var t=e[o];if(t)return t.call(e);if("function"==typeof e.next)return e;if(!isNaN(e.length)){var n=-1,A=function t(){for(;++n<e.length;)if(r.call(e,n))return t.value=e[n],t.done=!1,t;return t.value=void 0,t.done=!0,t};return A.next=A}}return{next:m}}function m(){return{value:void 0,done:!0}}return g.prototype=h.constructor=l,l.constructor=g,l[a]=g.displayName="GeneratorFunction",e.isGeneratorFunction=function(e){var t="function"==typeof e&&e.constructor;return!!t&&(t===g||"GeneratorFunction"===(t.displayName||t.name))},e.mark=function(e){return Object.setPrototypeOf?Object.setPrototypeOf(e,l):(e.__proto__=l,a in e||(e[a]="GeneratorFunction")),e.prototype=Object.create(h),e},e.awrap=function(e){return{__await:e}},I(C.prototype),C.prototype[i]=function(){return this},e.AsyncIterator=C,e.async=function(t,n,r,A){var o=new C(u(t,n,r,A));return e.isGeneratorFunction(n)?o:o.next().then((function(e){return e.done?e.value:o.next()}))},I(h),h[a]="Generator",h[o]=function(){return this},h.toString=function(){return"[object Generator]"},e.keys=function(e){var t=[];for(var n in e)t.push(n);return t.reverse(),function r(){for(;t.length;){var n=t.pop();if(n in e)return r.value=n,r.done=!1,r}return r.done=!0,r}},e.values=w,Q.prototype={constructor:Q,reset:function(e){if(this.prev=0,this.next=0,this.sent=this._sent=void 0,this.done=!1,this.delegate=null,this.method="next",this.arg=void 0,this.tryEntries.forEach(v),!e)for(var t in this)"t"===t.charAt(0)&&r.call(this,t)&&!isNaN(+t.slice(1))&&(this[t]=void 0)},stop:function(){this.done=!0;var e=this.tryEntries[0].completion;if("throw"===e.type)throw e.arg;return this.rval},dispatchException:function(e){if(this.done)throw e;var t=this;function n(n,r){return i.type="throw",i.arg=e,t.next=n,r&&(t.method="next",t.arg=void 0),!!r}for(var A=this.tryEntries.length-1;A>=0;--A){var o=this.tryEntries[A],i=o.completion;if("root"===o.tryLoc)return n("end");if(o.tryLoc<=this.prev){var a=r.call(o,"catchLoc"),u=r.call(o,"finallyLoc");if(a&&u){if(this.prev<o.catchLoc)return n(o.catchLoc,!0);if(this.prev<o.finallyLoc)return n(o.finallyLoc)}else if(a){if(this.prev<o.catchLoc)return n(o.catchLoc,!0)}else{if(!u)throw new Error("try statement without catch or finally");if(this.prev<o.finallyLoc)return n(o.finallyLoc)}}}},abrupt:function(e,t){for(var n=this.tryEntries.length-1;n>=0;--n){var A=this.tryEntries[n];if(A.tryLoc<=this.prev&&r.call(A,"finallyLoc")&&this.prev<A.finallyLoc){var o=A;break}}o&&("break"===e||"continue"===e)&&o.tryLoc<=t&&t<=o.finallyLoc&&(o=null);var i=o?o.completion:{};return i.type=e,i.arg=t,o?(this.method="next",this.next=o.finallyLoc,s):this.complete(i)},complete:function(e,t){if("throw"===e.type)throw e.arg;return"break"===e.type||"continue"===e.type?this.next=e.arg:"return"===e.type?(this.rval=this.arg=e.arg,this.method="return",this.next="end"):"normal"===e.type&&t&&(this.next=t),s},finish:function(e){for(var t=this.tryEntries.length-1;t>=0;--t){var n=this.tryEntries[t];if(n.finallyLoc===e)return this.complete(n.completion,n.afterLoc),v(n),s}},"catch":function(e){for(var t=this.tryEntries.length-1;t>=0;--t){var n=this.tryEntries[t];if(n.tryLoc===e){var r=n.completion;if("throw"===r.type){var A=r.arg;v(n)}return A}}throw new Error("illegal catch attempt")},delegateYield:function(e,t,n){return this.delegate={iterator:w(e),resultName:t,nextLoc:n},"next"===this.method&&(this.arg=void 0),s}},e}("object"===t(e)?e.exports:{});try{regeneratorRuntime=r}catch(A){Function("r","regeneratorRuntime = r")(r)}}).call(this,n(188)(e))},function(e,t,n){var r=n(47),A=n(29);e.exports=function(e){return r(A(e))}},function(e,t,n){var r=n(40),A=n(47),o=n(13),i=n(6),a=n(117),u=[].push,c=function(e){var t=1==e,n=2==e,c=3==e,s=4==e,f=6==e,g=5==e||f;return function(l,d,p,y){for(var h,I,C=o(l),B=A(C),E=r(d,p,3),v=i(B.length),Q=0,w=y||a,m=t?w(l,v):n?w(l,0):undefined;v>Q;Q++)if((g||Q in B)&&(I=E(h=B[Q],Q,C),e))if(t)m[Q]=I;else if(I)switch(e){case 3:return!0;case 5:return h;case 6:return Q;case 2:u.call(m,h)}else if(s)return!1;return f?-1:c||s?s:m}};e.exports={forEach:c(0),map:c(1),filter:c(2),some:c(3),every:c(4),find:c(5),findIndex:c(6)}},function(e,t,n){var r,A,o,i=n(181),a=n(1),u=n(8),c=n(14),s=n(10),f=n(60),g=n(50),l=a.WeakMap;if(i){var d=new l,p=d.get,y=d.has,h=d.set;r=function(e,t){return h.call(d,e,t),t},A=function(e){return p.call(d,e)||{}},o=function(e){return y.call(d,e)}}else{var I=f("state");g[I]=!0,r=function(e,t){return c(e,I,t),t},A=function(e){return s(e,I)?e[I]:{}},o=function(e){return s(e,I)}}e.exports={set:r,get:A,has:o,enforce:function(e){return o(e)?A(e):r(e,{})},getterFor:function(e){return function(t){var n;if(!u(t)||(n=A(t)).type!==e)throw TypeError("Incompatible receiver, "+e+" required");return n}}}},function(e,t,n){var r=n(5),A=n(101),o=n(37),i=n(19),a=n(48),u=n(10),c=n(133),s=Object.getOwnPropertyDescriptor;t.f=r?s:function(e,t){if(e=i(e),t=a(t,!0),c)try{return s(e,t)}catch(n){}if(u(e,t))return o(!A.f.call(e,t),e[t])}},function(e,t){var n={}.toString;e.exports=function(e){return n.call(e).slice(8,-1)}},function(e,t){var n=Math.ceil,r=Math.floor;e.exports=function(e){return isNaN(e=+e)?0:(e>0?r:n)(e)}},function(e,t,n){var r=n(9).f,A=n(10),o=n(4)("toStringTag");e.exports=function(e,t,n){e&&!A(e=n?e:e.prototype,o)&&r(e,o,{configurable:!0,value:t})}},function(e,t,n){var r=n(11),A=n(54),o=n(4)("species");e.exports=function(e,t){var n,i=r(e).constructor;return i===undefined||(n=r(i)[o])==undefined?t:A(n)}},function(e,t,n){var r=n(1),A=n(159),o=n(16),i=n(14),a=n(4),u=a("iterator"),c=a("toStringTag"),s=o.values;for(var f in A){var g=r[f],l=g&&g.prototype;if(l){if(l[u]!==s)try{i(l,u,s)}catch(p){l[u]=s}if(l[c]||i(l,c,f),A[f])for(var d in o)if(l[d]!==o[d])try{i(l,d,o[d])}catch(p){l[d]=o[d]}}}},function(e,t,n){"use strict";function r(e,t){return function(e){if(Array.isArray(e))return e}(e)||function(e,t){if(!(Symbol.iterator in Object(e)||"[object Arguments]"===Object.prototype.toString.call(e)))return;var n=[],r=!0,A=!1,o=undefined;try{for(var i,a=e[Symbol.iterator]();!(r=(i=a.next()).done)&&(n.push(i.value),!t||n.length!==t);r=!0);}catch(err){A=!0,o=err}finally{try{r||null==a["return"]||a["return"]()}finally{if(A)throw o}}return n}(e,t)||function(){throw new TypeError("Invalid attempt to destructure non-iterable instance")}()}function A(e,t){if(!(e instanceof t))throw new TypeError("Cannot call a class as a function")}function o(e,t){for(var n=0;n<t.length;n++){var r=t[n];r.enumerable=r.enumerable||!1,r.configurable=!0,"value"in r&&(r.writable=!0),Object.defineProperty(e,r.key,r)}}function i(e,t,n){return t in e?Object.defineProperty(e,t,{value:n,enumerable:!0,configurable:!0,writable:!0}):e[t]=n,e}function a(e){return!(!e.ue||!e.ue.count)}function u(e){return!!(e.ue&&e.uex&&e.uet)}n(34),n(42),n(43),n(99),n(140),n(166),n(16),n(35),n(119),n(17),n(7),n(45),n(151),n(36),n(27),Object.defineProperty(t,"__esModule",{value:!0}),t.logLibraryLoadMetrics=function(e){var t=r(performance.getEntriesByType("resource").filter((function(e){return e.name.includes("SiegeClientSideDecryption")})),1)[0];if(!t)throw new Error("No performance information about library available");e.updateCounter("Siege:Csd:LibraryDownloadTime",Math.ceil(t.duration));var n=r(performance.getEntriesByName("Siege:Csd:LibStart","mark"),1)[0];n&&e.updateCounter("Siege:Csd:LibraryEvalWaitTime",Math.ceil(n.startTime-(t.startTime+t.duration)))},t.Logger=void 0;var c=function(){function e(){var t=arguments.length>0&&arguments[0]!==undefined?arguments[0]:function(){return window.location};A(this,e),this._location=t}var t,n,r;return t=e,(n=[{key:"updateCounter",value:function(e,t){return a(window)?window.ue.count(e,t,{bf:"1"}):undefined}},{key:"incrementCounter",value:function(e){var t,n=arguments.length>1&&arguments[1]!==undefined?arguments[1]:1;return a(window)?this.updateCounter(e,(null!==(t=window.ue.count(e))&&void 0!==t?t:0)+n):undefined}},{key:"buildLogConfig",value:function(t){var n,r,A;return{logLevel:null!==(n=t.logLevel)&&void 0!==n?n:e.DEFAULT_LOG_LEVEL,attribution:null!==(r=t.attribution)&&void 0!==r?r:e.DEFAULT_LOG_ATTRIBUTION,message:null!==(A=t.message)&&void 0!==A?A:e.DEFAULT_LOG_MESSAGE}}},{key:"log",value:function(t,n){if(window.ueLogError){var r;r=n?this.buildLogConfig(n):this.buildLogConfig({});var A=this._location();return!(A.port!==undefined&&!e.ALLOWED_LOG_PORTS.includes(A.port)||(window.ueLogError(t,r),0))}return!1}},{key:"logError",value:function(t,n){var r=this.buildLogConfig({logLevel:e.ERROR_LOG_LEVEL,attribution:null!=n?n:e.DEFAULT_LOG_ATTRIBUTION});return this.log(t,r)}},{key:"logWarn",value:function(t,n){var r=this.buildLogConfig({logLevel:e.WARN_LOG_LEVEL,attribution:null!=n?n:e.DEFAULT_LOG_ATTRIBUTION});return this.log(t,r)}},{key:"getFullTimerName",value:function(t){return e.LATENCY_NAME_PREFIX+t}},{key:"startTimer",value:function(e){if(u(window))try{window.uet("bb",this.getFullTimerName(e),{wb:1})}catch(t){this.log(t,{message:"startTimer"})}}},{key:"stopTimer",value:function(e){if(u(window))try{window.uet("cf",this.getFullTimerName(e),{wb:1})}catch(t){this.log(t,{message:"endTimer"})}}},{key:"sendTimer",value:function(e){if(u(window))try{window.uex("ld",this.getFullTimerName(e),{wb:1})}catch(t){this.log(t,{message:"sendTimer"})}}},{key:"stopAndSendTimer",value:function(e){this.stopTimer(e),this.sendTimer(e)}}])&&o(t.prototype,n),r&&o(t,r),e}();t.Logger=c,i(c,"WARN_LOG_LEVEL","WARN"),i(c,"ERROR_LOG_LEVEL","ERROR"),i(c,"DEFAULT_LOG_LEVEL",c.ERROR_LOG_LEVEL),i(c,"DEFAULT_LOG_ATTRIBUTION","Siege:Csd"),i(c,"DEFAULT_LOG_MESSAGE","SiegeClientSideDecryptionJS "),i(c,"LATENCY_NAME_PREFIX","Siege:Csd:"),i(c,"ALLOWED_LOG_PORTS",["","443","80"])},function(e,t){e.exports=function(e){if(e==undefined)throw TypeError("Can't call method on "+e);return e}},function(e,t){e.exports=!1},function(e,t,n){var r=n(137),A=n(1),o=function(e){return"function"==typeof e?e:undefined};e.exports=function(e,t){return arguments.length<2?o(r[e])||o(A[e]):r[e]&&r[e][t]||A[e]&&A[e][t]}},function(e,t,n){var r=n(24),A=Math.max,o=Math.min;e.exports=function(e,t){var n=r(e);return n<0?A(n+t,0):o(n,t)}},function(e,t,n){var r=n(182),A=n(52);e.exports=function(e){return!!A(e)&&r.apply(this,arguments)}},function(e,t,n){"use strict";var r=n(0),A=n(1),o=n(31),i=n(30),a=n(5),u=n(109),c=n(142),s=n(2),f=n(10),g=n(41),l=n(8),d=n(11),p=n(13),y=n(19),h=n(48),I=n(37),C=n(39),B=n(62),E=n(38),v=n(189),Q=n(107),w=n(22),m=n(9),b=n(101),x=n(14),S=n(15),D=n(105),k=n(60),R=n(50),F=n(49),O=n(4),M=n(154),G=n(65),N=n(25),T=n(21),L=n(20).forEach,H=k("hidden"),j=O("toPrimitive"),Y=T.set,U=T.getterFor("Symbol"),P=Object.prototype,K=A.Symbol,_=o("JSON","stringify"),X=w.f,J=m.f,q=v.f,Z=b.f,z=D("symbols"),V=D("op-symbols"),W=D("string-to-symbol-registry"),$=D("symbol-to-string-registry"),ee=D("wks"),te=A.QObject,ne=!te||!te.prototype||!te.prototype.findChild,re=a&&s((function(){return 7!=C(J({},"a",{get:function(){return J(this,"a",{value:7}).a}})).a}))?function(e,t,n){var r=X(P,t);r&&delete P[t],J(e,t,n),r&&e!==P&&J(P,t,r)}:J,Ae=function(e,t){var n=z[e]=C(K.prototype);return Y(n,{type:"Symbol",tag:e,description:t}),a||(n.description=t),n},oe=c?function(e){return"symbol"==typeof e}:function(e){return Object(e)instanceof K},ie=function(e,t,n){e===P&&ie(V,t,n),d(e);var r=h(t,!0);return d(n),f(z,r)?(n.enumerable?(f(e,H)&&e[H][r]&&(e[H][r]=!1),n=C(n,{enumerable:I(0,!1)})):(f(e,H)||J(e,H,I(1,{})),e[H][r]=!0),re(e,r,n)):J(e,r,n)},ae=function(e,t){d(e);var n=y(t),r=B(n).concat(fe(n));return L(r,(function(t){a&&!ue.call(n,t)||ie(e,t,n[t])})),e},ue=function(e){var t=h(e,!0),n=Z.call(this,t);return!(this===P&&f(z,t)&&!f(V,t))&&(!(n||!f(this,t)||!f(z,t)||f(this,H)&&this[H][t])||n)},ce=function(e,t){var n=y(e),r=h(t,!0);if(n!==P||!f(z,r)||f(V,r)){var A=X(n,r);return!A||!f(z,r)||f(n,H)&&n[H][r]||(A.enumerable=!0),A}},se=function(e){var t=q(y(e)),n=[];return L(t,(function(e){f(z,e)||f(R,e)||n.push(e)})),n},fe=function(e){var t=e===P,n=q(t?V:y(e)),r=[];return L(n,(function(e){!f(z,e)||t&&!f(P,e)||r.push(z[e])})),r};(u||(S((K=function(){if(this instanceof K)throw TypeError("Symbol is not a constructor");var e=arguments.length&&arguments[0]!==undefined?String(arguments[0]):undefined,t=F(e),n=function(e){this===P&&n.call(V,e),f(this,H)&&f(this[H],t)&&(this[H][t]=!1),re(this,t,I(1,e))};return a&&ne&&re(P,t,{configurable:!0,set:n}),Ae(t,e)}).prototype,"toString",(function(){return U(this).tag})),S(K,"withoutSetter",(function(e){return Ae(F(e),e)})),b.f=ue,m.f=ie,w.f=ce,E.f=v.f=se,Q.f=fe,M.f=function(e){return Ae(O(e),e)},a&&(J(K.prototype,"description",{configurable:!0,get:function(){return U(this).description}}),i||S(P,"propertyIsEnumerable",ue,{unsafe:!0}))),r({global:!0,wrap:!0,forced:!u,sham:!u},{Symbol:K}),L(B(ee),(function(e){G(e)})),r({target:"Symbol",stat:!0,forced:!u},{"for":function(e){var t=String(e);if(f(W,t))return W[t];var n=K(t);return W[t]=n,$[n]=t,n},keyFor:function(e){if(!oe(e))throw TypeError(e+" is not a symbol");if(f($,e))return $[e]},useSetter:function(){ne=!0},useSimple:function(){ne=!1}}),r({target:"Object",stat:!0,forced:!u,sham:!a},{create:function(e,t){return t===undefined?C(e):ae(C(e),t)},defineProperty:ie,defineProperties:ae,getOwnPropertyDescriptor:ce}),r({target:"Object",stat:!0,forced:!u},{getOwnPropertyNames:se,getOwnPropertySymbols:fe}),r({target:"Object",stat:!0,forced:s((function(){Q.f(1)}))},{getOwnPropertySymbols:function(e){return Q.f(p(e))}}),_)&&r({target:"JSON",stat:!0,forced:!u||s((function(){var e=K();return"[null]"!=_([e])||"{}"!=_({a:e})||"{}"!=_(Object(e))}))},{stringify:function(e,t,n){for(var r,A=[e],o=1;arguments.length>o;)A.push(arguments[o++]);if(r=t,(l(t)||e!==undefined)&&!oe(e))return g(t)||(t=function(e,t){if("function"==typeof r&&(t=r.call(this,e,t)),!oe(t))return t}),A[1]=t,_.apply(null,A)}});K.prototype[j]||x(K.prototype,j,K.prototype.valueOf),N(K,"Symbol"),R[H]=!0},function(e,t,n){var r=n(15),A=Date.prototype,o=A.toString,i=A.getTime;new Date(NaN)+""!="Invalid Date"&&r(A,"toString",(function(){var e=i.call(this);return e==e?o.call(this):"Invalid Date"}))},function(e,t,n){"use strict";var r=n(158).charAt,A=n(21),o=n(118),i=A.set,a=A.getterFor("String Iterator");o(String,"String",(function(e){i(this,{type:"String Iterator",string:String(e),index:0})}),(function(){var e,t=a(this),n=t.string,A=t.index;return A>=n.length?{value:undefined,done:!0}:(e=r(n,A),t.index+=e.length,{value:e,done:!1})}))},function(e,t){e.exports=function(e,t){return{enumerable:!(1&e),configurable:!(2&e),writable:!(4&e),value:t}}},function(e,t,n){var r=n(138),A=n(106).concat("length","prototype");t.f=Object.getOwnPropertyNames||function(e){return r(e,A)}},function(e,t,n){var r,A=n(11),o=n(143),i=n(106),a=n(50),u=n(144),c=n(102),s=n(60),f=s("IE_PROTO"),g=function(){},l=function(e){return"<script>"+e+"<\/script>"},d=function(){try{r=document.domain&&new ActiveXObject("htmlfile")}catch(A){}var e,t;d=r?function(e){e.write(l("")),e.close();var t=e.parentWindow.Object;return e=null,t}(r):((t=c("iframe")).style.display="none",u.appendChild(t),t.src=String("javascript:"),(e=t.contentWindow.document).open(),e.write(l("document.F=Object")),e.close(),e.F);for(var n=i.length;n--;)delete d.prototype[i[n]];return d()};a[f]=!0,e.exports=Object.create||function(e,t){var n;return null!==e?(g.prototype=A(e),n=new g,g.prototype=null,n[f]=e):n=d(),t===undefined?n:o(n,t)}},function(e,t,n){var r=n(54);e.exports=function(e,t,n){if(r(e),t===undefined)return e;switch(n){case 0:return function(){return e.call(t)};case 1:return function(n){return e.call(t,n)};case 2:return function(n,r){return e.call(t,n,r)};case 3:return function(n,r,A){return e.call(t,n,r,A)}}return function(){return e.apply(t,arguments)}}},function(e,t,n){var r=n(23);e.exports=Array.isArray||function(e){return"Array"==r(e)}},function(e,t,n){"use strict";var r=n(0),A=n(5),o=n(1),i=n(10),a=n(8),u=n(9).f,c=n(135),s=o.Symbol;if(A&&"function"==typeof s&&(!("description"in s.prototype)||s().description!==undefined)){var f={},g=function(){var e=arguments.length<1||arguments[0]===undefined?undefined:String(arguments[0]),t=this instanceof g?new s(e):e===undefined?s():s(e);return""===e&&(f[t]=!0),t};c(g,s);var l=g.prototype=s.prototype;l.constructor=g;var d=l.toString,p="Symbol(test)"==String(s("test")),y=/^Symbol\((.*)\)[^)]+$/;u(l,"description",{configurable:!0,get:function(){var e=a(this)?this.valueOf():this,t=d.call(e);if(i(f,e))return"";var n=p?t.slice(7,-1):t.replace(y,"$1");return""===n?undefined:n}}),r({global:!0,forced:!0},{Symbol:g})}},function(e,t,n){n(65)("iterator")},function(e,t,n){var r=n(11),A=n(193);e.exports=Object.setPrototypeOf||("__proto__"in{}?function(){var e,t=!1,n={};try{(e=Object.getOwnPropertyDescriptor(Object.prototype,"__proto__").set).call(n,[]),t=n instanceof Array}catch(o){}return function(n,o){return r(n),A(o),t?e.call(n,o):n.__proto__=o,n}}():undefined)},function(e,t,n){"use strict";var r=n(15),A=n(11),o=n(2),i=n(120),a=RegExp.prototype,u=a.toString,c=o((function(){return"/a/b"!=u.call({source:"a",flags:"b"})})),s="toString"!=u.name;(c||s)&&r(RegExp.prototype,"toString",(function(){var e=A(this),t=String(e.source),n=e.flags;return"/"+t+"/"+String(n===undefined&&e instanceof RegExp&&!("flags"in a)?i.call(e):n)}),{unsafe:!0})},function(e,t,n){"use strict";n(34),n(99),n(66),n(129),n(17),n(130),n(131),n(73),n(68),Object.defineProperty(t,"__esModule",{value:!0}),t.cookieManagerSave=function(e,t,n){var A=arguments.length>3&&arguments[3]!==undefined?arguments[3]:{},i=o({},A,{v:1,kid:e,key:t});(0,r.cookieSet)("csd-key",btoa(JSON.stringify(i)),n)},t.cookieManagerDelete=function(){(0,r.cookieDelete)("csd-key")},t.cookieManagerDisable=function(){(0,r.cookieSet)("csd-key","disabled",30)},t.cookieManagerGet=a,t.cookieManagerGetRaw=function(){return(0,r.cookieGet)("csd-key")},t.cookieManagerIsDisabled=function(){return"disabled"===(0,r.cookieGet)("csd-key")},t.cookieManagerIsEnabled=function(){try{return a(),!0}catch(e){return!1}},t.CSD_COOKIE_NAME=void 0;var r=n(228);function A(e,t){var n=Object.keys(e);if(Object.getOwnPropertySymbols){var r=Object.getOwnPropertySymbols(e);t&&(r=r.filter((function(t){return Object.getOwnPropertyDescriptor(e,t).enumerable}))),n.push.apply(n,r)}return n}function o(e){for(var t=1;t<arguments.length;t++){var n=null!=arguments[t]?arguments[t]:{};t%2?A(Object(n),!0).forEach((function(t){i(e,t,n[t])})):Object.getOwnPropertyDescriptors?Object.defineProperties(e,Object.getOwnPropertyDescriptors(n)):A(Object(n)).forEach((function(t){Object.defineProperty(e,t,Object.getOwnPropertyDescriptor(n,t))}))}return e}function i(e,t,n){return t in e?Object.defineProperty(e,t,{value:n,enumerable:!0,configurable:!0,writable:!0}):e[t]=n,e}t.CSD_COOKIE_NAME="csd-key";function a(){var e,t=(0,r.cookieGet)("csd-key");if(""===t)throw new Error("Cookie value was empty");try{e=JSON.parse(atob(t))}catch(n){throw n instanceof Error&&(n.message="Could not parse cookie value. ".concat(n.message)),n}if(e===undefined||e.key===undefined||e.kid===undefined)throw new Error("Could not parse cookie value (2)");return e}},function(e,t,n){var r=n(2),A=n(23),o="".split;e.exports=r((function(){return!Object("z").propertyIsEnumerable(0)}))?function(e){return"String"==A(e)?o.call(e,""):Object(e)}:Object},function(e,t,n){var r=n(8);e.exports=function(e,t){if(!r(e))return e;var n,A;if(t&&"function"==typeof(n=e.toString)&&!r(A=n.call(e)))return A;if("function"==typeof(n=e.valueOf)&&!r(A=n.call(e)))return A;if(!t&&"function"==typeof(n=e.toString)&&!r(A=n.call(e)))return A;throw TypeError("Can't convert object to primitive value")}},function(e,t){var n=0,r=Math.random();e.exports=function(e){return"Symbol("+String(e===undefined?"":e)+")_"+(++n+r).toString(36)}},function(e,t){e.exports={}},function(e,t,n){var r=n(19),A=n(6),o=n(32),i=function(e){return function(t,n,i){var a,u=r(t),c=A(u.length),s=o(i,c);if(e&&n!=n){for(;c>s;)if((a=u[s++])!=a)return!0}else for(;c>s;s++)if((e||s in u)&&u[s]===n)return e||s||0;return!e&&-1}};e.exports={includes:i(!0),indexOf:i(!1)}},function(e,t,n){"use strict";var r=n(2);e.exports=function(e,t){var n=[][e];return!!n&&r((function(){n.call(null,t||function(){throw 1},1)}))}},function(e,t,n){"use strict";var r=n(31),A=n(9),o=n(4),i=n(5),a=o("species");e.exports=function(e){var t=r(e),n=A.f;i&&t&&!t[a]&&n(t,a,{configurable:!0,get:function(){return this}})}},function(e,t){e.exports=function(e){if("function"!=typeof e)throw TypeError(String(e)+" is not a function");return e}},function(e,t){e.exports=function(e,t,n){if(!(e instanceof t))throw TypeError("Incorrect "+(n?n+" ":"")+"invocation");return e}},function(e,t){e.exports={}},function(e,t,n){var r=n(10),A=n(13),o=n(60),i=n(157),a=o("IE_PROTO"),u=Object.prototype;e.exports=i?Object.getPrototypeOf:function(e){return e=A(e),r(e,a)?e[a]:"function"==typeof e.constructor&&e instanceof e.constructor?e.constructor.prototype:e instanceof Object?u:null}},function(e,t,n){"use strict";var r=n(0),A=n(8),o=n(41),i=n(32),a=n(6),u=n(19),c=n(59),s=n(4),f=n(67),g=n(33),l=f("slice"),d=g("slice",{ACCESSORS:!0,0:0,1:2}),p=s("species"),y=[].slice,h=Math.max;r({target:"Array",proto:!0,forced:!l||!d},{slice:function(e,t){var n,r,s,f=u(this),g=a(f.length),l=i(e,g),d=i(t===undefined?g:t,g);if(o(f)&&("function"!=typeof(n=f.constructor)||n!==Array&&!o(n.prototype)?A(n)&&null===(n=n[p])&&(n=undefined):n=undefined,n===Array||n===undefined))return y.call(f,l,d);for(r=new(n===undefined?Array:n)(h(d-l,0)),s=0;l<d;l++,s++)l in f&&c(r,s,f[l]);return r.length=s,r}})},function(e,t,n){"use strict";var r=n(48),A=n(9),o=n(37);e.exports=function(e,t,n){var i=r(t);i in e?A.f(e,i,o(0,n)):e[i]=n}},function(e,t,n){var r=n(105),A=n(49),o=r("keys");e.exports=function(e){return o[e]||(o[e]=A(e))}},function(e,t,n){var r=n(2),A=/#|\.prototype\./,o=function(e,t){var n=a[i(e)];return n==c||n!=u&&("function"==typeof t?r(t):!!t)},i=o.normalize=function(e){return String(e).replace(A,".").toLowerCase()},a=o.data={},u=o.NATIVE="N",c=o.POLYFILL="P";e.exports=o},function(e,t,n){var r=n(138),A=n(106);e.exports=Object.keys||function(e){return r(e,A)}},function(e,t,n){var r=n(110),A=n(23),o=n(4)("toStringTag"),i="Arguments"==A(function(){return arguments}());e.exports=r?A:function(e){var t,n,r;return e===undefined?"Undefined":null===e?"Null":"string"==typeof(n=function(e,t){try{return e[t]}catch(n){}}(t=Object(e),o))?n:i?A(t):"Object"==(r=A(t))&&"function"==typeof t.callee?"Arguments":r}},function(e,t,n){var r=n(4)("iterator"),A=!1;try{var o=0,i={next:function(){return{done:!!o++}},"return":function(){A=!0}};i[r]=function(){return this},Array.from(i,(function(){throw 2}))}catch(a){}e.exports=function(e,t){if(!t&&!A)return!1;var n=!1;try{var o={};o[r]=function(){return{next:function(){return{done:n=!0}}}},e(o)}catch(a){}return n}},function(e,t,n){var r=n(137),A=n(10),o=n(154),i=n(9).f;e.exports=function(e){var t=r.Symbol||(r.Symbol={});A(t,e)||i(t,e,{value:o.f(e)})}},function(e,t,n){"use strict";var r=n(0),A=n(155);r({target:"Array",proto:!0,forced:[].forEach!=A},{forEach:A})},function(e,t,n){var r=n(2),A=n(4),o=n(115),i=A("species");e.exports=function(e){return o>=51||!r((function(){var t=[];return(t.constructor={})[i]=function(){return{foo:1}},1!==t[e](Boolean).foo}))}},function(e,t,n){var r=n(1),A=n(159),o=n(155),i=n(14);for(var a in A){var u=r[a],c=u&&u.prototype;if(c&&c.forEach!==o)try{i(c,"forEach",o)}catch(s){c.forEach=o}}},function(e,t,n){"use strict";var r=n(0),A=n(51).indexOf,o=n(52),i=n(33),a=[].indexOf,u=!!a&&1/[1].indexOf(1,-0)<0,c=o("indexOf"),s=i("indexOf",{ACCESSORS:!0,1:0});r({target:"Array",proto:!0,forced:u||!c||!s},{indexOf:function(e){return u?a.apply(this,arguments)||0:A(this,e,arguments.length>1?arguments[1]:undefined)}})},function(e,t,n){"use strict";var r,A,o=n(120),i=n(164),a=RegExp.prototype.exec,u=String.prototype.replace,c=a,s=(r=/a/,A=/b*/g,a.call(r,"a"),a.call(A,"a"),0!==r.lastIndex||0!==A.lastIndex),f=i.UNSUPPORTED_Y||i.BROKEN_CARET,g=/()??/.exec("")[1]!==undefined;(s||g||f)&&(c=function(e){var t,n,r,A,i=this,c=f&&i.sticky,l=o.call(i),d=i.source,p=0,y=e;return c&&(-1===(l=l.replace("y","")).indexOf("g")&&(l+="g"),y=String(e).slice(i.lastIndex),i.lastIndex>0&&(!i.multiline||i.multiline&&"\n"!==e[i.lastIndex-1])&&(d="(?: "+d+")",y=" "+y,p++),n=new RegExp("^(?:"+d+")",l)),g&&(n=new RegExp("^"+d+"$(?!\\s)",l)),s&&(t=i.lastIndex),r=a.call(c?n:i,y),c?r?(r.input=r.input.slice(p),r[0]=r[0].slice(p),r.index=i.lastIndex,i.lastIndex+=r[0].length):i.lastIndex=0:s&&r&&(i.lastIndex=i.global?r.index+r[0].length:t),g&&r&&r.length>1&&u.call(r[0],n,(function(){for(A=1;A<arguments.length-2;A++)arguments[A]===undefined&&(r[A]=undefined)})),r}),e.exports=c},function(e,t,n){"use strict";var r=n(0),A=n(2),o=n(72),i=n(11),a=n(32),u=n(6),c=n(26),s=o.ArrayBuffer,f=o.DataView,g=s.prototype.slice;r({target:"ArrayBuffer",proto:!0,unsafe:!0,forced:A((function(){return!new s(2).slice(1,undefined).byteLength}))},{slice:function(e,t){if(g!==undefined&&t===undefined)return g.call(i(this),e);for(var n=i(this).byteLength,r=a(e,n),A=a(t===undefined?n:t,n),o=new(c(this,s))(u(A-r)),l=new f(this),d=new f(o),p=0;r<A;)d.setUint8(p++,l.getUint8(r++));return o}})},function(e,t,n){"use strict";var r=n(1),A=n(5),o=n(128),i=n(14),a=n(111),u=n(2),c=n(55),s=n(24),f=n(6),g=n(169),l=n(214),d=n(57),p=n(44),y=n(38).f,h=n(9).f,I=n(170),C=n(25),B=n(21),E=B.get,v=B.set,Q=r.ArrayBuffer,w=Q,m=r.DataView,b=m&&m.prototype,x=Object.prototype,S=r.RangeError,D=l.pack,k=l.unpack,R=function(e){return[255&e]},F=function(e){return[255&e,e>>8&255]},O=function(e){return[255&e,e>>8&255,e>>16&255,e>>24&255]},M=function(e){return e[3]<<24|e[2]<<16|e[1]<<8|e[0]},G=function(e){return D(e,23,4)},N=function(e){return D(e,52,8)},T=function(e,t){h(e.prototype,t,{get:function(){return E(this)[t]}})},L=function(e,t,n,r){var A=g(n),o=E(e);if(A+t>o.byteLength)throw S("Wrong index");var i=E(o.buffer).bytes,a=A+o.byteOffset,u=i.slice(a,a+t);return r?u:u.reverse()},H=function(e,t,n,r,A,o){var i=g(n),a=E(e);if(i+t>a.byteLength)throw S("Wrong index");for(var u=E(a.buffer).bytes,c=i+a.byteOffset,s=r(+A),f=0;f<t;f++)u[c+f]=s[o?f:t-f-1]};if(o){if(!u((function(){Q(1)}))||!u((function(){new Q(-1)}))||u((function(){return new Q,new Q(1.5),new Q(NaN),"ArrayBuffer"!=Q.name}))){for(var j,Y=(w=function(e){return c(this,w),new Q(g(e))}).prototype=Q.prototype,U=y(Q),P=0;U.length>P;)(j=U[P++])in w||i(w,j,Q[j]);Y.constructor=w}p&&d(b)!==x&&p(b,x);var K=new m(new w(2)),_=b.setInt8;K.setInt8(0,2147483648),K.setInt8(1,2147483649),!K.getInt8(0)&&K.getInt8(1)||a(b,{setInt8:function(e,t){_.call(this,e,t<<24>>24)},setUint8:function(e,t){_.call(this,e,t<<24>>24)}},{unsafe:!0})}else w=function(e){c(this,w,"ArrayBuffer");var t=g(e);v(this,{bytes:I.call(new Array(t),0),byteLength:t}),A||(this.byteLength=t)},m=function(e,t,n){c(this,m,"DataView"),c(e,w,"DataView");var r=E(e).byteLength,o=s(t);if(o<0||o>r)throw S("Wrong offset");if(o+(n=n===undefined?r-o:f(n))>r)throw S("Wrong length");v(this,{buffer:e,byteLength:n,byteOffset:o}),A||(this.buffer=e,this.byteLength=n,this.byteOffset=o)},A&&(T(w,"byteLength"),T(m,"buffer"),T(m,"byteLength"),T(m,"byteOffset")),a(m.prototype,{getInt8:function(e){return L(this,1,e)[0]<<24>>24},getUint8:function(e){return L(this,1,e)[0]},getInt16:function(e){var t=L(this,2,e,arguments.length>1?arguments[1]:undefined);return(t[1]<<8|t[0])<<16>>16},getUint16:function(e){var t=L(this,2,e,arguments.length>1?arguments[1]:undefined);return t[1]<<8|t[0]},getInt32:function(e){return M(L(this,4,e,arguments.length>1?arguments[1]:undefined))},getUint32:function(e){return M(L(this,4,e,arguments.length>1?arguments[1]:undefined))>>>0},getFloat32:function(e){return k(L(this,4,e,arguments.length>1?arguments[1]:undefined),23)},getFloat64:function(e){return k(L(this,8,e,arguments.length>1?arguments[1]:undefined),52)},setInt8:function(e,t){H(this,1,e,R,t)},setUint8:function(e,t){H(this,1,e,R,t)},setInt16:function(e,t){H(this,2,e,F,t,arguments.length>2?arguments[2]:undefined)},setUint16:function(e,t){H(this,2,e,F,t,arguments.length>2?arguments[2]:undefined)},setInt32:function(e,t){H(this,4,e,O,t,arguments.length>2?arguments[2]:undefined)},setUint32:function(e,t){H(this,4,e,O,t,arguments.length>2?arguments[2]:undefined)},setFloat32:function(e,t){H(this,4,e,G,t,arguments.length>2?arguments[2]:undefined)},setFloat64:function(e,t){H(this,8,e,N,t,arguments.length>2?arguments[2]:undefined)}});C(w,"ArrayBuffer"),C(m,"DataView"),e.exports={ArrayBuffer:w,DataView:m}},function(e,t,n){var r=n(0),A=n(13),o=n(62);r({target:"Object",stat:!0,forced:n(2)((function(){o(1)}))},{keys:function(e){return o(A(e))}})},function(e,t,n){n(215)("Uint8",(function(e){return function(t,n,r){return e(this,t,n,r)}}))},function(e,t,n){"use strict";var r=n(3),A=n(219),o=r.aTypedArray;(0,r.exportTypedArrayMethod)("copyWithin",(function(e,t){return A.call(o(this),e,t,arguments.length>2?arguments[2]:undefined)}))},function(e,t,n){"use strict";var r=n(3),A=n(20).every,o=r.aTypedArray;(0,r.exportTypedArrayMethod)("every",(function(e){return A(o(this),e,arguments.length>1?arguments[1]:undefined)}))},function(e,t,n){"use strict";var r=n(3),A=n(170),o=r.aTypedArray;(0,r.exportTypedArrayMethod)("fill",(function(e){return A.apply(o(this),arguments)}))},function(e,t,n){"use strict";var r=n(3),A=n(20).filter,o=n(26),i=r.aTypedArray,a=r.aTypedArrayConstructor;(0,r.exportTypedArrayMethod)("filter",(function(e){for(var t=A(i(this),e,arguments.length>1?arguments[1]:undefined),n=o(this,this.constructor),r=0,u=t.length,c=new(a(n))(u);u>r;)c[r]=t[r++];return c}))},function(e,t,n){"use strict";var r=n(3),A=n(20).find,o=r.aTypedArray;(0,r.exportTypedArrayMethod)("find",(function(e){return A(o(this),e,arguments.length>1?arguments[1]:undefined)}))},function(e,t,n){"use strict";var r=n(3),A=n(20).findIndex,o=r.aTypedArray;(0,r.exportTypedArrayMethod)("findIndex",(function(e){return A(o(this),e,arguments.length>1?arguments[1]:undefined)}))},function(e,t,n){"use strict";var r=n(3),A=n(20).forEach,o=r.aTypedArray;(0,r.exportTypedArrayMethod)("forEach",(function(e){A(o(this),e,arguments.length>1?arguments[1]:undefined)}))},function(e,t,n){"use strict";var r=n(3),A=n(51).includes,o=r.aTypedArray;(0,r.exportTypedArrayMethod)("includes",(function(e){return A(o(this),e,arguments.length>1?arguments[1]:undefined)}))},function(e,t,n){"use strict";var r=n(3),A=n(51).indexOf,o=r.aTypedArray;(0,r.exportTypedArrayMethod)("indexOf",(function(e){return A(o(this),e,arguments.length>1?arguments[1]:undefined)}))},function(e,t,n){"use strict";var r=n(1),A=n(3),o=n(16),i=n(4)("iterator"),a=r.Uint8Array,u=o.values,c=o.keys,s=o.entries,f=A.aTypedArray,g=A.exportTypedArrayMethod,l=a&&a.prototype[i],d=!!l&&("values"==l.name||l.name==undefined),p=function(){return u.call(f(this))};g("entries",(function(){return s.call(f(this))})),g("keys",(function(){return c.call(f(this))})),g("values",p,!d),g(i,p,!d)},function(e,t,n){"use strict";var r=n(3),A=r.aTypedArray,o=r.exportTypedArrayMethod,i=[].join;o("join",(function(e){return i.apply(A(this),arguments)}))},function(e,t,n){"use strict";var r=n(3),A=n(220),o=r.aTypedArray;(0,r.exportTypedArrayMethod)("lastIndexOf",(function(e){return A.apply(o(this),arguments)}))},function(e,t,n){"use strict";var r=n(3),A=n(20).map,o=n(26),i=r.aTypedArray,a=r.aTypedArrayConstructor;(0,r.exportTypedArrayMethod)("map",(function(e){return A(i(this),e,arguments.length>1?arguments[1]:undefined,(function(e,t){return new(a(o(e,e.constructor)))(t)}))}))},function(e,t,n){"use strict";var r=n(3),A=n(172).left,o=r.aTypedArray;(0,r.exportTypedArrayMethod)("reduce",(function(e){return A(o(this),e,arguments.length,arguments.length>1?arguments[1]:undefined)}))},function(e,t,n){"use strict";var r=n(3),A=n(172).right,o=r.aTypedArray;(0,r.exportTypedArrayMethod)("reduceRight",(function(e){return A(o(this),e,arguments.length,arguments.length>1?arguments[1]:undefined)}))},function(e,t,n){"use strict";var r=n(3),A=r.aTypedArray,o=r.exportTypedArrayMethod,i=Math.floor;o("reverse",(function(){for(var e,t=A(this).length,n=i(t/2),r=0;r<n;)e=this[r],this[r++]=this[--t],this[t]=e;return this}))},function(e,t,n){"use strict";var r=n(3),A=n(6),o=n(171),i=n(13),a=n(2),u=r.aTypedArray;(0,r.exportTypedArrayMethod)("set",(function(e){u(this);var t=o(arguments.length>1?arguments[1]:undefined,1),n=this.length,r=i(e),a=A(r.length),c=0;if(a+t>n)throw RangeError("Wrong length");for(;c<a;)this[t+c]=r[c++]}),a((function(){new Int8Array(1).set({})})))},function(e,t,n){"use strict";var r=n(3),A=n(26),o=n(2),i=r.aTypedArray,a=r.aTypedArrayConstructor,u=r.exportTypedArrayMethod,c=[].slice;u("slice",(function(e,t){for(var n=c.call(i(this),e,t),r=A(this,this.constructor),o=0,u=n.length,s=new(a(r))(u);u>o;)s[o]=n[o++];return s}),o((function(){new Int8Array(1).slice()})))},function(e,t,n){"use strict";var r=n(3),A=n(20).some,o=r.aTypedArray;(0,r.exportTypedArrayMethod)("some",(function(e){return A(o(this),e,arguments.length>1?arguments[1]:undefined)}))},function(e,t,n){"use strict";var r=n(3),A=r.aTypedArray,o=r.exportTypedArrayMethod,i=[].sort;o("sort",(function(e){return i.call(A(this),e)}))},function(e,t,n){"use strict";var r=n(3),A=n(6),o=n(32),i=n(26),a=r.aTypedArray;(0,r.exportTypedArrayMethod)("subarray",(function(e,t){var n=a(this),r=n.length,u=o(e,r);return new(i(n,n.constructor))(n.buffer,n.byteOffset+u*n.BYTES_PER_ELEMENT,A((t===undefined?r:o(t,r))-u))}))},function(e,t,n){"use strict";var r=n(1),A=n(3),o=n(2),i=r.Int8Array,a=A.aTypedArray,u=A.exportTypedArrayMethod,c=[].toLocaleString,s=[].slice,f=!!i&&o((function(){c.call(new i(1))}));u("toLocaleString",(function(){return c.apply(f?s.call(a(this)):a(this),arguments)}),o((function(){return[1,2].toLocaleString()!=new i([1,2]).toLocaleString()}))||!o((function(){i.prototype.toLocaleString.call([1,2])})))},function(e,t,n){"use strict";var r=n(3).exportTypedArrayMethod,A=n(2),o=n(1).Uint8Array,i=o&&o.prototype||{},a=[].toString,u=[].join;A((function(){a.call({})}))&&(a=function(){return u.call(this)});var c=i.toString!=a;r("toString",a,c)},function(e,t,n){"use strict";function r(e,t){for(var n=0;n<t.length;n++){var r=t[n];r.enumerable=r.enumerable||!1,r.configurable=!0,"value"in r&&(r.writable=!0),Object.defineProperty(e,r.key,r)}}n(16),n(71),n(223),n(17),n(7),n(74),n(75),n(76),n(77),n(78),n(79),n(80),n(81),n(82),n(83),n(84),n(85),n(86),n(87),n(88),n(89),n(90),n(91),n(92),n(93),n(94),n(95),n(96),n(97),Object.defineProperty(t,"__esModule",{value:!0}),t.Encoder=void 0;var A=function(){function e(){!function(e,t){if(!(e instanceof t))throw new TypeError("Cannot call a class as a function")}(this,e)}var t,n,A;return t=e,(n=[{key:"encode",value:function(e){for(var t="",n=new DataView(e),r=0;r<n.byteLength;r++)t+=String.fromCharCode(n.getUint8(r));return btoa(t)}},{key:"decode",value:function(e){for(var t=atob(e),n=t.length,r=new Uint8Array(n),A=0;A<n;A++)r[A]=t.charCodeAt(A);return r.buffer}}])&&r(t.prototype,n),A&&r(t,A),e}();t.Encoder=A},function(e,t,n){"use strict";var r=n(0),A=n(20).filter,o=n(67),i=n(33),a=o("filter"),u=i("filter");r({target:"Array",proto:!0,forced:!a||!u},{filter:function(e){return A(this,e,arguments.length>1?arguments[1]:undefined)}})},function(e,t){var n;n=function(){return this}();try{n=n||new Function("return this")()}catch(r){"object"==typeof window&&(n=window)}e.exports=n},function(e,t,n){"use strict";var r={}.propertyIsEnumerable,A=Object.getOwnPropertyDescriptor,o=A&&!r.call({1:2},1);t.f=o?function(e){var t=A(this,e);return!!t&&t.enumerable}:r},function(e,t,n){var r=n(1),A=n(8),o=r.document,i=A(o)&&A(o.createElement);e.exports=function(e){return i?o.createElement(e):{}}},function(e,t,n){var r=n(1),A=n(14);e.exports=function(e,t){try{A(r,e,t)}catch(n){r[e]=t}return t}},function(e,t,n){var r=n(134),A=Function.toString;"function"!=typeof r.inspectSource&&(r.inspectSource=function(e){return A.call(e)}),e.exports=r.inspectSource},function(e,t,n){var r=n(30),A=n(134);(e.exports=function(e,t){return A[e]||(A[e]=t!==undefined?t:{})})("versions",[]).push({version:"3.6.4",mode:r?"pure":"global",copyright:"© 2020 Denis Pushkarev (zloirock.ru)"})},function(e,t){e.exports=["constructor","hasOwnProperty","isPrototypeOf","propertyIsEnumerable","toLocaleString","toString","valueOf"]},function(e,t){t.f=Object.getOwnPropertySymbols},function(e,t,n){var r=n(31);e.exports=r("navigator","userAgent")||""},function(e,t,n){var r=n(2);e.exports=!!Object.getOwnPropertySymbols&&!r((function(){return!String(Symbol())}))},function(e,t,n){var r={};r[n(4)("toStringTag")]="z",e.exports="[object z]"===String(r)},function(e,t,n){var r=n(15);e.exports=function(e,t,n){for(var A in t)r(e,A,t[A],n);return e}},function(e,t,n){var r=n(11),A=n(113),o=n(6),i=n(40),a=n(114),u=n(146),c=function(e,t){this.stopped=e,this.result=t};(e.exports=function(e,t,n,s,f){var g,l,d,p,y,h,I,C=i(t,n,s?2:1);if(f)g=e;else{if("function"!=typeof(l=a(e)))throw TypeError("Target is not iterable");if(A(l)){for(d=0,p=o(e.length);p>d;d++)if((y=s?C(r(I=e[d])[0],I[1]):C(e[d]))&&y instanceof c)return y;return new c(!1)}g=l.call(e)}for(h=g.next;!(I=h.call(g)).done;)if("object"==typeof(y=u(g,C,I.value,s))&&y&&y instanceof c)return y;return new c(!1)}).stop=function(e){return new c(!0,e)}},function(e,t,n){var r=n(4),A=n(56),o=r("iterator"),i=Array.prototype;e.exports=function(e){return e!==undefined&&(A.Array===e||i[o]===e)}},function(e,t,n){var r=n(63),A=n(56),o=n(4)("iterator");e.exports=function(e){if(e!=undefined)return e[o]||e["@@iterator"]||A[r(e)]}},function(e,t,n){var r,A,o=n(1),i=n(108),a=o.process,u=a&&a.versions,c=u&&u.v8;c?A=(r=c.split("."))[0]+r[1]:i&&(!(r=i.match(/Edge\/(\d+)/))||r[1]>=74)&&(r=i.match(/Chrome\/(\d+)/))&&(A=r[1]),e.exports=A&&+A},function(e,t,n){var r=n(8),A=n(23),o=n(4)("match");e.exports=function(e){var t;return r(e)&&((t=e[o])!==undefined?!!t:"RegExp"==A(e))}},function(e,t,n){var r=n(8),A=n(41),o=n(4)("species");e.exports=function(e,t){var n;return A(e)&&("function"!=typeof(n=e.constructor)||n!==Array&&!A(n.prototype)?r(n)&&null===(n=n[o])&&(n=undefined):n=undefined),new(n===undefined?Array:n)(0===t?0:t)}},function(e,t,n){"use strict";var r=n(0),A=n(192),o=n(57),i=n(44),a=n(25),u=n(14),c=n(15),s=n(4),f=n(30),g=n(56),l=n(156),d=l.IteratorPrototype,p=l.BUGGY_SAFARI_ITERATORS,y=s("iterator"),h=function(){return this};e.exports=function(e,t,n,s,l,I,C){A(n,t,s);var B,E,v,Q=function(e){if(e===l&&S)return S;if(!p&&e in b)return b[e];switch(e){case"keys":case"values":case"entries":return function(){return new n(this,e)}}return function(){return new n(this)}},w=t+" Iterator",m=!1,b=e.prototype,x=b[y]||b["@@iterator"]||l&&b[l],S=!p&&x||Q(l),D="Array"==t&&b.entries||x;if(D&&(B=o(D.call(new e)),d!==Object.prototype&&B.next&&(f||o(B)===d||(i?i(B,d):"function"!=typeof B[y]&&u(B,y,h)),a(B,w,!0,!0),f&&(g[w]=h))),"values"==l&&x&&"values"!==x.name&&(m=!0,S=function(){return x.call(this)}),f&&!C||b[y]===S||u(b,y,S),g[t]=S,l)if(E={values:Q("values"),keys:I?S:Q("keys"),entries:Q("entries")},C)for(v in E)!p&&!m&&v in b||c(b,v,E[v]);else r({target:t,proto:!0,forced:p||m},E);return E}},function(e,t,n){var r=n(5),A=n(9).f,o=Function.prototype,i=o.toString,a=/^\s*function ([^ (]*)/;!r||"name"in o||A(o,"name",{configurable:!0,get:function(){try{return i.call(this).match(a)[1]}catch(e){return""}}})},function(e,t,n){"use strict";var r=n(11);e.exports=function(){var e=r(this),t="";return e.global&&(t+="g"),e.ignoreCase&&(t+="i"),e.multiline&&(t+="m"),e.dotAll&&(t+="s"),e.unicode&&(t+="u"),e.sticky&&(t+="y"),t}},function(e,t,n){var r=n(8),A=n(44);e.exports=function(e,t,n){var o,i;return A&&"function"==typeof(o=t.constructor)&&o!==n&&r(i=o.prototype)&&i!==n.prototype&&A(e,i),e}},function(e,t,n){"use strict";var r=n(0),A=n(70);r({target:"RegExp",proto:!0,forced:/./.exec!==A},{exec:A})},function(e,t,n){"use strict";n(17),Object.defineProperty(t,"__esModule",{value:!0}),t.getCryptoEngineSingleton=function(){r||(r=u());return r},t.createWasmCryptoEngine=u,t.BasicCryptoEngine=void 0;var r,A=n(124),o=n(127);function i(e,t){for(var n=0;n<t.length;n++){var r=t[n];r.enumerable=r.enumerable||!1,r.configurable=!0,"value"in r&&(r.writable=!0),Object.defineProperty(e,r.key,r)}}function a(e,t,n){return t in e?Object.defineProperty(e,t,{value:n,enumerable:!0,configurable:!0,writable:!0}):e[t]=n,e}function u(){var e=(new A.KeyManager).getKeyCache(),t=new o.AesWasmCrypto(e);return new c(t)}var c=function(){function e(t){!function(e,t){if(!(e instanceof t))throw new TypeError("Cannot call a class as a function")}(this,e),a(this,"name","BasicCryptoEngine"),a(this,"cryptoAlg",void 0),this.cryptoAlg=t}var t,n,r;return t=e,(n=[{key:"decrypt",value:function(e){return this.cryptoAlg.decrypt(e)}}])&&i(t.prototype,n),r&&i(t,r),e}();t.BasicCryptoEngine=c},function(e,t,n){"use strict";n(34),n(42),n(43),n(208),n(69),n(166),n(16),n(162),n(210),n(35),n(125),n(17),n(7),n(12),n(45),n(36),n(27),Object.defineProperty(t,"__esModule",{value:!0}),t.KeyManager=void 0,n(18);var r=n(126),A=n(168),o=n(229),i=n(174),a=n(175),u=n(98),c=n(46),s=n(28);function f(e,t){return function(e){if(Array.isArray(e))return e}(e)||function(e,t){if(!(Symbol.iterator in Object(e)||"[object Arguments]"===Object.prototype.toString.call(e)))return;var n=[],r=!0,A=!1,o=undefined;try{for(var i,a=e[Symbol.iterator]();!(r=(i=a.next()).done)&&(n.push(i.value),!t||n.length!==t);r=!0);}catch(err){A=!0,o=err}finally{try{r||null==a["return"]||a["return"]()}finally{if(A)throw o}}return n}(e,t)||function(){throw new TypeError("Invalid attempt to destructure non-iterable instance")}()}function g(e,t,n,r,A,o,i){try{var a=e[o](i),u=a.value}catch(c){return void n(c)}a.done?t(u):Promise.resolve(u).then(r,A)}function l(e){return function(){var t=this,n=arguments;return new Promise((function(r,A){var o=e.apply(t,n);function i(e){g(o,r,A,i,a,"next",e)}function a(e){g(o,r,A,i,a,"throw",e)}i(undefined)}))}}function d(e,t){for(var n=0;n<t.length;n++){var r=t[n];r.enumerable=r.enumerable||!1,r.configurable=!0,"value"in r&&(r.writable=!0),Object.defineProperty(e,r.key,r)}}function p(e,t,n){return t in e?Object.defineProperty(e,t,{value:n,enumerable:!0,configurable:!0,writable:!0}):e[t]=n,e}var y=new a.LocalStorage,h=new i.KeyCache(y),I=function(){function e(){!function(e,t){if(!(e instanceof t))throw new TypeError("Cannot call a class as a function")}(this,e),p(this,"encoder",new u.Encoder),p(this,"logger",new s.Logger),p(this,"COOKIE_KEY_STORAGE_PERIOD_DAYS",60),p(this,"ROTATION_PERIOD_MILLISECONDS",2592e6),p(this,"MAX_UNUSED_PERIOD_MILLISECONDS",6048e5),p(this,"temporaryRsaPublicKey",{alg:"RSA-OAEP-256",e:"AQAB",ext:!0,key_ops:["wrapKey"],kty:"RSA",n:"m8r2gkd7h4rm-MpK7axgjooGpepzaCohLoesAK3GRmIekT8Kq51n-FVib_KuiZE5evdoyf9s0bF4NSuGdecBs_arbeSzTiEHis23bpXevhNY54a_LbVRCiaQnG9KVonvOBW-PTFl5GWn4F7nx4pSz3ramYF8yc_I2MXXrEgNZvpU6Mmrn_KoyjxLitD-c9GcM5xVaR-riYXIdhC2zV-s07HhFXwo6gOKPSjD56HBbqauwkZH9XTTT7uTMT3flkAHqLxRJ157zj-as7QsVr7HM3MQyoHah0MurGUGaXe8Sutt03dnOL48ydzaIb2jDWDxl4nEWK_tcOseOStaUY0n3w"})}var t,n,i,a,g,I,C,B,E,v;return t=e,(n=[{key:"rsaEncryptKey",value:(v=l(regeneratorRuntime.mark((function Q(e){var t,n;return regeneratorRuntime.wrap((function(A){for(;;)switch(A.prev=A.next){case 0:return t=(0,r.aesImportKey)(e,!0,["wrapKey"]),n=(0,o.rsaImportKey)(this.temporaryRsaPublicKey,!1,["wrapKey"]),A.t0=o.rsaWrap,A.next=5,n;case 5:return A.t1=A.sent,A.next=8,t;case 8:return A.t2=A.sent,A.abrupt("return",(0,A.t0)(A.t1,A.t2));case 10:case"end":return A.stop()}}),Q,this)}))),function(e){return v.apply(this,arguments)})},{key:"createKey",value:(E=l(regeneratorRuntime.mark((function w(){var e,t,n,o;return regeneratorRuntime.wrap((function(i){for(;;)switch(i.prev=i.next){case 0:return i.next=2,(0,r.aesGenerateKey)();case 2:if(e=i.sent,t=(0,A.generateUid)(),n={wasmTested:!0,wasmCompatible:!0,webCryptoTested:!1},y.put(t,e),y.get(t)){i.next=8;break}throw new Error("New key disappeared after it was saved");case 8:return i.next=10,this.rsaEncryptKey(e);case 10:return o=i.sent,(0,c.cookieManagerSave)(t,this.encoder.encode(o),this.COOKIE_KEY_STORAGE_PERIOD_DAYS,n),this.logger.incrementCounter("Siege:Csd:KeyManager:CreateKey",1),i.abrupt("return",t);case 14:case"end":return i.stop()}}),w,this)}))),function(){return E.apply(this,arguments)})},{key:"getKeysThatExceededMaxUnusedPeriod",value:function(e){var t=new Map(e),n=!0,r=!1,A=undefined;try{for(var o,i=e[Symbol.iterator]();!(n=(o=i.next()).done);n=!0){var a=f(o.value,2),u=a[0],c=a[1];(!c.lastUsedDate||c.lastUsedDate>new Date(Date.now()-this.MAX_UNUSED_PERIOD_MILLISECONDS))&&t["delete"](u)}}catch(err){r=!0,A=err}finally{try{n||null==i["return"]||i["return"]()}finally{if(r)throw A}}return t}},{key:"getOlderKeys",value:function(e){var t=this.getKeysThatExceededMaxUnusedPeriod(e),n=Array.from(t.keys()),r=(0,c.cookieManagerGet)().kid,A=n.indexOf(r);return A>-1&&n.splice(A,1),n}},{key:"cacheActiveKey",value:(B=l(regeneratorRuntime.mark((function m(){return regeneratorRuntime.wrap((function(e){for(;;)switch(e.prev=e.next){case 0:return e.next=2,this.isInitialized();case 2:if(e.sent){e.next=4;break}return e.abrupt("return");case 4:this.getActiveKey();case 5:case"end":return e.stop()}}),m,this)}))),function(){return B.apply(this,arguments)})},{key:"rotateKeyIfNeeded",value:(C=l(regeneratorRuntime.mark((function b(){var e,t,n,r;return regeneratorRuntime.wrap((function(A){for(;;)switch(A.prev=A.next){case 0:return A.next=2,this.isInitialized();case 2:if(A.sent){A.next=4;break}return A.abrupt("return",!1);case 4:if(e=this.getActiveKey(),t=y.getAll(),n=this.getOlderKeys(t),y.removeKeys(n),this.logger.incrementCounter("Siege:Csd:KeyManager:DeleteOlderKeys",n.length),r=new Date(Date.now()-this.ROTATION_PERIOD_MILLISECONDS),!(e.issuedDate<r)){A.next=15;break}return A.next=13,this.createKey();case 13:return this.logger.incrementCounter("Siege:Csd:KeyManager:RotateKeys",1),A.abrupt("return",!0);case 15:return A.abrupt("return",!1);case 16:case"end":return A.stop()}}),b,this)}))),function(){return C.apply(this,arguments)})},{key:"getActiveKey",value:function(){var e=(0,c.cookieManagerGet)().kid;try{return h.get(e)}catch(t){throw this.logger.incrementCounter("Siege:Csd:KeyManager:ActiveKeyMissing",1),t}}},{key:"isInitialized",value:(I=l(regeneratorRuntime.mark((function x(){return regeneratorRuntime.wrap((function(e){for(;;)switch(e.prev=e.next){case 0:if(e.prev=0,(0,c.cookieManagerIsEnabled)()){e.next=3;break}return e.abrupt("return",!1);case 3:return this.getActiveKey(),e.abrupt("return",!0);case 7:return e.prev=7,e.t0=e["catch"](0),e.abrupt("return",!1);case 10:case"end":return e.stop()}}),x,this,[[0,7]])}))),function(){return I.apply(this,arguments)})},{key:"isDisabled",value:(g=l(regeneratorRuntime.mark((function S(){return regeneratorRuntime.wrap((function(e){for(;;)switch(e.prev=e.next){case 0:return e.abrupt("return",new Promise((function(e){e((0,c.cookieManagerIsDisabled)())})));case 1:case"end":return e.stop()}}),S)}))),function(){return g.apply(this,arguments)})},{key:"disable",value:function(){this.logger.incrementCounter("Siege:Csd:KeyManager:Disabling",1),(0,c.cookieManagerDisable)()}},{key:"delete",value:(a=l(regeneratorRuntime.mark((function D(){var e,t=arguments;return regeneratorRuntime.wrap((function(n){for(;;)switch(n.prev=n.next){case 0:if(e=t.length>0&&t[0]!==undefined&&t[0],this.logger.incrementCounter("Siege:Csd:KeyManager:Deleting",1),(0,c.cookieManagerDelete)(),!e){n.next=9;break}return this.logger.incrementCounter("Siege:Csd:KeyManager:DeletingStorage",1),n.next=7,y.clear();case 7:return n.next=9,h.cacheAllKeys();case 9:case"end":return n.stop()}}),D,this)}))),function(){return a.apply(this,arguments)})},{key:"getKeyCache",value:function(){return h}}])&&d(t.prototype,n),i&&d(t,i),e}();t.KeyManager=I},function(e,t,n){"use strict";var r=n(211),A=n(213);e.exports=r("Map",(function(e){return function(){return e(this,arguments.length?arguments[0]:undefined)}}),A)},function(e,t,n){"use strict";function r(e,t,n,r,A,o,i){try{var a=e[o](i),u=a.value}catch(c){return void n(c)}a.done?t(u):Promise.resolve(u).then(r,A)}function A(e){return function(){var t=this,n=arguments;return new Promise((function(A,o){var i=e.apply(t,n);function a(e){r(i,A,o,a,u,"next",e)}function u(e){r(i,A,o,a,u,"throw",e)}a(undefined)}))}}n(7),n(12),Object.defineProperty(t,"__esModule",{value:!0}),t.aesGenerateKey=function(){return o.apply(this,arguments)},t.aesImportKey=function(e,t,n){return i.apply(this,arguments)},t.AES_NAME=void 0,n(18);t.AES_NAME="AES-GCM";function o(){return(o=A(regeneratorRuntime.mark((function e(){var t,n;return regeneratorRuntime.wrap((function(e){for(;;)switch(e.prev=e.next){case 0:return e.next=2,crypto.subtle.generateKey({name:"AES-GCM",length:128},!0,["wrapKey"]);case 2:return t=e.sent,e.next=5,crypto.subtle.exportKey("raw",t);case 5:return n=e.sent,e.abrupt("return",n);case 7:case"end":return e.stop()}}),e)})))).apply(this,arguments)}function i(){return(i=A(regeneratorRuntime.mark((function e(t,n,r){return regeneratorRuntime.wrap((function(e){for(;;)switch(e.prev=e.next){case 0:return e.abrupt("return",crypto.subtle.importKey("raw",t,{name:"AES-GCM",length:128},n,r));case 1:case"end":return e.stop()}}),e)})))).apply(this,arguments)}},function(e,t,n){"use strict";n(16),n(58),n(71),n(17),n(73),n(7),n(12),n(74),n(75),n(76),n(77),n(78),n(79),n(80),n(81),n(82),n(83),n(84),n(85),n(86),n(87),n(88),n(89),n(90),n(91),n(92),n(93),n(94),n(95),n(96),n(97),n(27),Object.defineProperty(t,"__esModule",{value:!0}),t.AesWasmCrypto=void 0,n(18),n(221);var r=n(98),A=n(28),o=n(126),i=n(224),a=n(227);function u(e,t,n,r,A,o,i){try{var a=e[o](i),u=a.value}catch(c){return void n(c)}a.done?t(u):Promise.resolve(u).then(r,A)}function c(e,t){for(var n=0;n<t.length;n++){var r=t[n];r.enumerable=r.enumerable||!1,r.configurable=!0,"value"in r&&(r.writable=!0),Object.defineProperty(e,r.key,r)}}var s=new A.Logger;var f=function(){s.startTimer("AesWasm:Compilation");var e={};function t(){e.memory=new Uint8Array(e.exports.memory.buffer)}var n=(0,i.loadCondensedWasm)(a.program,{env:{emscripten_notify_memory_growth:t}});return n._initialize(),e.exports=n,t(),s.stopAndSendTimer("AesWasm:Compilation"),e}();function g(e){for(var t,n=0,r=Object.keys(e);n<r.length;n++){var A=r[n];try{f.exports.free(e[A]),delete e[A]}catch(o){t=o}}if(t!==undefined)throw t}function l(e){if(0!==e)throw new Error("Unexpected return from mbedtls: ".concat(e))}var d=function(){function e(t){var n,A,o;!function(e,t){if(!(e instanceof t))throw new TypeError("Cannot call a class as a function")}(this,e),this.keys=t,o=void 0,(A="encoder")in(n=this)?Object.defineProperty(n,A,{value:o,enumerable:!0,configurable:!0,writable:!0}):n[A]=o,this.encoder=new r.Encoder}var t,n,A,i,a;return t=e,(n=[{key:"unpack",value:function(e){return{ct:this.encoder.decode(e.ct),iv:this.encoder.decode(e.iv),kid:e.kid}}},{key:"pack",value:function(e){return{ct:this.encoder.encode(e.ct),iv:this.encoder.encode(e.iv),kid:e.kid}}},{key:"encrypt",value:(i=regeneratorRuntime.mark((function s(e,t){var n,r,A,i;return regeneratorRuntime.wrap((function(a){for(;;)switch(a.prev=a.next){case 0:return n=(new TextEncoder).encode(t),a.next=3,(0,o.aesImportKey)(this.keys.getCryptoKey(e),!1,["encrypt"]);case 3:return r=a.sent,A=crypto.getRandomValues(new Uint8Array(12)).buffer,a.next=7,crypto.subtle.encrypt({name:"AES-GCM",iv:A,tagLength:128},r,n);case 7:return i=a.sent,a.abrupt("return",this.pack({ct:i,iv:A,kid:e}));case 9:case"end":return a.stop()}}),s,this)})),a=function(){var e=this,t=arguments;return new Promise((function(n,r){var A=i.apply(e,t);function o(e){u(A,n,r,o,a,"next",e)}function a(e){u(A,n,r,o,a,"throw",e)}o(undefined)}))},function(e,t){return a.apply(this,arguments)})},{key:"internalDecrypt",value:function(e,t,n){var r=function(e){for(var t={},n=0,r=Object.keys(e);n<r.length;n++){var A=r[n];try{var o=f.exports.malloc(e[A]);if(0===o)throw new Error("malloc returned null");t[A]=o}catch(i){throw g(t),i}}return t}({ctx:f.exports.sizeof_mbedtls_gcm_context(),key:e.byteLength,tag:16,data:t.byteLength-16+8,iv:n.byteLength});try{f.exports.mbedtls_gcm_init(r.ctx);try{return f.memory.set(new Uint8Array(e),r.key),l(f.exports.mbedtls_gcm_setkey(r.ctx,f.exports.mbedtls_cipher_id_aes(),r.key,8*e.byteLength)),f.memory.set(new Uint8Array(t,t.byteLength-16,16),r.tag),f.memory.set(new Uint8Array(t,0,t.byteLength-16),r.data+8),f.memory.set(new Uint8Array(n),r.iv),l(f.exports.mbedtls_gcm_auth_decrypt(r.ctx,t.byteLength-16,r.iv,n.byteLength,0,0,r.tag,16,r.data+8,r.data)),f.memory.slice(r.data,r.data+t.byteLength-16)}finally{f.exports.mbedtls_gcm_free(r.ctx)}}finally{g(r)}}},{key:"decrypt",value:function(e){var t=this.unpack(e),n=this.internalDecrypt(this.keys.getCryptoKey(t.kid),t.ct,t.iv);return(new TextDecoder).decode(n)}}])&&c(t.prototype,n),A&&c(t,A),e}();t.AesWasmCrypto=d},function(e,t){e.exports="undefined"!=typeof ArrayBuffer&&"undefined"!=typeof DataView},function(e,t,n){var r=n(0),A=n(5);r({target:"Object",stat:!0,forced:!A,sham:!A},{defineProperties:n(143)})},function(e,t,n){var r=n(0),A=n(2),o=n(19),i=n(22).f,a=n(5),u=A((function(){i(1)}));r({target:"Object",stat:!0,forced:!a||u,sham:!a},{getOwnPropertyDescriptor:function(e,t){return i(o(e),t)}})},function(e,t,n){var r=n(0),A=n(5),o=n(136),i=n(19),a=n(22),u=n(59);r({target:"Object",stat:!0,sham:!A},{getOwnPropertyDescriptors:function(e){for(var t,n,r=i(e),A=a.f,c=o(r),s={},f=0;c.length>f;)(n=A(r,t=c[f++]))!==undefined&&u(s,t,n);return s}})},function(e,t,n){var r=n(0),A=n(1),o=n(108),i=[].slice,a=function(e){return function(t,n){var r=arguments.length>2,A=r?i.call(arguments,2):undefined;return e(r?function(){("function"==typeof t?t:Function(t)).apply(this,A)}:t,n)}};r({global:!0,bind:!0,forced:/MSIE .\./.test(o)},{setTimeout:a(A.setTimeout),setInterval:a(A.setInterval)})},function(e,t,n){var r=n(5),A=n(2),o=n(102);e.exports=!r&&!A((function(){return 7!=Object.defineProperty(o("div"),"a",{get:function(){return 7}}).a}))},function(e,t,n){var r=n(1),A=n(103),o=r["__core-js_shared__"]||A("__core-js_shared__",{});e.exports=o},function(e,t,n){var r=n(10),A=n(136),o=n(22),i=n(9);e.exports=function(e,t){for(var n=A(t),a=i.f,u=o.f,c=0;c<n.length;c++){var s=n[c];r(e,s)||a(e,s,u(t,s))}}},function(e,t,n){var r=n(31),A=n(38),o=n(107),i=n(11);e.exports=r("Reflect","ownKeys")||function(e){var t=A.f(i(e)),n=o.f;return n?t.concat(n(e)):t}},function(e,t,n){var r=n(1);e.exports=r},function(e,t,n){var r=n(10),A=n(19),o=n(51).indexOf,i=n(50);e.exports=function(e,t){var n,a=A(e),u=0,c=[];for(n in a)!r(i,n)&&r(a,n)&&c.push(n);for(;t.length>u;)r(a,n=t[u++])&&(~o(c,n)||c.push(n));return c}},function(e,t,n){"use strict";function r(e){return(r="function"==typeof Symbol&&"symbol"==typeof Symbol.iterator?function(e){return typeof e}:function(e){return e&&"function"==typeof Symbol&&e.constructor===Symbol&&e!==Symbol.prototype?"symbol":typeof e})(e)}n(140),n(7),n(12),n(187),n(151),Object.defineProperty(t,"__esModule",{value:!0}),t.csdStatus=function(){return(0,a.cookieManagerIsEnabled)()?"enabled":(0,a.cookieManagerIsDisabled)()?"disabled":"bootstrapping"},t.bootstrap=function(){return E.apply(this,arguments)},t.decryptInElementWithId=function(e,t,n){try{C.incrementCounter("Siege:Csd:decryptInElementWithId");var r=(0,o.getCryptoEngineSingleton)();l.decryptInPlace(e,t,C,I,r,n),C.updateCounter("Siege:Csd:Decrypt:Success",1)}catch(A){C.updateCounter("Siege:Csd:Decrypt:Failure",1),(0,u.csdDisable)(),C.logError(A,"Siege:Csd:Decrypt"),(0,f.reloadPage)()}},n(18);var A=p(n(200)),o=n(123),i=n(230),a=n(46),u=n(176),c=n(177),s=n(28),f=n(232),g=n(178),l=p(n(233));function d(){if("function"!=typeof WeakMap)return null;var e=new WeakMap;return d=function(){return e},e}function p(e){if(e&&e.__esModule)return e;if(null===e||"object"!==r(e)&&"function"!=typeof e)return{"default":e};var t=d();if(t&&t.has(e))return t.get(e);var n={},A=Object.defineProperty&&Object.getOwnPropertyDescriptor;for(var o in e)if(Object.prototype.hasOwnProperty.call(e,o)){var i=A?Object.getOwnPropertyDescriptor(e,o):null;i&&(i.get||i.set)?Object.defineProperty(n,o,i):n[o]=e[o]}return n["default"]=e,t&&t.set(e,n),n}function y(e,t,n,r,A,o,i){try{var a=e[o](i),u=a.value}catch(c){return void n(c)}a.done?t(u):Promise.resolve(u).then(r,A)}function h(e){return function(){var t=this,n=arguments;return new Promise((function(r,A){var o=e.apply(t,n);function i(e){y(o,r,A,i,a,"next",e)}function a(e){y(o,r,A,i,a,"throw",e)}i(undefined)}))}}var I=new i.NodeDisplay,C=new s.Logger;try{(0,s.logLibraryLoadMetrics)(C)}catch(v){}var B=!1;function E(){return(E=h(regeneratorRuntime.mark((function e(){return regeneratorRuntime.wrap((function(e){for(;;)switch(e.prev=e.next){case 0:if(e.prev=0,!B&&!g.bootstrapPromise){e.next=3;break}return e.abrupt("return");case 3:return B=!0,e.next=6,(0,u.csdBootstrap)();case 6:e.next=13;break;case 8:e.prev=8,e.t0=e["catch"](0),C.updateCounter("Siege:Csd:Bootstrap:Failure",1),(0,u.csdDisable)(),C.logWarn(e.t0,"Siege:Csd:Bootstrap");case 13:case"end":return e.stop()}}),e,null,[[0,8]])})))).apply(this,arguments)}A.before((function(e,t){(0,g.beforeHandler)(e)["catch"]((function(e){C.updateCounter("Siege:Csd:Bootstrap:Failure",1),(0,u.csdDisable)(),C.logWarn(e,"Siege:Csd:Bootstrap")}))["finally"]((function(){return t()}))})),A.after((function(e,t,n){var r=t instanceof Response?t.headers.get("content-type"):t.headers["content-type"];if(null==r?void 0:r.toLowerCase().includes("text/event-stream"))return C.incrementCounter("Siege:Csd:StreamSkipped"),void n(t);(0,g.afterHandler)(e,t).then((function(e){return n(e)}))["catch"]((function(e){n((0,c.reqResHandler)(t).errorResponse(e)),e instanceof SyntaxError||(C.updateCounter("Siege:Csd:Decrypt:Failure",1),(0,u.csdDisable)(),C.logError(e,"Siege:Csd:Decrypt"))}))}))},function(e,t,n){"use strict";var r=n(0),A=n(51).includes,o=n(141);r({target:"Array",proto:!0,forced:!n(33)("indexOf",{ACCESSORS:!0,1:0})},{includes:function(e){return A(this,e,arguments.length>1?arguments[1]:undefined)}}),o("includes")},function(e,t,n){var r=n(4),A=n(39),o=n(9),i=r("unscopables"),a=Array.prototype;a[i]==undefined&&o.f(a,i,{configurable:!0,value:A(null)}),e.exports=function(e){a[i][e]=!0}},function(e,t,n){var r=n(109);e.exports=r&&!Symbol.sham&&"symbol"==typeof Symbol.iterator},function(e,t,n){var r=n(5),A=n(9),o=n(11),i=n(62);e.exports=r?Object.defineProperties:function(e,t){o(e);for(var n,r=i(t),a=r.length,u=0;a>u;)A.f(e,n=r[u++],t[n]);return e}},function(e,t,n){var r=n(31);e.exports=r("document","documentElement")},function(e,t,n){var r=n(1);e.exports=r.Promise},function(e,t,n){var r=n(11);e.exports=function(e,t,n,A){try{return A?t(r(n)[0],n[1]):t(n)}catch(i){var o=e["return"];throw o!==undefined&&r(o.call(e)),i}}},function(e,t,n){var r,A,o,i=n(1),a=n(2),u=n(23),c=n(40),s=n(144),f=n(102),g=n(148),l=i.location,d=i.setImmediate,p=i.clearImmediate,y=i.process,h=i.MessageChannel,I=i.Dispatch,C=0,B={},E=function(e){if(B.hasOwnProperty(e)){var t=B[e];delete B[e],t()}},v=function(e){return function(){E(e)}},Q=function(e){E(e.data)},w=function(e){i.postMessage(e+"",l.protocol+"//"+l.host)};d&&p||(d=function(e){for(var t=[],n=1;arguments.length>n;)t.push(arguments[n++]);return B[++C]=function(){("function"==typeof e?e:Function(e)).apply(undefined,t)},r(C),C},p=function(e){delete B[e]},"process"==u(y)?r=function(e){y.nextTick(v(e))}:I&&I.now?r=function(e){I.now(v(e))}:h&&!g?(o=(A=new h).port2,A.port1.onmessage=Q,r=c(o.postMessage,o,1)):!i.addEventListener||"function"!=typeof postMessage||i.importScripts||a(w)?r="onreadystatechange"in f("script")?function(e){s.appendChild(f("script")).onreadystatechange=function(){s.removeChild(this),E(e)}}:function(e){setTimeout(v(e),0)}:(r=w,i.addEventListener("message",Q,!1))),e.exports={set:d,clear:p}},function(e,t,n){var r=n(108);e.exports=/(iphone|ipod|ipad).*applewebkit/i.test(r)},function(e,t,n){var r=n(11),A=n(8),o=n(150);e.exports=function(e,t){if(r(e),A(t)&&t.constructor===e)return t;var n=o.f(e);return(0,n.resolve)(t),n.promise}},function(e,t,n){"use strict";var r=n(54),A=function(e){var t,n;this.promise=new e((function(e,r){if(t!==undefined||n!==undefined)throw TypeError("Bad Promise constructor");t=e,n=r})),this.resolve=r(t),this.reject=r(n)};e.exports.f=function(e){return new A(e)}},function(e,t,n){"use strict";var r=n(0),A=n(152),o=n(29);r({target:"String",proto:!0,forced:!n(153)("includes")},{includes:function(e){return!!~String(o(this)).indexOf(A(e),arguments.length>1?arguments[1]:undefined)}})},function(e,t,n){var r=n(116);e.exports=function(e){if(r(e))throw TypeError("The method doesn't accept regular expressions");return e}},function(e,t,n){var r=n(4)("match");e.exports=function(e){var t=/./;try{"/./"[e](t)}catch(n){try{return t[r]=!1,"/./"[e](t)}catch(A){}}return!1}},function(e,t,n){var r=n(4);t.f=r},function(e,t,n){"use strict";var r=n(20).forEach,A=n(52),o=n(33),i=A("forEach"),a=o("forEach");e.exports=i&&a?[].forEach:function(e){return r(this,e,arguments.length>1?arguments[1]:undefined)}},function(e,t,n){"use strict";var r,A,o,i=n(57),a=n(14),u=n(10),c=n(4),s=n(30),f=c("iterator"),g=!1;[].keys&&("next"in(o=[].keys())?(A=i(i(o)))!==Object.prototype&&(r=A):g=!0),r==undefined&&(r={}),s||u(r,f)||a(r,f,(function(){return this})),e.exports={IteratorPrototype:r,BUGGY_SAFARI_ITERATORS:g}},function(e,t,n){var r=n(2);e.exports=!r((function(){function e(){}return e.prototype.constructor=null,Object.getPrototypeOf(new e)!==e.prototype}))},function(e,t,n){var r=n(24),A=n(29),o=function(e){return function(t,n){var o,i,a=String(A(t)),u=r(n),c=a.length;return u<0||u>=c?e?"":undefined:(o=a.charCodeAt(u))<55296||o>56319||u+1===c||(i=a.charCodeAt(u+1))<56320||i>57343?e?a.charAt(u):o:e?a.slice(u,u+2):i-56320+(o-55296<<10)+65536}};e.exports={codeAt:o(!1),charAt:o(!0)}},function(e,t){e.exports={CSSRuleList:0,CSSStyleDeclaration:0,CSSValueList:0,ClientRectList:0,DOMRectList:0,DOMStringList:0,DOMTokenList:1,DataTransferItemList:0,FileList:0,HTMLAllCollection:0,HTMLCollection:0,HTMLFormElement:0,HTMLSelectElement:0,MediaList:0,MimeTypeArray:0,NamedNodeMap:0,NodeList:1,PaintRequestList:0,Plugin:0,PluginArray:0,SVGLengthList:0,SVGNumberList:0,SVGPathSegList:0,SVGPointList:0,SVGStringList:0,SVGTransformList:0,SourceBufferList:0,StyleSheetList:0,TextTrackCueList:0,TextTrackList:0,TouchList:0}},function(e,t,n){"use strict";var r=n(0),A=n(2),o=n(41),i=n(8),a=n(13),u=n(6),c=n(59),s=n(117),f=n(67),g=n(4),l=n(115),d=g("isConcatSpreadable"),p=l>=51||!A((function(){var e=[];return e[d]=!1,e.concat()[0]!==e})),y=f("concat"),h=function(e){if(!i(e))return!1;var t=e[d];return t!==undefined?!!t:o(e)};r({target:"Array",proto:!0,forced:!p||!y},{concat:function(e){var t,n,r,A,o,i=a(this),f=s(i,0),g=0;for(t=-1,r=arguments.length;t<r;t++)if(o=-1===t?i:arguments[t],h(o)){if(g+(A=u(o.length))>9007199254740991)throw TypeError("Maximum allowed index exceeded");for(n=0;n<A;n++,g++)n in o&&c(f,g,o[n])}else{if(g>=9007199254740991)throw TypeError("Maximum allowed index exceeded");c(f,g++,o)}return f.length=g,f}})},function(e,t,n){"use strict";var r=n(0),A=n(47),o=n(19),i=n(52),a=[].join,u=A!=Object,c=i("join",",");r({target:"Array",proto:!0,forced:u||!c},{join:function(e){return a.call(o(this),e===undefined?",":e)}})},function(e,t,n){"use strict";var r=n(0),A=n(32),o=n(24),i=n(6),a=n(13),u=n(117),c=n(59),s=n(67),f=n(33),g=s("splice"),l=f("splice",{ACCESSORS:!0,0:0,1:2}),d=Math.max,p=Math.min;r({target:"Array",proto:!0,forced:!g||!l},{splice:function(e,t){var n,r,s,f,g,l,y=a(this),h=i(y.length),I=A(e,h),C=arguments.length;if(0===C?n=r=0:1===C?(n=0,r=h-I):(n=C-2,r=p(d(o(t),0),h-I)),h+n-r>9007199254740991)throw TypeError("Maximum allowed length exceeded");for(s=u(y,r),f=0;f<r;f++)(g=I+f)in y&&c(s,f,y[g]);if(s.length=r,n<r){for(f=I;f<h-r;f++)l=f+n,(g=f+r)in y?y[l]=y[g]:delete y[l];for(f=h;f>h-r+n;f--)delete y[f-1]}else if(n>r)for(f=h-r;f>I;f--)l=f+n-1,(g=f+r-1)in y?y[l]=y[g]:delete y[l];for(f=0;f<n;f++)y[f+I]=arguments[f+2];return y.length=h-r+n,s}})},function(e,t){e.exports="\t\n\x0B\f\r                　\u2028\u2029\ufeff"},function(e,t,n){"use strict";var r=n(2);function A(e,t){return RegExp(e,t)}t.UNSUPPORTED_Y=r((function(){var e=A("a","y");return e.lastIndex=2,null!=e.exec("abcd")})),t.BROKEN_CARET=r((function(){var e=A("^r","gy");return e.lastIndex=2,null!=e.exec("str")}))},function(e,t,n){"use strict";var r=n(205),A=n(116),o=n(11),i=n(29),a=n(26),u=n(206),c=n(6),s=n(207),f=n(70),g=n(2),l=[].push,d=Math.min,p=!g((function(){return!RegExp(4294967295,"y")}));r("split",2,(function(e,t,n){var r;return r="c"=="abbc".split(/(b)*/)[1]||4!="test".split(/(?:)/,-1).length||2!="ab".split(/(?:ab)*/).length||4!=".".split(/(.?)(.?)/).length||".".split(/()()/).length>1||"".split(/.?/).length?function(e,n){var r=String(i(this)),o=n===undefined?4294967295:n>>>0;if(0===o)return[];if(e===undefined)return[r];if(!A(e))return t.call(r,e,o);for(var a,u,c,s=[],g=(e.ignoreCase?"i":"")+(e.multiline?"m":"")+(e.unicode?"u":"")+(e.sticky?"y":""),d=0,p=new RegExp(e.source,g+"g");(a=f.call(p,r))&&!((u=p.lastIndex)>d&&(s.push(r.slice(d,a.index)),a.length>1&&a.index<r.length&&l.apply(s,a.slice(1)),c=a[0].length,d=u,s.length>=o));)p.lastIndex===a.index&&p.lastIndex++;return d===r.length?!c&&p.test("")||s.push(""):s.push(r.slice(d)),s.length>o?s.slice(0,o):s}:"0".split(undefined,0).length?function(e,n){return e===undefined&&0===n?[]:t.call(this,e,n)}:t,[function(t,n){var A=i(this),o=t==undefined?undefined:t[e];return o!==undefined?o.call(t,A,n):r.call(String(A),t,n)},function(e,A){var i=n(r,e,this,A,r!==t);if(i.done)return i.value;var f=o(e),g=String(this),l=a(f,RegExp),y=f.unicode,h=(f.ignoreCase?"i":"")+(f.multiline?"m":"")+(f.unicode?"u":"")+(p?"y":"g"),I=new l(p?f:"^(?:"+f.source+")",h),C=A===undefined?4294967295:A>>>0;if(0===C)return[];if(0===g.length)return null===s(I,g)?[g]:[];for(var B=0,E=0,v=[];E<g.length;){I.lastIndex=p?E:0;var Q,w=s(I,p?g:g.slice(E));if(null===w||(Q=d(c(I.lastIndex+(p?0:E)),g.length))===B)E=u(g,E,y);else{if(v.push(g.slice(B,E)),v.length===C)return v;for(var m=1;m<=w.length-1;m++)if(v.push(w[m]),v.length===C)return v;E=B=Q}}return v.push(g.slice(B)),v}]}),!p)},function(e,t,n){n(0)({target:"Array",stat:!0},{isArray:n(41)})},function(e,t,n){var r=n(50),A=n(8),o=n(10),i=n(9).f,a=n(49),u=n(212),c=a("meta"),s=0,f=Object.isExtensible||function(){return!0},g=function(e){i(e,c,{value:{objectID:"O"+ ++s,weakData:{}}})},l=e.exports={REQUIRED:!1,fastKey:function(e,t){if(!A(e))return"symbol"==typeof e?e:("string"==typeof e?"S":"P")+e;if(!o(e,c)){if(!f(e))return"F";if(!t)return"E";g(e)}return e[c].objectID},getWeakData:function(e,t){if(!o(e,c)){if(!f(e))return!0;if(!t)return!1;g(e)}return e[c].weakData},onFreeze:function(e){return u&&l.REQUIRED&&f(e)&&!o(e,c)&&g(e),e}};r[c]=!0},function(e,t,n){"use strict";n(35),n(7),n(12),n(45),Object.defineProperty(t,"__esModule",{value:!0}),t.exportCryptoKey=function(e){return u.apply(this,arguments)},t.generateUid=function(){return Math.random().toString(16).substring(2,8)},t.encryptPayloadWithActiveKey=function(e){return c.apply(this,arguments)},n(18);var r=n(127),A=n(46),o=n(124);function i(e,t,n,r,A,o,i){try{var a=e[o](i),u=a.value}catch(c){return void n(c)}a.done?t(u):Promise.resolve(u).then(r,A)}function a(e){return function(){var t=this,n=arguments;return new Promise((function(r,A){var o=e.apply(t,n);function a(e){i(o,r,A,a,u,"next",e)}function u(e){i(o,r,A,a,u,"throw",e)}a(undefined)}))}}function u(){return(u=a(regeneratorRuntime.mark((function e(t){return regeneratorRuntime.wrap((function(e){for(;;)switch(e.prev=e.next){case 0:return e.abrupt("return",crypto.subtle.exportKey("jwk",t));case 1:case"end":return e.stop()}}),e)})))).apply(this,arguments)}function c(){return(c=a(regeneratorRuntime.mark((function e(t){var n,i,a,u,c;return regeneratorRuntime.wrap((function(e){for(;;)switch(e.prev=e.next){case 0:return n=new o.KeyManager,i=n.getKeyCache(),a=(0,A.cookieManagerGet)().kid,u=new r.AesWasmCrypto(i),e.next=6,u.encrypt(a,t);case 6:return c=e.sent,e.abrupt("return",c);case 8:case"end":return e.stop()}}),e)})))).apply(this,arguments)}},function(e,t,n){var r=n(24),A=n(6);e.exports=function(e){if(e===undefined)return 0;var t=r(e),n=A(t);if(t!==n)throw RangeError("Wrong length or index");return n}},function(e,t,n){"use strict";var r=n(13),A=n(32),o=n(6);e.exports=function(e){for(var t=r(this),n=o(t.length),i=arguments.length,a=A(i>1?arguments[1]:undefined,n),u=i>2?arguments[2]:undefined,c=u===undefined?n:A(u,n);c>a;)t[a++]=e;return t}},function(e,t,n){var r=n(217);e.exports=function(e,t){var n=r(e);if(n%t)throw RangeError("Wrong offset");return n}},function(e,t,n){var r=n(54),A=n(13),o=n(47),i=n(6),a=function(e){return function(t,n,a,u){r(n);var c=A(t),s=o(c),f=i(c.length),g=e?f-1:0,l=e?-1:1;if(a<2)for(;;){if(g in s){u=s[g],g+=l;break}if(g+=l,e?g<0:f<=g)throw TypeError("Reduce of empty array with no initial value")}for(;e?g>=0:f>g;g+=l)g in s&&(u=n(u,s[g],g,c));return u}};e.exports={left:a(!1),right:a(!0)}},function(e,t,n){"use strict";var r,A=n(0),o=n(22).f,i=n(6),a=n(152),u=n(29),c=n(153),s=n(30),f="".startsWith,g=Math.min,l=c("startsWith");A({target:"String",proto:!0,forced:!!(s||l||(r=o(String.prototype,"startsWith"),!r||r.writable))&&!l},{startsWith:function(e){var t=String(u(this));a(e);var n=i(g(arguments.length>1?arguments[1]:undefined,t.length)),r=String(e);return f?f.call(t,r,n):t.slice(n,n+r.length)===r}})},function(e,t,n){"use strict";n(16),n(125),n(17),n(7),n(12),n(36),n(27),Object.defineProperty(t,"__esModule",{value:!0}),t.KeyCache=void 0,n(18);var r=n(28);function A(e,t,n,r,A,o,i){try{var a=e[o](i),u=a.value}catch(c){return void n(c)}a.done?t(u):Promise.resolve(u).then(r,A)}function o(e,t){for(var n=0;n<t.length;n++){var r=t[n];r.enumerable=r.enumerable||!1,r.configurable=!0,"value"in r&&(r.writable=!0),Object.defineProperty(e,r.key,r)}}function i(e,t,n){return t in e?Object.defineProperty(e,t,{value:n,enumerable:!0,configurable:!0,writable:!0}):e[t]=n,e}var a=function(){function e(t){!function(e,t){if(!(e instanceof t))throw new TypeError("Cannot call a class as a function")}(this,e),i(this,"keys",new Map),i(this,"storage",void 0),i(this,"logger",new r.Logger),i(this,"isFirstLogKeyCacheStatus",!0),this.storage=t}var t,n,a,u,c;return t=e,(n=[{key:"getCryptoKey",value:function(e){return this.get(e).key}},{key:"cacheKey",value:function(e){var t=this.storage.get(e);this.keys.set(e,t)}},{key:"cacheAllKeys",value:(u=regeneratorRuntime.mark((function s(){return regeneratorRuntime.wrap((function(e){for(;;)switch(e.prev=e.next){case 0:this.keys=this.storage.getAll();case 1:case"end":return e.stop()}}),s,this)})),c=function(){var e=this,t=arguments;return new Promise((function(n,r){var o=u.apply(e,t);function i(e){A(o,n,r,i,a,"next",e)}function a(e){A(o,n,r,i,a,"throw",e)}i(undefined)}))},function(){return c.apply(this,arguments)})},{key:"get",value:function(e){this.keys.has(e)&&this.keys.get(e)||this.cacheKey(e);var t=this.keys.get(e);if(!t)throw this.logKeyCacheStatus(e),new Error("Expecting a key with id '".concat(e,"' but got none"));return t}},{key:"logKeyCacheStatus",value:function(e){if(this.isFirstLogKeyCacheStatus){this.isFirstLogKeyCacheStatus=!1;var t=this.storage.getAll();this.logger.updateCounter("Siege:Csd:KeyCache:TotalKeysInCache",t.size),t.has(e)?this.logger.updateCounter("Siege:Csd:KeyCache:RequiredKeyAppearedLate",1):this.logger.updateCounter("Siege:Csd:KeyCache:IsMissingRequiredKey",1)}}}])&&o(t.prototype,n),a&&o(t,a),e}();t.KeyCache=a},function(e,t,n){"use strict";n(34),n(42),n(43),n(99),n(66),n(16),n(35),n(125),n(129),n(17),n(130),n(131),n(73),n(7),n(12),n(36),n(173),n(68),n(27),Object.defineProperty(t,"__esModule",{value:!0}),t.LocalStorage=void 0,n(18);var r=n(28),A=n(98);function o(e,t,n,r,A,o,i){try{var a=e[o](i),u=a.value}catch(c){return void n(c)}a.done?t(u):Promise.resolve(u).then(r,A)}function i(e,t){var n=Object.keys(e);if(Object.getOwnPropertySymbols){var r=Object.getOwnPropertySymbols(e);t&&(r=r.filter((function(t){return Object.getOwnPropertyDescriptor(e,t).enumerable}))),n.push.apply(n,r)}return n}function a(e){for(var t=1;t<arguments.length;t++){var n=null!=arguments[t]?arguments[t]:{};t%2?i(Object(n),!0).forEach((function(t){c(e,t,n[t])})):Object.getOwnPropertyDescriptors?Object.defineProperties(e,Object.getOwnPropertyDescriptors(n)):i(Object(n)).forEach((function(t){Object.defineProperty(e,t,Object.getOwnPropertyDescriptor(n,t))}))}return e}function u(e,t){for(var n=0;n<t.length;n++){var r=t[n];r.enumerable=r.enumerable||!1,r.configurable=!0,"value"in r&&(r.writable=!0),Object.defineProperty(e,r.key,r)}}function c(e,t,n){return t in e?Object.defineProperty(e,t,{value:n,enumerable:!0,configurable:!0,writable:!0}):e[t]=n,e}var s=function(){function e(){!function(e,t){if(!(e instanceof t))throw new TypeError("Cannot call a class as a function")}(this,e),c(this,"logger",new r.Logger),c(this,"encoder",new A.Encoder)}var t,n,i,s,f;return t=e,(n=[{key:"put",value:function(e,t){var n=arguments.length>2&&arguments[2]!==undefined?arguments[2]:new Date;localStorage.setItem("SIEGE_CSD_"+e,JSON.stringify({key:this.encoder.encode(t),issuedDate:n}))}},{key:"getAll",value:function(){var e=new Map,t=!0,n=!1,r=undefined;try{for(var A,o=this.getAllKeys()[Symbol.iterator]();!(t=(A=o.next()).done);t=!0){var i=A.value;e.set(i,this.get(i,!1))}}catch(err){n=!0,r=err}finally{try{t||null==o["return"]||o["return"]()}finally{if(n)throw r}}return e}},{key:"get",value:function(e){var t=!(arguments.length>1&&arguments[1]!==undefined)||arguments[1],n=localStorage.getItem("SIEGE_CSD_"+e);if(null===n)return undefined;var r=new Date,A=JSON.parse(n);return(t||A.lastUsedDate===undefined)&&localStorage.setItem("SIEGE_CSD_"+e,JSON.stringify(a({},A,{lastUsedDate:r}))),{key:this.encoder.decode(A.key),issuedDate:new Date(A.issuedDate),lastUsedDate:A.lastUsedDate!==undefined?new Date(A.lastUsedDate):r}}},{key:"removeKeys",value:function(e){var t=!0,n=!1,r=undefined;try{for(var A,o=e[Symbol.iterator]();!(t=(A=o.next()).done);t=!0){var i=A.value;localStorage.removeItem("SIEGE_CSD_"+i)}}catch(err){n=!0,r=err}finally{try{t||null==o["return"]||o["return"]()}finally{if(n)throw r}}}},{key:"getAllKeys",value:function(){for(var e=[],t=0;t<localStorage.length;t++){var n=localStorage.key(t);n.startsWith("SIEGE_CSD_")&&e.push(n.substr("SIEGE_CSD_".length))}return e}},{key:"clear",value:(s=regeneratorRuntime.mark((function g(){return regeneratorRuntime.wrap((function(e){for(;;)switch(e.prev=e.next){case 0:this.logger.incrementCounter("Siege:Csd:LocalStorage:Clearing",1),this.removeKeys(this.getAllKeys());case 2:case"end":return e.stop()}}),g,this)})),f=function(){var e=this,t=arguments;return new Promise((function(n,r){var A=s.apply(e,t);function i(e){o(A,n,r,i,a,"next",e)}function a(e){o(A,n,r,i,a,"throw",e)}i(undefined)}))},function(){return f.apply(this,arguments)})}])&&u(t.prototype,n),i&&u(t,i),e}();t.LocalStorage=s},function(e,t,n){"use strict";n(160),n(7),n(12),Object.defineProperty(t,"__esModule",{value:!0}),t.csdBootstrap=function(){return g.apply(this,arguments)},t.csdUninstall=l,t.csdDisable=function(){c.disable(),u.updateCounter("Siege:Csd:Bootstrap:Disable",1)},t.csdIsInstalled=p,t.csdIsDisabled=h,n(18);var r=n(46),A=n(124),o=n(231);function i(e,t,n,r,A,o,i){try{var a=e[o](i),u=a.value}catch(c){return void n(c)}a.done?t(u):Promise.resolve(u).then(r,A)}function a(e){return function(){var t=this,n=arguments;return new Promise((function(r,A){var o=e.apply(t,n);function a(e){i(o,r,A,a,u,"next",e)}function u(e){i(o,r,A,a,u,"throw",e)}a(undefined)}))}}var u=new(n(28).Logger),c=new A.KeyManager;function s(){return f.apply(this,arguments)}function f(){return(f=a(regeneratorRuntime.mark((function e(){var t,n;return regeneratorRuntime.wrap((function(e){for(;;)switch(e.prev=e.next){case 0:return e.next=2,l();case 2:return t=new o.CompatibilityValidator,e.next=5,t.validateBeforeInstall();case 5:return e.next=7,c.createKey();case 7:if((n=e.sent)===(0,r.cookieManagerGet)().kid){e.next=10;break}throw new Error("Cookie Manager does not return the new key after creation (expected ".concat(n,", got ").concat((0,r.cookieManagerGet)().kid,")"));case 10:return e.next=12,t.validateAfterInstall();case 12:case"end":return e.stop()}}),e)})))).apply(this,arguments)}function g(){return(g=a(regeneratorRuntime.mark((function e(){return regeneratorRuntime.wrap((function(e){for(;;)switch(e.prev=e.next){case 0:return e.next=2,p();case 2:if(e.t0=e.sent,!e.t0){e.next=5;break}e.t0=(0,r.cookieManagerGet)().wasmTested;case 5:if(!e.t0){e.next=13;break}return u.updateCounter("Siege:Csd:Bootstrap:Skip:AlreadyInstalled",1),u.updateCounter("Siege:Csd:Bootstrap:Success",1),e.next=10,c.rotateKeyIfNeeded();case 10:return e.sent?u.updateCounter("Siege:Csd:Bootstrap:KeyRotated",1):u.updateCounter("Siege:Csd:Bootstrap:KeyRotated",0),e.abrupt("return");case 13:return e.next=15,h();case 15:if(!e.sent){e.next=18;break}return u.updateCounter("Siege:Csd:Bootstrap:Skip:Disabled",1),e.abrupt("return");case 18:return e.next=20,s();case 20:u.updateCounter("Siege:Csd:Bootstrap:Success",1),u.updateCounter("Siege:Csd:Bootstrap:NewUser",1);case 22:case"end":return e.stop()}}),e)})))).apply(this,arguments)}function l(){return d.apply(this,arguments)}function d(){return(d=a(regeneratorRuntime.mark((function e(){var t,n=arguments;return regeneratorRuntime.wrap((function(e){for(;;)switch(e.prev=e.next){case 0:return t=n.length>0&&n[0]!==undefined&&n[0],e.next=3,c["delete"](t);case 3:return e.next=5,p();case 5:if(!e.sent){e.next=7;break}throw new Error("csdIsInstalled still returned true after uninstall");case 7:case"end":return e.stop()}}),e)})))).apply(this,arguments)}function p(){return y.apply(this,arguments)}function y(){return(y=a(regeneratorRuntime.mark((function e(){return regeneratorRuntime.wrap((function(e){for(;;)switch(e.prev=e.next){case 0:return e.abrupt("return",c.isInitialized());case 1:case"end":return e.stop()}}),e)})))).apply(this,arguments)}function h(){return I.apply(this,arguments)}function I(){return(I=a(regeneratorRuntime.mark((function e(){return regeneratorRuntime.wrap((function(e){for(;;)switch(e.prev=e.next){case 0:return e.abrupt("return",c.isDisabled());case 1:case"end":return e.stop()}}),e)})))).apply(this,arguments)}},function(e,t,n){"use strict";n(17),n(7),n(12),Object.defineProperty(t,"__esModule",{value:!0}),t.reqResHandler=function(e){return e instanceof Request||e instanceof Response?function(e){return{getHeader:function(t){return e.headers.get(t)},setHeader:function(t,n){e.headers.set(t,n)},csdStatusHeader:function(){var t=e.headers.get(r.Header.Status);return null!==t?JSON.parse(atob(t)):{payloadEncrypted:!1}},retrievePayload:function(){return i(regeneratorRuntime.mark((function t(){var n;return regeneratorRuntime.wrap((function(t){for(;;)switch(t.prev=t.next){case 0:return n=e.clone(),t.abrupt("return",n.text());case 2:case"end":return t.stop()}}),t)})))()},successResponse:function(t){return new Response(t,{headers:e.headers,status:e.status,statusText:e.statusText})},errorResponse:function(t){return new Response(e.body,{status:491,statusText:"SIEGE Client Side Decryption error, check x-csd-error header",headers:A({},r.Header.Error,t.message!==undefined?t.message:t)})}}}(e):function(e){return{getHeader:function(t){return e.headers[t]},setHeader:function(t,n){e.headers[t]=n},csdStatusHeader:function(){var t=e.headers[r.Header.Status];return t!==undefined?JSON.parse(atob(t)):{payloadEncrypted:!1}},successResponse:function(t){return e.data=t,e.text=e.data,e},retrievePayload:function(){return i(regeneratorRuntime.mark((function t(){return regeneratorRuntime.wrap((function(t){for(;;)switch(t.prev=t.next){case 0:return t.abrupt("return",e.data);case 1:case"end":return t.stop()}}),t)})))()},errorResponse:function(t){return e.status=491,e.statusText="SIEGE Client Side Decryption error, check x-csd-error header",e.headers[r.Header.Error]=t.message!==undefined?t.message:t,e}}}(e)},n(18);var r=n(178);function A(e,t,n){return t in e?Object.defineProperty(e,t,{value:n,enumerable:!0,configurable:!0,writable:!0}):e[t]=n,e}function o(e,t,n,r,A,o,i){try{var a=e[o](i),u=a.value}catch(c){return void n(c)}a.done?t(u):Promise.resolve(u).then(r,A)}function i(e){return function(){var t=this,n=arguments;return new Promise((function(r,A){var i=e.apply(t,n);function a(e){o(i,r,A,a,u,"next",e)}function u(e){o(i,r,A,a,u,"throw",e)}a(undefined)}))}}},function(e,t,n){"use strict";n(7),n(12),Object.defineProperty(t,"__esModule",{value:!0}),t.resetBootstrapPromise=function(){t.bootstrapPromise=s=undefined},t.beforeHandler=function(e){return d.apply(this,arguments)},t.afterHandler=function(e,t){return p.apply(this,arguments)},t.cryptoEngine=t.Header=t.bootstrapPromise=void 0,n(18);var r=n(123),A=n(46),o=n(176),i=n(28),a=n(177);function u(e,t,n,r,A,o,i){try{var a=e[o](i),u=a.value}catch(c){return void n(c)}a.done?t(u):Promise.resolve(u).then(r,A)}function c(e){return function(){var t=this,n=arguments;return new Promise((function(r,A){var o=e.apply(t,n);function i(e){u(o,r,A,i,a,"next",e)}function a(e){u(o,r,A,i,a,"throw",e)}i(undefined)}))}}var s,f,g=new i.Logger;t.bootstrapPromise=s,t.Header=f,function(e){e.Enable="x-csd-enable",e.Status="x-csd-status",e.Key="x-csd-key",e.Error="x-csd-error"}(f||(t.Header=f={}));var l=(0,r.getCryptoEngineSingleton)();function d(){return(d=c(regeneratorRuntime.mark((function e(n){var r;return regeneratorRuntime.wrap((function(e){for(;;)switch(e.prev=e.next){case 0:if("true"===(0,a.reqResHandler)(n).getHeader(f.Enable)){e.next=2;break}return e.abrupt("return");case 2:if(!(0,A.cookieManagerIsEnabled)()){e.next=6;break}r=(0,A.cookieManagerGetRaw)(),e.next=10;break;case 6:return s||(t.bootstrapPromise=s=(0,o.csdBootstrap)()),e.next=9,s;case 9:r=(0,A.cookieManagerGetRaw)();case 10:(0,a.reqResHandler)(n).setHeader(f.Key,r);case 11:case"end":return e.stop()}}),e)})))).apply(this,arguments)}function p(){return(p=c(regeneratorRuntime.mark((function e(t,n){var r,A,o;return regeneratorRuntime.wrap((function(e){for(;;)switch(e.prev=e.next){case 0:if((0,a.reqResHandler)(n).csdStatusHeader().payloadEncrypted){e.next=2;break}return e.abrupt("return",n);case 2:return e.next=4,(0,a.reqResHandler)(n).retrievePayload();case 4:if(r=e.sent,null==(A=JSON.parse(r)).error){e.next=8;break}throw new Error("Server-side CSD error: ".concat(A.error));case 8:return g.incrementCounter("Siege:Csd:decryptAJAX"),o=l.decrypt(A),g.updateCounter("Siege:Csd:Decrypt:Success",1),e.abrupt("return",(0,a.reqResHandler)(n).successResponse(o));case 12:case"end":return e.stop()}}),e)})))).apply(this,arguments)}t.cryptoEngine=l},function(e,t,n){e.exports=n(180)},function(e,t,n){"use strict";n(132);var r=n(139);setTimeout((function(){(0,r.bootstrap)()}),1e4),e.exports=n(139)},function(e,t,n){var r=n(1),A=n(104),o=r.WeakMap;e.exports="function"==typeof o&&/native code/.test(A(o))},function(e,t,n){var r=n(5),A=n(2),o=n(10),i=Object.defineProperty,a={},u=function(e){throw e};e.exports=function(e,t){if(o(a,e))return a[e];t||(t={});var n=[][e],c=!!o(t,"ACCESSORS")&&t.ACCESSORS,s=o(t,0)?t[0]:u,f=o(t,1)?t[1]:undefined;return a[e]=!!n&&!A((function(){if(c&&!r)return!0;var e={length:-1};c?i(e,1,{enumerable:!0,get:u}):e[1]=1,n.call(e,s,f)}))}},function(e,t,n){"use strict";var r=n(110),A=n(63);e.exports=r?{}.toString:function(){return"[object "+A(this)+"]"}},function(e,t,n){var r,A,o,i,a,u,c,s,f=n(1),g=n(22).f,l=n(23),d=n(147).set,p=n(148),y=f.MutationObserver||f.WebKitMutationObserver,h=f.process,I=f.Promise,C="process"==l(h),B=g(f,"queueMicrotask"),E=B&&B.value;E||(r=function(){var e,t;for(C&&(e=h.domain)&&e.exit();A;){t=A.fn,A=A.next;try{t()}catch(n){throw A?i():o=undefined,n}}o=undefined,e&&e.enter()},C?i=function(){h.nextTick(r)}:y&&!p?(a=!0,u=document.createTextNode(""),new y(r).observe(u,{characterData:!0}),i=function(){u.data=a=!a}):I&&I.resolve?(c=I.resolve(undefined),s=c.then,i=function(){s.call(c,r)}):i=function(){d.call(f,r)}),e.exports=E||function(e){var t={fn:e,next:undefined};o&&(o.next=t),A||(A=t,i()),o=t}},function(e,t,n){var r=n(1);e.exports=function(e,t){var n=r.console;n&&n.error&&(1===arguments.length?n.error(e):n.error(e,t))}},function(e,t){e.exports=function(e){try{return{error:!1,value:e()}}catch(t){return{error:!0,value:t}}}},function(e,t,n){"use strict";var r=n(0),A=n(30),o=n(145),i=n(2),a=n(31),u=n(26),c=n(149),s=n(15);r({target:"Promise",proto:!0,real:!0,forced:!!o&&i((function(){o.prototype["finally"].call({then:function(){}},(function(){}))}))},{"finally":function(e){var t=u(this,a("Promise")),n="function"==typeof e;return this.then(n?function(n){return c(t,e()).then((function(){return n}))}:e,n?function(n){return c(t,e()).then((function(){throw n}))}:e)}}),A||"function"!=typeof o||o.prototype["finally"]||s(o.prototype,"finally",a("Promise").prototype["finally"])},function(e,t){e.exports=function(e){return e.webpackPolyfill||(e.deprecate=function(){},e.paths=[],e.children||(e.children=[]),Object.defineProperty(e,"loaded",{enumerable:!0,get:function(){return e.l}}),Object.defineProperty(e,"id",{enumerable:!0,get:function(){return e.i}}),e.webpackPolyfill=1),e}},function(e,t,n){var r=n(19),A=n(38).f,o={}.toString,i="object"==typeof window&&window&&Object.getOwnPropertyNames?Object.getOwnPropertyNames(window):[];e.exports.f=function(e){return i&&"[object Window]"==o.call(e)?function(e){try{return A(e)}catch(t){return i.slice()}}(e):A(r(e))}},function(e,t,n){n(65)("asyncIterator")},function(e,t,n){n(65)("toStringTag")},function(e,t,n){"use strict";var r=n(156).IteratorPrototype,A=n(39),o=n(37),i=n(25),a=n(56),u=function(){return this};e.exports=function(e,t,n){var c=t+" Iterator";return e.prototype=A(r,{next:o(1,n)}),i(e,c,!1,!0),a[c]=u,e}},function(e,t,n){var r=n(8);e.exports=function(e){if(!r(e)&&null!==e)throw TypeError("Can't set "+String(e)+" as a prototype");return e}},function(e,t,n){"use strict";var r=n(0),A=n(41),o=[].reverse,i=[1,2];r({target:"Array",proto:!0,forced:String(i)===String(i.reverse())},{reverse:function(){return A(this)&&(this.length=this.length),o.call(this)}})},function(e,t,n){var r=n(1);n(25)(r.JSON,"JSON",!0)},function(e,t,n){n(25)(Math,"Math",!0)},function(e,t,n){n(0)({target:"Object",stat:!0,sham:!n(5)},{create:n(39)})},function(e,t,n){var r=n(0),A=n(2),o=n(13),i=n(57),a=n(157);r({target:"Object",stat:!0,forced:A((function(){i(1)})),sham:!a},{getPrototypeOf:function(e){return i(o(e))}})},function(e,t,n){n(0)({target:"Object",stat:!0},{setPrototypeOf:n(44)})},function(e,t,n){"use strict";(function(r){var A;function o(e){return(o="function"==typeof Symbol&&"symbol"==typeof Symbol.iterator?function(e){return typeof e}:function(e){return e&&"function"==typeof Symbol&&e.constructor===Symbol&&e!==Symbol.prototype?"symbol":typeof e})(e)}
+// Copyright © 2022 Jaime Pillora <dev@example.com>
+n(34),n(42),n(43),n(160),n(69),n(16),n(161),n(58),n(162),n(7),n(201),n(12),n(204),n(122),n(45),n(36),n(165),n(27),n(132);var i,a,u,c,s,f,g,l,d,p,y,h,I,C,B,E,v,Q,w,m,b,x,S,D,k=[].indexOf;d=null,d="undefined"!=typeof WorkerGlobalScope&&self instanceof WorkerGlobalScope?self:void 0!==r?r:window,E=d.document,g="addEventListener",f="removeEventListener",u="dispatchEvent",h="XMLHttpRequest",l=["load","loadend","loadstart"],i=["progress","abort","error","timeout"],S="undefined"!=typeof navigator&&navigator.useragent?navigator.userAgent:"",w=parseInt((/msie (\d+)/.exec(S.toLowerCase())||[])[1]),isNaN(w)&&(w=parseInt((/trident\/.*; rv:(\d+)/.exec(S.toLowerCase())||[])[1])),(I=Array.prototype).indexOf||(I.indexOf=function(e){var t,n,r;for(this,t=n=0,r=this.length;n<r;t=++n)if(this[t]===e)return t;return-1}),x=function(e,t){return Array.prototype.slice.call(e,t)},B=function(e){return"returnValue"===e||"totalSize"===e||"position"===e},Q=function(e,t){var n;for(n in e)if(e[n],!B(n))try{t[n]=e[n]}catch(r){}return t},m=function(e){return void 0===e?null:e},b=function(e,t,n){var r,A,o,i;for(i=function(e){return function(r){var A,o,i;for(o in A={},r)B(o)||(i=r[o],A[o]=i===t?n:i);return n[u](e,A)}},A=0,o=e.length;A<o;A++)r=e[A],n._has(r)&&(t["on".concat(r)]=i(r))},v=function(e){var t;if(E&&null!=E.createEventObject)return(t=E.createEventObject()).type=e,t;try{return new Event(e)}catch(n){return{type:e}}},(D=(a=function(e){var t,n,r;return n={},r=function(e){return n[e]||[]},(t={})[g]=function(e,t,A){n[e]=r(e),n[e].indexOf(t)>=0||(A=A===undefined?n[e].length:A,n[e].splice(A,0,t))},t[f]=function(e,t){var A;e!==undefined?(t===undefined&&(n[e]=[]),-1!==(A=r(e).indexOf(t))&&r(e).splice(A,1)):n={}},t[u]=function(){var n,A,o,i,a,u,c;for(A=(n=x(arguments)).shift(),e||(n[0]=Q(n[0],v(A))),(a=t["on".concat(A)])&&a.apply(t,n),o=i=0,u=(c=r(A).concat(r("*"))).length;i<u;o=++i)c[o].apply(t,n)},t._has=function(e){return!(!n[e]&&!t["on".concat(e)])},e&&(t.listeners=function(e){return x(r(e))},t.on=t[g],t.off=t[f],t.fire=t[u],t.once=function(e,n){var r;return r=function(){return t.off(e,r),n.apply(null,arguments)},t.on(e,r)},t.destroy=function(){return n={}}),t})(!0)).EventEmitter=a,D.before=function(e,t){if(e.length<1||e.length>2)throw"invalid hook";return D[g]("before",e,t)},D.after=function(e,t){if(e.length<2||e.length>3)throw"invalid hook";return D[g]("after",e,t)},D.enable=function(){d[h]=y,"function"==typeof p&&(d.fetch=p)},D.disable=function(){d[h]=D[h],d.fetch=D.fetch},C=D.headers=function(e,t){var n,r,A,i,a,u,c,s,f;switch(void 0===t&&(t={}),o(e)){case"object":for(i in r=[],e)s=e[i],u=i.toLowerCase(),r.push("".concat(u,":\t").concat(s));return r.join("\n")+"\n";case"string":for(A=0,a=(r=e.split("\n")).length;A<a;A++)n=r[A],/([^:]+):\s*(.+)/.test(n)&&(u=null!=(c=RegExp.$1)?c.toLowerCase():void 0,f=RegExp.$2,null==t[u]&&(t[u]=f));return t}},s=d[h],D[h]=s,y=d[h]=function(){var e,t,n,r,A,c,s,f,d,p,y,I,B,E,v,x,S,R,F,O;O=new D[h],x=null,c=void 0,S=void 0,E=void 0,y=function(){var e,t,n,r;if(E.status=x||O.status,-1===x&&w<10||(E.statusText=O.statusText),-1!==x)for(e in n=C(O.getAllResponseHeaders()))r=n[e],E.headers[e]||(t=e.toLowerCase(),E.headers[t]=r)},p=function(){if(O.responseType&&"text"!==O.responseType)"document"===O.responseType?(E.xml=O.responseXML,E.data=O.responseXML):E.data=O.response;else{E.text=O.responseText,E.data=O.responseText;try{E.xml=O.responseXML}catch(e){}}"responseURL"in O&&(E.finalUrl=O.responseURL)},F=function(){A.status=E.status,A.statusText=E.statusText},R=function(){"text"in E&&(A.responseText=E.text),"xml"in E&&(A.responseXML=E.xml),"data"in E&&(A.response=E.data),"finalUrl"in E&&(A.responseURL=E.finalUrl)},n=function(n){for(;n>e&&e<4;)A.readyState=++e,1===e&&A[u]("loadstart",{}),2===e&&F(),4===e&&(F(),R()),A[u]("readystatechange",{}),4===e&&(!1===B.async?t():setTimeout(t,0))},t=function(){c||A[u]("load",{}),A[u]("loadend",{}),c&&(A.readyState=0)},e=0,v=function(e){var t,r;4===e?(t=D.listeners("after"),(r=function(){var e;return t.length?2===(e=t.shift()).length?(e(B,E),r()):3===e.length&&B.async?e(B,E,r):r():n(4)})()):n(e)},A=(B={}).xhr=a(),O.onreadystatechange=function(e){try{2===O.readyState&&y()}catch(t){}4===O.readyState&&(S=!1,y(),p()),v(O.readyState)},s=function(){c=!0},A[g]("error",s),A[g]("timeout",s),A[g]("abort",s),A[g]("progress",(function(){e<3?v(3):A[u]("readystatechange",{})})),("withCredentials"in O||D.addWithCredentials)&&(A.withCredentials=!1),A.status=0;for(f=0,d=(I=i.concat(l)).length;f<d;f++)r=I[f],A["on".concat(r)]=null;return A.open=function(t,n,r,A,o){e=0,c=!1,S=!1,B.headers={},B.headerNames={},B.status=0,(E={}).headers={},B.method=t,B.url=n,B.async=!1!==r,B.user=A,B.pass=o,v(1)},A.send=function(e){var t,n,r,a,u,c,s,f;for(r=0,a=(s=["type","timeout","withCredentials"]).length;r<a;r++)(u="type"===(n=s[r])?"responseType":n)in A&&(B[n]=A[u]);B.body=e,f=function(){var e,t,r,o,a,c;for(b(i,O,A),A.upload&&b(i.concat(l),O.upload,A.upload),S=!0,O.open(B.method,B.url,B.async,B.user,B.pass),r=0,t=(o=["type","timeout","withCredentials"]).length;r<t;r++)u="type"===(n=o[r])?"responseType":n,n in B&&(O[u]=B[n]);for(e in a=B.headers)c=a[e],e&&O.setRequestHeader(e,c);O.send(B.body)},t=D.listeners("before"),(c=function(){var e,n;return t.length?((e=function(e){if("object"===o(e)&&("number"==typeof e.status||"number"==typeof E.status))return Q(e,E),k.call(e,"data")<0&&(e.data=e.response||e.text),void v(4);c()}).head=function(e){return Q(e,E),v(2)},e.progress=function(e){return Q(e,E),v(3)},1===(n=t.shift()).length?e(n(B)):2===n.length&&B.async?n(B,e):e()):f()})()},A.abort=function(){x=-1,S?O.abort():A[u]("abort",{})},A.setRequestHeader=function(e,t){var n,r;n=null!=e?e.toLowerCase():void 0,r=B.headerNames[n]=B.headerNames[n]||e,B.headers[r]&&(t=B.headers[r]+", "+t),B.headers[r]=t},A.getResponseHeader=function(e){var t;return t=null!=e?e.toLowerCase():void 0,m(E.headers[t])},A.getAllResponseHeaders=function(){return m(C(E.headers))},O.overrideMimeType&&(A.overrideMimeType=function(){return O.overrideMimeType.apply(O,arguments)}),O.upload&&(A.upload=B.upload=a()),A.UNSENT=0,A.OPENED=1,A.HEADERS_RECEIVED=2,A.LOADING=3,A.DONE=4,A.response="",A.responseText="",A.responseXML=null,A.readyState=0,A.statusText="",A},"function"==typeof d.fetch&&(c=d.fetch,D.fetch=c,p=d.fetch=function(e,t){var n,r,A;return void 0===t&&(t={headers:{}}),t.url=e,A=null,r=D.listeners("before"),n=D.listeners("after"),new Promise((function(e,o){var i,a,u,s,f;a=function(){return t.headers&&(t.headers=new Headers(t.headers)),A||(A=new Request(t.url,t)),Q(t,A)},u=function(t){var r;return n.length?2===(r=n.shift()).length?(r(a(),t),u(t)):3===r.length?r(a(),t,u):u(t):e(t)},i=function(t){var n;if(void 0!==t)return n=new Response(t.body||t.text,t),e(n),void u(n);s()},s=function(){var e;if(r.length)return 1===(e=r.shift()).length?i(e(t)):2===e.length?e(a(),i):void 0;f()},f=function(){return c(a()).then((function(e){return u(e)}))["catch"]((function(e){}),u(err),o(err))},s()}))}),y.UNSENT=0,y.OPENED=1,y.HEADERS_RECEIVED=2,y.LOADING=3,y.DONE=4,(A=function(){return D}.apply(t,[]))===undefined||(e.exports=A)}).call(this,n(100))},function(e,t,n){var r=n(0),A=n(202);r({global:!0,forced:parseInt!=A},{parseInt:A})},function(e,t,n){var r=n(1),A=n(203).trim,o=n(163),i=r.parseInt,a=/^[+-]?0[Xx]/,u=8!==i(o+"08")||22!==i(o+"0x16");e.exports=u?function(e,t){var n=A(String(e));return i(n,t>>>0||(a.test(n)?16:10))}:i},function(e,t,n){var r=n(29),A="["+n(163)+"]",o=RegExp("^"+A+A+"*"),i=RegExp(A+A+"*$"),a=function(e){return function(t){var n=String(r(t));return 1&e&&(n=n.replace(o,"")),2&e&&(n=n.replace(i,"")),n}};e.exports={start:a(1),end:a(2),trim:a(3)}},function(e,t,n){var r=n(5),A=n(1),o=n(61),i=n(121),a=n(9).f,u=n(38).f,c=n(116),s=n(120),f=n(164),g=n(15),l=n(2),d=n(21).set,p=n(53),y=n(4)("match"),h=A.RegExp,I=h.prototype,C=/a/g,B=/a/g,E=new h(C)!==C,v=f.UNSUPPORTED_Y;if(r&&o("RegExp",!E||v||l((function(){return B[y]=!1,h(C)!=C||h(B)==B||"/a/i"!=h(C,"i")})))){for(var Q=function(e,t){var n,r=this instanceof Q,A=c(e),o=t===undefined;if(!r&&A&&e.constructor===Q&&o)return e;E?A&&!o&&(e=e.source):e instanceof Q&&(o&&(t=s.call(e)),e=e.source),v&&(n=!!t&&t.indexOf("y")>-1)&&(t=t.replace(/y/g,""));var a=i(E?new h(e,t):h(e,t),r?this:I,Q);return v&&n&&d(a,{sticky:n}),a},w=function(e){e in Q||a(Q,e,{configurable:!0,get:function(){return h[e]},set:function(t){h[e]=t}})},m=u(h),b=0;m.length>b;)w(m[b++]);I.constructor=Q,Q.prototype=I,g(A,"RegExp",Q)}p("RegExp")},function(e,t,n){"use strict";n(122);var r=n(15),A=n(2),o=n(4),i=n(70),a=n(14),u=o("species"),c=!A((function(){var e=/./;return e.exec=function(){var e=[];return e.groups={a:"7"},e},"7"!=="".replace(e,"$<a>")})),s="$0"==="a".replace(/./,"$0"),f=o("replace"),g=!!/./[f]&&""===/./[f]("a","$0"),l=!A((function(){var e=/(?:)/,t=e.exec;e.exec=function(){return t.apply(this,arguments)};var n="ab".split(e);return 2!==n.length||"a"!==n[0]||"b"!==n[1]}));e.exports=function(e,t,n,f){var d=o(e),p=!A((function(){var t={};return t[d]=function(){return 7},7!=""[e](t)})),y=p&&!A((function(){var t=!1,n=/a/;return"split"===e&&((n={}).constructor={},n.constructor[u]=function(){return n},n.flags="",n[d]=/./[d]),n.exec=function(){return t=!0,null},n[d](""),!t}));if(!p||!y||"replace"===e&&(!c||!s||g)||"split"===e&&!l){var h=/./[d],I=n(d,""[e],(function(e,t,n,r,A){return t.exec===i?p&&!A?{done:!0,value:h.call(t,n,r)}:{done:!0,value:e.call(n,t,r)}:{done:!1}}),{REPLACE_KEEPS_$0:s,REGEXP_REPLACE_SUBSTITUTES_UNDEFINED_CAPTURE:g}),C=I[0],B=I[1];r(String.prototype,e,C),r(RegExp.prototype,d,2==t?function(e,t){return B.call(e,this,t)}:function(e){return B.call(e,this)})}f&&a(RegExp.prototype[d],"sham",!0)}},function(e,t,n){"use strict";var r=n(158).charAt;e.exports=function(e,t,n){return t+(n?r(e,t).length:1)}},function(e,t,n){var r=n(23),A=n(70);e.exports=function(e,t){var n=e.exec;if("function"==typeof n){var o=n.call(e,t);if("object"!=typeof o)throw TypeError("RegExp exec method returned something other than an Object or null");return o}if("RegExp"!==r(e))throw TypeError("RegExp#exec called on incompatible receiver");return A.call(e,t)}},function(e,t,n){var r=n(0),A=n(209);r({target:"Array",stat:!0,forced:!n(64)((function(e){Array.from(e)}))},{from:A})},function(e,t,n){"use strict";var r=n(40),A=n(13),o=n(146),i=n(113),a=n(6),u=n(59),c=n(114);e.exports=function(e){var t,n,s,f,g,l,d=A(e),p="function"==typeof this?this:Array,y=arguments.length,h=y>1?arguments[1]:undefined,I=h!==undefined,C=c(d),B=0;if(I&&(h=r(h,y>2?arguments[2]:undefined,2)),C==undefined||p==Array&&i(C))for(n=new p(t=a(d.length));t>B;B++)l=I?h(d[B],B):d[B],u(n,B,l);else for(g=(f=C.call(d)).next,n=new p;!(s=g.call(f)).done;B++)l=I?o(f,h,[s.value,B],!0):s.value,u(n,B,l);return n.length=B,n}},function(e,t,n){n(0)({target:"Date",stat:!0},{now:function(){return(new Date).getTime()}})},function(e,t,n){"use strict";var r=n(0),A=n(1),o=n(61),i=n(15),a=n(167),u=n(112),c=n(55),s=n(8),f=n(2),g=n(64),l=n(25),d=n(121);e.exports=function(e,t,n){var p=-1!==e.indexOf("Map"),y=-1!==e.indexOf("Weak"),h=p?"set":"add",I=A[e],C=I&&I.prototype,B=I,E={},v=function(e){var t=C[e];i(C,e,"add"==e?function(e){return t.call(this,0===e?0:e),this}:"delete"==e?function(e){return!(y&&!s(e))&&t.call(this,0===e?0:e)}:"get"==e?function(e){return y&&!s(e)?undefined:t.call(this,0===e?0:e)}:"has"==e?function(e){return!(y&&!s(e))&&t.call(this,0===e?0:e)}:function(e,n){return t.call(this,0===e?0:e,n),this})};if(o(e,"function"!=typeof I||!(y||C.forEach&&!f((function(){(new I).entries().next()})))))B=n.getConstructor(t,e,p,h),a.REQUIRED=!0;else if(o(e,!0)){var Q=new B,w=Q[h](y?{}:-0,1)!=Q,m=f((function(){Q.has(1)})),b=g((function(e){new I(e)})),x=!y&&f((function(){for(var e=new I,t=5;t--;)e[h](t,t);return!e.has(-0)}));b||((B=t((function(t,n){c(t,B,e);var r=d(new I,t,B);return n!=undefined&&u(n,r[h],r,p),r}))).prototype=C,C.constructor=B),(m||x)&&(v("delete"),v("has"),p&&v("get")),(x||w)&&v(h),y&&C.clear&&delete C.clear}return E[e]=B,r({global:!0,forced:B!=I},E),l(B,e),y||n.setStrong(B,e,p),B}},function(e,t,n){var r=n(2);e.exports=!r((function(){return Object.isExtensible(Object.preventExtensions({}))}))},function(e,t,n){"use strict";var r=n(9).f,A=n(39),o=n(111),i=n(40),a=n(55),u=n(112),c=n(118),s=n(53),f=n(5),g=n(167).fastKey,l=n(21),d=l.set,p=l.getterFor;e.exports={getConstructor:function(e,t,n,c){var s=e((function(e,r){a(e,s,t),d(e,{type:t,index:A(null),first:undefined,last:undefined,size:0}),f||(e.size=0),r!=undefined&&u(r,e[c],e,n)})),l=p(t),y=function(e,t,n){var r,A,o=l(e),i=h(e,t);return i?i.value=n:(o.last=i={index:A=g(t,!0),key:t,value:n,previous:r=o.last,next:undefined,removed:!1},o.first||(o.first=i),r&&(r.next=i),f?o.size++:e.size++,"F"!==A&&(o.index[A]=i)),e},h=function(e,t){var n,r=l(e),A=g(t);if("F"!==A)return r.index[A];for(n=r.first;n;n=n.next)if(n.key==t)return n};return o(s.prototype,{clear:function(){for(var e=l(this),t=e.index,n=e.first;n;)n.removed=!0,n.previous&&(n.previous=n.previous.next=undefined),delete t[n.index],n=n.next;e.first=e.last=undefined,f?e.size=0:this.size=0},"delete":function(e){var t=l(this),n=h(this,e);if(n){var r=n.next,A=n.previous;delete t.index[n.index],n.removed=!0,A&&(A.next=r),r&&(r.previous=A),t.first==n&&(t.first=r),t.last==n&&(t.last=A),f?t.size--:this.size--}return!!n},forEach:function(e){for(var t,n=l(this),r=i(e,arguments.length>1?arguments[1]:undefined,3);t=t?t.next:n.first;)for(r(t.value,t.key,this);t&&t.removed;)t=t.previous},has:function(e){return!!h(this,e)}}),o(s.prototype,n?{get:function(e){var t=h(this,e);return t&&t.value},set:function(e,t){return y(this,0===e?0:e,t)}}:{add:function(e){return y(this,e=0===e?0:e,e)}}),f&&r(s.prototype,"size",{get:function(){return l(this).size}}),s},setStrong:function(e,t,n){var r=t+" Iterator",A=p(t),o=p(r);c(e,t,(function(e,t){d(this,{type:r,target:e,state:A(e),kind:t,last:undefined})}),(function(){for(var e=o(this),t=e.kind,n=e.last;n&&n.removed;)n=n.previous;return e.target&&(e.last=n=n?n.next:e.state.first)?"keys"==t?{value:n.key,done:!1}:"values"==t?{value:n.value,done:!1}:{value:[n.key,n.value],done:!1}:(e.target=undefined,{value:undefined,done:!0})}),n?"entries":"values",!n,!0),s(t)}}},function(e,t){var n=Math.abs,r=Math.pow,A=Math.floor,o=Math.log,i=Math.LN2;e.exports={pack:function(e,t,a){var u,c,s,f=new Array(a),g=8*a-t-1,l=(1<<g)-1,d=l>>1,p=23===t?r(2,-24)-r(2,-77):0,y=e<0||0===e&&1/e<0?1:0,h=0;for((e=n(e))!=e||e===1/0?(c=e!=e?1:0,u=l):(u=A(o(e)/i),e*(s=r(2,-u))<1&&(u--,s*=2),(e+=u+d>=1?p/s:p*r(2,1-d))*s>=2&&(u++,s/=2),u+d>=l?(c=0,u=l):u+d>=1?(c=(e*s-1)*r(2,t),u+=d):(c=e*r(2,d-1)*r(2,t),u=0));t>=8;f[h++]=255&c,c/=256,t-=8);for(u=u<<t|c,g+=t;g>0;f[h++]=255&u,u/=256,g-=8);return f[--h]|=128*y,f},unpack:function(e,t){var n,A=e.length,o=8*A-t-1,i=(1<<o)-1,a=i>>1,u=o-7,c=A-1,s=e[c--],f=127&s;for(s>>=7;u>0;f=256*f+e[c],c--,u-=8);for(n=f&(1<<-u)-1,f>>=-u,u+=t;u>0;n=256*n+e[c],c--,u-=8);if(0===f)f=1-a;else{if(f===i)return n?NaN:s?-1/0:1/0;n+=r(2,t),f-=a}return(s?-1:1)*n*r(2,f-t)}}},function(e,t,n){"use strict";var r=n(0),A=n(1),o=n(5),i=n(216),a=n(3),u=n(72),c=n(55),s=n(37),f=n(14),g=n(6),l=n(169),d=n(171),p=n(48),y=n(10),h=n(63),I=n(8),C=n(39),B=n(44),E=n(38).f,v=n(218),Q=n(20).forEach,w=n(53),m=n(9),b=n(22),x=n(21),S=n(121),D=x.get,k=x.set,R=m.f,F=b.f,O=Math.round,M=A.RangeError,G=u.ArrayBuffer,N=u.DataView,T=a.NATIVE_ARRAY_BUFFER_VIEWS,L=a.TYPED_ARRAY_TAG,H=a.TypedArray,j=a.TypedArrayPrototype,Y=a.aTypedArrayConstructor,U=a.isTypedArray,P=function(e,t){for(var n=0,r=t.length,A=new(Y(e))(r);r>n;)A[n]=t[n++];return A},K=function(e,t){R(e,t,{get:function(){return D(this)[t]}})},_=function(e){var t;return e instanceof G||"ArrayBuffer"==(t=h(e))||"SharedArrayBuffer"==t},X=function(e,t){return U(e)&&"symbol"!=typeof t&&t in e&&String(+t)==String(t)},J=function(e,t){return X(e,t=p(t,!0))?s(2,e[t]):F(e,t)},q=function(e,t,n){return!(X(e,t=p(t,!0))&&I(n)&&y(n,"value"))||y(n,"get")||y(n,"set")||n.configurable||y(n,"writable")&&!n.writable||y(n,"enumerable")&&!n.enumerable?R(e,t,n):(e[t]=n.value,e)};o?(T||(b.f=J,m.f=q,K(j,"buffer"),K(j,"byteOffset"),K(j,"byteLength"),K(j,"length")),r({target:"Object",stat:!0,forced:!T},{getOwnPropertyDescriptor:J,defineProperty:q}),e.exports=function(e,t,n){var o=e.match(/\d+$/)[0]/8,a=e+(n?"Clamped":"")+"Array",u="get"+e,s="set"+e,p=A[a],y=p,h=y&&y.prototype,m={},b=function(e,t){R(e,t,{get:function(){return function(e,t){var n=D(e);return n.view[u](t*o+n.byteOffset,!0)}(this,t)},set:function(e){return function(e,t,r){var A=D(e);n&&(r=(r=O(r))<0?0:r>255?255:255&r),A.view[s](t*o+A.byteOffset,r,!0)}(this,t,e)},enumerable:!0})};T?i&&(y=t((function(e,t,n,r){return c(e,y,a),S(I(t)?_(t)?r!==undefined?new p(t,d(n,o),r):n!==undefined?new p(t,d(n,o)):new p(t):U(t)?P(y,t):v.call(y,t):new p(l(t)),e,y)})),B&&B(y,H),Q(E(p),(function(e){e in y||f(y,e,p[e])})),y.prototype=h):(y=t((function(e,t,n,r){c(e,y,a);var A,i,u,s=0,f=0;if(I(t)){if(!_(t))return U(t)?P(y,t):v.call(y,t);A=t,f=d(n,o);var p=t.byteLength;if(r===undefined){if(p%o)throw M("Wrong length");if((i=p-f)<0)throw M("Wrong length")}else if((i=g(r)*o)+f>p)throw M("Wrong length");u=i/o}else u=l(t),A=new G(i=u*o);for(k(e,{buffer:A,byteOffset:f,byteLength:i,length:u,view:new N(A)});s<u;)b(e,s++)})),B&&B(y,H),h=y.prototype=C(j)),h.constructor!==y&&f(h,"constructor",y),L&&f(h,L,a),m[a]=y,r({global:!0,forced:y!=p,sham:!T},m),"BYTES_PER_ELEMENT"in y||f(y,"BYTES_PER_ELEMENT",o),"BYTES_PER_ELEMENT"in h||f(h,"BYTES_PER_ELEMENT",o),w(a)}):e.exports=function(){}},function(e,t,n){var r=n(1),A=n(2),o=n(64),i=n(3).NATIVE_ARRAY_BUFFER_VIEWS,a=r.ArrayBuffer,u=r.Int8Array;e.exports=!i||!A((function(){u(1)}))||!A((function(){new u(-1)}))||!o((function(e){new u,new u(null),new u(1.5),new u(e)}),!0)||A((function(){return 1!==new u(new a(2),1,undefined).length}))},function(e,t,n){var r=n(24);e.exports=function(e){var t=r(e);if(t<0)throw RangeError("The argument can't be less than 0");return t}},function(e,t,n){var r=n(13),A=n(6),o=n(114),i=n(113),a=n(40),u=n(3).aTypedArrayConstructor;e.exports=function(e){var t,n,c,s,f,g,l=r(e),d=arguments.length,p=d>1?arguments[1]:undefined,y=p!==undefined,h=o(l);if(h!=undefined&&!i(h))for(g=(f=h.call(l)).next,l=[];!(s=g.call(f)).done;)l.push(s.value);for(y&&d>2&&(p=a(p,arguments[2],2)),n=A(l.length),c=new(u(this))(n),t=0;n>t;t++)c[t]=y?p(l[t],t):l[t];return c}},function(e,t,n){"use strict";var r=n(13),A=n(32),o=n(6),i=Math.min;e.exports=[].copyWithin||function(e,t){var n=r(this),a=o(n.length),u=A(e,a),c=A(t,a),s=arguments.length>2?arguments[2]:undefined,f=i((s===undefined?a:A(s,a))-c,a-u),g=1;for(c<u&&u<c+f&&(g=-1,c+=f-1,u+=f-1);f-- >0;)c in n?n[u]=n[c]:delete n[u],u+=g,c+=g;return n}},function(e,t,n){"use strict";var r=n(19),A=n(24),o=n(6),i=n(52),a=n(33),u=Math.min,c=[].lastIndexOf,s=!!c&&1/[1].lastIndexOf(1,-0)<0,f=i("lastIndexOf"),g=a("indexOf",{ACCESSORS:!0,1:0}),l=s||!f||!g;e.exports=l?function(e){if(s)return c.apply(this,arguments)||0;var t=r(this),n=o(t.length),i=n-1;for(arguments.length>1&&(i=u(i,A(arguments[1]))),i<0&&(i=n+i);i>=0;i--)if(i in t&&t[i]===e)return i||0;return-1}:c},function(e,t,n){"use strict";(function(e){n(69),n(16),n(161),n(58),n(222),n(71),n(17),n(7),n(74),n(75),n(76),n(77),n(78),n(79),n(80),n(81),n(82),n(83),n(84),n(85),n(86),n(87),n(88),n(89),n(90),n(91),n(92),n(93),n(94),n(95),n(96),n(97),function(e){function t(){}function n(e,t){if(e=void 0===e?"utf-8":e,t=void 0===t?{fatal:!1}:t,-1===r.indexOf(e.toLowerCase()))throw new RangeError("Failed to construct 'TextDecoder': The encoding label provided ('"+e+"') is invalid.");if(t.fatal)throw Error("Failed to construct 'TextDecoder': the 'fatal' option is unsupported.")}if(e.TextEncoder&&e.TextDecoder)return!1;var r=["utf-8","utf8","unicode-1-1-utf-8"];Object.defineProperty(t.prototype,"encoding",{value:"utf-8"}),t.prototype.encode=function(e,t){if((t=void 0===t?{stream:!1}:t).stream)throw Error("Failed to encode: the 'stream' option is unsupported.");t=0;for(var n=e.length,r=0,A=Math.max(32,n+(n>>1)+7),o=new Uint8Array(A>>3<<3);t<n;){var i=e.charCodeAt(t++);if(55296<=i&&56319>=i){if(t<n){var a=e.charCodeAt(t);56320==(64512&a)&&(++t,i=((1023&i)<<10)+(1023&a)+65536)}if(55296<=i&&56319>=i)continue}if(r+4>o.length&&(A+=8,A=(A*=1+t/e.length*2)>>3<<3,(a=new Uint8Array(A)).set(o),o=a),0==(4294967168&i))o[r++]=i;else{if(0==(4294965248&i))o[r++]=i>>6&31|192;else if(0==(4294901760&i))o[r++]=i>>12&15|224,o[r++]=i>>6&63|128;else{if(0!=(4292870144&i))continue;o[r++]=i>>18&7|240,o[r++]=i>>12&63|128,o[r++]=i>>6&63|128}o[r++]=63&i|128}}return o.slice?o.slice(0,r):o.subarray(0,r)},Object.defineProperty(n.prototype,"encoding",{value:"utf-8"}),Object.defineProperty(n.prototype,"fatal",{value:!1}),Object.defineProperty(n.prototype,"ignoreBOM",{value:!1}),n.prototype.decode=function(e,t){if((t=void 0===t?{stream:!1}:t).stream)throw Error("Failed to decode: the 'stream' option is unsupported.");!((t=e)instanceof Uint8Array)&&t.buffer instanceof ArrayBuffer&&(t=new Uint8Array(e.buffer)),e=0;for(var n=[],r=[];;){var A=e<t.length;if(!A||65536&e){if(r.push(String.fromCharCode.apply(null,n)),!A)return r.join("");n=[],t=t.subarray(e),e=0}if(0===(A=t[e++]))n.push(0);else if(0==(128&A))n.push(A);else if(192==(224&A)){var o=63&t[e++];n.push((31&A)<<6|o)}else if(224==(240&A)){o=63&t[e++];var i=63&t[e++];n.push((31&A)<<12|o<<6|i)}else if(240==(248&A)){65535<(A=(7&A)<<18|(o=63&t[e++])<<12|(i=63&t[e++])<<6|63&t[e++])&&(A-=65536,n.push(A>>>10&1023|55296),A=56320|1023&A),n.push(A)}}},e.TextEncoder=t,e.TextDecoder=n}("undefined"!=typeof window?window:void 0!==e?e:void 0)}).call(this,n(100))},function(e,t,n){"use strict";var r=n(0),A=n(1),o=n(72),i=n(53),a=o.ArrayBuffer;r({global:!0,forced:A.ArrayBuffer!==a},{ArrayBuffer:a}),i("ArrayBuffer")},function(e,t,n){var r=n(0),A=n(72);r({global:!0,forced:!n(128)},{DataView:A.DataView})},function(e,t,n){"use strict";n(34),n(42),n(43),n(99),n(66),n(16),n(58),n(225),n(129),n(17),n(130),n(131),n(73),n(7),n(36),n(173),n(68),n(27),Object.defineProperty(t,"__esModule",{value:!0}),t.loadCondensedWasm=function(e){var t=arguments.length>1&&arguments[1]!==undefined?arguments[1]:{},n="_wasm_dep",A=o({},t,i({},n,{})),a={},u=new r.Encoder,c=!0,s=!1,f=undefined;try{for(var g,l=e[Symbol.iterator]();!(c=(g=l.next()).done);c=!0){var d=g.value,p=new WebAssembly.Module(u.decode(d)),y=new WebAssembly.Instance(p,A);Object.assign(a,y.exports);for(var h=0,I=Object.keys(a);h<I.length;h++){var C=I[h];C.startsWith(n)&&(A[n][C.slice(n.length)]=a[C],delete a[C])}}}catch(err){s=!0,f=err}finally{try{c||null==l["return"]||l["return"]()}finally{if(s)throw f}}return a};var r=n(98);function A(e,t){var n=Object.keys(e);if(Object.getOwnPropertySymbols){var r=Object.getOwnPropertySymbols(e);t&&(r=r.filter((function(t){return Object.getOwnPropertyDescriptor(e,t).enumerable}))),n.push.apply(n,r)}return n}function o(e){for(var t=1;t<arguments.length;t++){var n=null!=arguments[t]?arguments[t]:{};t%2?A(Object(n),!0).forEach((function(t){i(e,t,n[t])})):Object.getOwnPropertyDescriptors?Object.defineProperties(e,Object.getOwnPropertyDescriptors(n)):A(Object(n)).forEach((function(t){Object.defineProperty(e,t,Object.getOwnPropertyDescriptor(n,t))}))}return e}function i(e,t,n){return t in e?Object.defineProperty(e,t,{value:n,enumerable:!0,configurable:!0,writable:!0}):e[t]=n,e}},function(e,t,n){var r=n(0),A=n(226);r({target:"Object",stat:!0,forced:Object.assign!==A},{assign:A})},function(e,t,n){"use strict";var r=n(5),A=n(2),o=n(62),i=n(107),a=n(101),u=n(13),c=n(47),s=Object.assign,f=Object.defineProperty;e.exports=!s||A((function(){if(r&&1!==s({b:1},s(f({},"a",{enumerable:!0,get:function(){f(this,"b",{value:3,enumerable:!1})}}),{b:2})).b)return!0;var e={},t={},n=Symbol();return e[n]=7,"abcdefghijklmnopqrst".split("").forEach((function(e){t[e]=e})),7!=s({},e)[n]||"abcdefghijklmnopqrst"!=o(s({},t)).join("")}))?function(e,t){for(var n=u(e),A=arguments.length,s=1,f=i.f,g=a.f;A>s;)for(var l,d=c(arguments[s++]),p=f?o(d).concat(f(d)):o(d),y=p.length,h=0;y>h;)l=p[h++],r&&!g.call(d,l)||(n[l]=d[l]);return n}:s},function(e){e.exports=JSON.parse('{"program":["AGFzbQEAAAABw4CAgACJgICAAGADf39/AX9gAX8AYAABf2ABfwF/YAR/f39/AX9gA39/fwBgAn9/AGAFf39/f38Bf2AKf39/f39/f39/fwF/AoWAgIAAgICAgAADlICAgACPgICAAAICAgAFBgQHBQQACAIBAwSJgICAAIGAgIAAcAELCwWLgICAAIGAgIAAAYACgIACBpCAgIAAgoCAgAB/AUEAC38AQZAMCwfqgYCAAIyAgIAABm1lbW9yeQIAGnNpemVvZl9tYmVkdGxzX2djbV9jb250ZXh0AAAVbWJlZHRsc19jaXBoZXJfaWRfYWVzAAEYbWJlZHRsc19nY21fYXV0aF9kZWNyeXB0AAsQX19lcnJub19sb2NhdGlvbgACCXN0YWNrU2F2ZQAMDHN0YWNrUmVzdG9yZQANCnN0YWNrQWxsb2MADhFfd2FzbV9kZXBfZnVuY18xOAAFEV93YXNtX2RlcF9mdW5jXzM2AAYSX3dhc21fZGVwX21lbW9yeV8wAgARX3dhc21fZGVwX3RhYmxlXzABAAmFgICAAICAgIAACriWgIAAj4CAgACFgICAAABBgAMLhICAgAAAQQILhYCAgAAAQaAMC4GEgIAAAQN/IAJBgARPBEAgACABIAIQBCAADwsgACACaiEDAkAgACABc0EDcUUEQAJAIAJBAUgEQCAAIQIMAQsgAEEDcUUEQCAAIQIMAQsgACECA0AgAiABLQAAOgAAIAFBAWohASACQQFqIgIgA08NASACQQNxDQALCwJAIANBfHEiBEHAAEkNACACIARBQGoiBUsNAANAIAIgASgCADYCACACIAEoAgQ2AgQgAiABKAIINgIIIAIgASgCDDYCDCACIAEoAhA2AhAgAiABKAIUNgIUIAIgASgCGDYCGCACIAEoAhw2AhwgAiABKAIgNgIgIAIgASgCJDYCJCACIAEoAig2AiggAiABKAIsNgIsIAIgASgCMDYCMCACIAEoAjQ2AjQgAiABKAI4NgI4IAIgASgCPDYCPCABQUBrIQEgAkFAayICIAVNDQALCyACIARPDQEDQCACIAEoAgA2AgAgAUEEaiEBIAJBBGoiAiAESQ0ACwwBCyADQQRJBEAgACECDAELIANBfGoiBCAASQRAIAAhAgwBCyAAIQIDQCACIAEtAAA6AAAgAiABLQABOgABIAIgAS0AAjoAAiACIAEtAAM6AAMgAUEEaiEBIAJBBGoiAiAETQ0ACwsgAiADSQRAA0AgAiABLQAAOgAAIAFBAWohASACQQFqIgIgA0cNAAsLIAALu4CAgAABAX8gAgRAA0AgACABIAJB/AMgAkH8A0kbIgMQAyEAIAFB/ANqIQEgAEH8A2ohACACIANrIgINAAsLC5eAgIAAACABBEAgAEEAIAFBgAgoAgARAAAaCwurgYCAAAEDf0GAvn4hBAJAIAAoAgAiBUUNACADQQA2AgAgBSgCGCEGAkACQAJAIAUoAgRBf2oOBgACAgICAQILQYC7fiEEIAZBEEcNAiADQRA2AgAgACgCNCAAKAIIIAEgAiAFKAIcKAIEEQQADwsgA0EQNgIAIAAoAjRBECABIAIQCQ8LIAZFBEBBgLl+DwsgASACRgRAIAAoAhwNAUEQIAZwDQELQYC/fiEECyAEC4iEgIAAAQt/IwEoAgBBEGsiCCQAIwEjADYCACAIQQA2AgwCQCACRQRAQWwhBQwBCyAAQoAANwPYAiAAQQA2AvgCIABCgAA3A7gCIABCgAA3A/ACIABB6AJqIgtCgAA3AwAgAEKAADcD4AIgAEKAADcDwAIgAEHYAmohBgJAIAJBDEYEQCAGIAEpAAA3AAAgBiABKAAINgAIIABBAToA5wIMAQsgAkEDdCEMIAJBBXYhDSACQQ12IQ4gAkEVdiEPA0AgAkEQIAJBEEkbIglBASAJQQFLGyEHQQAhBQNAIAAgBWpB2AJqIgogCi0AACABIAVqLQAAczoAACAFQQFqIgUgB0cNAAsgACAGIAYQCCABIAlqIQEgAiAJayICDQALIABB5wJqIgUgBS0AACAMczoAACAAQeYCaiIFIAUtAAAgDXM6AAAgAEHlAmoiBSAFLQAAIA5zOgAAIABB5AJqIgUgBS0AACAPczoAACAAIAYgBhAICyAAIAYgAEHIAmogCEEMahAGIgUNACAAIAStNwPAAiAEBEADQCAEQRAgBEEQSRsiB0EBIAdBAUsbIQFBACEFA0AgACAFakHoAmoiCiAKLQAAIAMgBWotAABzOgAAIAVBAWoiBSABRw0ACyAAIAsgCxAIIAMgB2ohAyAEIAdrIgQNAAsLQQAhBQsgCEEQaiQAIwEjADYCACAFC4uDgIAAAgN/A34gACABLQAPIgNBD3FBA3RqIgQpAzghByAEKQO4ASEGQQ8hBANAIANB8AFxQQR2IQUCQCAEQQ9GBEAgByEIDAELIAAgA0EPcUEDdGoiAykDOCAGQrwAhiAHQoQAiISFIQggAykDuAEgB6dBD3FBA3RBgAtqKQMAQrAAhiAGQoQAiIWFIQYLIAAgBUEDdGoiAykDOCAGQrwAhiAIQoQAiISFIQcgAykDuAEgCKdBD3FBA3RBgAtqKQMAQrAAhiAGQoQAiIWFIQYgBARAIAEgBEF/aiIEai0AACEDDAELCyACIAc8AA8gAiAGPAAHIAIgB0KIAIg8AA4gAiAHQpAAiDwADSACIAdCmACIPAAMIAIgB0KgAIg8AAsgAiAHQqgAiDwACiACIAdCsACIPAAJIAIgB0K4AIg8AAggAiAGQogAiDwABiACIAZCkACIPAAFIAIgBkKYAIg8AAQgAiAGQqAAiDwAAyACIAZCqACIPAACIAIgBkKwAIg8AAEgAiAGQrgAiDwAAAuJg4CAAAIIfwJ+IwEoAgBBIGsiBiQAIwEjADYCACAGQQA2AgwCQCADIAJLBEBBbCEEIAMgAmsgAUkNAQtBbCEEIAApA7gCIg0gAa18IgwgDVQNACAMQuD/////AVYNACAAIAw3A7gCIAEEQCAAQegCaiEIIABB2AJqIQkDQEEQIQQDQCAEQQ1PBEAgACAEQX9qIgRqQdgCaiIFIAUtAABBAWoiBToAACAFQf8BcSAFRw0BCwsgACAJIAZBEGogBkEMahAGIgQNAiABQRAgAUEQSRsiB0EBIAdBAUsbIQpBACEEA0AgACgC+AJFBEAgACAEakHoAmoiBSAFLQAAIAIgBGotAABzOgAACyADIARqIAIgBGotAAAgBkEQaiAEai0AAHMiBToAACAAKAL4AkEBRgRAIAAgBGpB6AJqIgsgCy0AACAFczoAAAsgBEEBaiIEIApHDQALIAAgCCAIEAggAyAHaiEDIAIgB2ohAiABIAdrIgENAAsLQQAhBAsgBkEgaiQAIwEjADYCACAEC/mDgIAAAgN/BH5BbCEEIAJBfGpBDE0EQCAAKQPAAiEGIAApA7gCIQcgASAAQcgCaiACEAMhBSAGQoMAhiIIIAdCgwCGIgmEUARAQQAPCyAAIAAtAOgCIAZCtQCIp3M6AOgCIABB6QJqIgEgAS0AACAGQq0AiKdzOgAAIABB6gJqIgEgAS0AACAGQqUAiKdzOgAAIABB6wJqIgEgAS0AACAGQp0AiKdzOgAAIABB7AJqIgEgAS0AACAGpyIBQRV2czoAACAAQe0CaiIDIAMtAAAgAUENdnM6AAAgAEHuAmoiAyADLQAAIAFBBXZzOgAAIABB7wJqIgEgAS0AACAIp3M6AAAgAEHwAmoiASABLQAAIAdCtQCIp3M6AAAgAEHxAmoiASABLQAAIAdCrQCIp3M6AAAgAEHyAmoiASABLQAAIAdCpQCIp3M6AAAgAEHzAmoiASABLQAAIAdCnQCIp3M6AAAgAEH0AmoiASABLQAAIAenIgFBFXZzOgAAIABB9QJqIgMgAy0AACABQQ12czoAACAAQfYCaiIDIAMtAAAgAUEFdnM6AAAgAEH3AmoiASABLQAAIAmnczoAACAAIABB6AJqIgEgARAIQQAhBEEAIQEDQCABIAVqIgMgAy0AACAAIAFqLQDoAnM6AAAgAUEBaiIBIAJHDQALCyAEC5mBgIAAAQF/IwEoAgBBEGsiCiQAIwEjADYCAAJAIAAgAiADIAQgBRAHIgINACAAIAEgCCAJEAkiAg0AIAAgCiAHEAoiAg0AQQAhAiAHRQ0AQQAhA0EAIQADQCADIAAgCmotAAAgACAGai0AAHNyIQMgAEEBaiIAIAdHDQALIANFDQAgCSABEAVBbiECCyAKQRBqJAAjASMANgIAIAILh4CAgAAAIwEoAgALjYCAgAAAIAAkACMBIwA2AgALmoCAgAAAIwEoAgAgAGtBcHEiACQAIwEjADYCACAACwvzg4CAAIiAgIAAAEGACAsSAgAAAAIAAAABAAAAgAAAAAgFAEGcCAsWEAAAABQFAAADAAAAAQAAAMAAAAAsBQBBvAgLFhAAAAAUBQAABAAAAAEAAAAAAQAAOAUAQdwIC2YQAAAAFAUAAA4AAAAGAAAAgAAAAEQFAAAMAAAAAQAAABAAAABQBQAADwAAAAYAAADAAAAAaAUAAAwAAAABAAAAEAAAAFAFAAAQAAAABgAAAAABAAB0BQAADAAAAAEAAAAQAAAAUAUAQdAJCy4CAAAABAQAAAMAAAAkBAAABAAAAEQEAAAOAAAAZAQAAA8AAACEBAAAEAAAAKQEAEGICgt3QUVTLTEyOC1FQ0IAAgAAAAMAAAAEAAAABQAAAAYAAAAHAAAAQUVTLTE5Mi1FQ0IAQUVTLTI1Ni1FQ0IAQUVTLTEyOC1HQ00AAgAAAAAAAAAIAAAACAAAAAkAAAAKAAAAQUVTLTE5Mi1HQ00AQUVTLTI1Ni1HQ00AQYgLC3IgHAAAAAAAAEA4AAAAAAAAYCQAAAAAAACAcAAAAAAAAKBsAAAAAAAAwEgAAAAAAADgVAAAAAAAAADhAAAAAAAAIP0AAAAAAABA2QAAAAAAAGDFAAAAAAAAgJEAAAAAAACgjQAAAAAAAMCpAAAAAAAA4LUAQYAMCwOALFA=","AGFzbQEAAAABmICAgACEgICAAGADf39/AX9gAX8AYAF/AX9gAAACxoCAgACCgICAAANlbnYfZW1zY3JpcHRlbl9ub3RpZnlfbWVtb3J5X2dyb3d0aAABCV93YXNtX2RlcAlfbWVtb3J5XzACAYACgIACA5GAgIAAjICAgAADAAICAwICAAIBAQIEhYCAgACAgICAAAWFgICAAICAgIAABpeAgIAAg4CAgAB/AUEAC38AQZAMC38AQYDZAAsH94CAgACIgICAAAZtYWxsb2MACQRmcmVlAAsEc2JyawAECl9fZGF0YV9lbmQDAhBfd2FzbV9kZXBfZnVuY18xAAEQX3dhc21fZGVwX2Z1bmNfNAACEV93YXNtX2RlcF9mdW5jXzE1AAoRX3dhc21fZGVwX2Z1bmNfMTcADAmFgICAAICAgIAACsaTgIAAjICAgACSgICAAABBgNnAAiQAIwEjADYCABAFC/SCgIAAAgJ/AX4CQCACRQ0AIAAgAmoiA0F/aiABOgAAIAAgAToAACACQQNJDQAgA0F+aiABOgAAIAAgAToAASADQX1qIAE6AAAgACABOgACIAJBB0kNACADQXxqIAE6AAAgACABOgADIAJBCUkNACAAQQAgAGtBA3EiBGoiAyABQf8BcUGBgoQIbCIBNgIAIAMgAiAEa0F8cSIEaiICQXxqIAE2AgAgBEEJSQ0AIAMgATYCCCADIAE2AgQgAkF4aiABNgIAIAJBdGogATYCACAEQRlJDQAgAyABNgIYIAMgATYCFCADIAE2AhAgAyABNgIMIAJBcGogATYCACACQWxqIAE2AgAgAkFoaiABNgIAIAJBZGogATYCACAEIANBBHFBGHIiBGsiAkEgSQ0AIAGtIgVCoACGIAWEIQUgAyAEaiEBA0AgASAFNwMYIAEgBTcDECABIAU3AwggASAFNwMAIAFBIGohASACQWBqIgJBH0sNAAsLIAALo4CAgAAAIAA/AEEQdGtB//8DakEQdkAAQX9GBEBBAA8LQQAQAEEBC9KAgIAAAQJ/QYAMKAIAIgEgAEEDakF8cSICaiEAAkAgAkEBTkEAIAAgAU0bDQAgAD8AQRB0SwRAIAAQA0UNAQtBgAwgADYCACABDwtBoAxBMDYCAEF/C7qAgIAAAQN/A0AgAEEEdCIBQbQMaiABQbAMaiICNgIAIAFBuAxqIAI2AgAgAEEBaiIAQcAARw0AC0EwEAYaC7yEgIAAAQZ/IAAQBCIDQQFOBEBBECECIAAgA2oiBEFwaiIBQRA2AgwgAUEQNgIAAkACQAJAQbAUKAIAIgBFDQAgAyAAKAIIRw0AIAMgA0F8aigCACICQR91IAJzayIGQXxqKAIAIQUgACAENgIIQXAhAiAGIAUgBUEfdXNrIgAgACgCAGpBfGooAgBBf0oNASAAKAIEIgIgACgCCDYCCCAAKAIIIAI2AgQgACABIABrIgE2AgAgAUF8cSAAakF8aiABQX9zNgIAIAACfyAAKAIAQXhqIgFB/wBNBEAgAUEDdkF/agwBCyABZyECIAFBHSACa3ZBBHMgAkECdGtB7gBqIAFB/x9NDQAaIAFBHiACa3ZBAnMgAkEBdGtBxwBqIgFBPyABQT9JGwsiAUEEdCICQbAMajYCBCAAIAJBuAxqIgIoAgA2AggMAgsgA0EQNgIMIANBEDYCACADIAQ2AgggAyAANgIEQbAUIAM2AgALIAIgA2oiACABIABrIgE2AgAgAUF8cSAAakF8aiABQX9zNgIAIAACfyAAKAIAQXhqIgFB/wBNBEAgAUEDdkF/agwBCyABZyECIAFBHSACa3ZBBHMgAkECdGtB7gBqIAFB/x9NDQAaIAFBHiACa3ZBAnMgAkEBdGtBxwBqIgFBPyABQT9JGwsiAUEEdCICQbAMajYCBCAAIAJBuAxqIgIoAgA2AggLIAIgADYCACAAKAIIIAA2AgRBuBRBuBQpAwBCgQAgAa2GhDcDAAsgA0EASgvtg4CAAAIGfwJ+QQghBAJAAkADQCAEIARBf2pxDQEgBEEIIARBCEsbIQRBuBQpAwAiCAJ/IABBA2pBfHFBCCAAQQhLGyIAQf8ATQRAIABBA3ZBf2oMAQsgAEEdIABnIgJrdkEEcyACQQJ0a0HuAGogAEH/H00NABogAEEeIAJrdkECcyACQQF0a0HHAGoiAkE/IAJBP0kbCyICrYgiB1BFBEADQCAHIAd6IgiIIQcCfiACIAinaiICQQR0IgNBuAxqKAIAIgEgA0GwDGoiBkcEQCABIAQgABAIIgUNBiABKAIEIgUgASgCCDYCCCABKAIIIAU2AgQgASAGNgIIIAEgA0G0DGoiAygCADYCBCADIAE2AgAgASgCBCABNgIIIAJBAWohAiAHQoEAiAwBC0G4FEG4FCkDAEL+fyACrYmDNwMAIAdCgQCFCyIHQoAAUg0AC0G4FCkDACEIC0E/IAh5p2tBBHQiAUGwDGohAyABQbgMaigCACEBAkAgCEKAgICABFQNAEHjACECIAEgA0YNAANAIAJFDQEgASAEIAAQCCIFDQQgAkF/aiECIAEoAggiASADRw0ACyADIQELIABBMGoQBg0ACyABIANGDQADQCABIAQgABAIIgUNAiABKAIIIgEgA0cNAAsLQQAhBQsgBQuog4CAAAEDfyABIABBBGoiBGpBf2pBACABa3EiBSACaiAAIAAoAgAiAWpBfGpNBH8gACgCBCIDIAAoAgg2AgggACgCCCADNgIEIAQgBUcEQCAAIABBfGooAgAiA0EfdSADc2siAyAFIARrIgQgAygCAGoiBTYCACAFQXxxIANqQXxqIAU2AgAgACAEaiIAIAEgBGsiATYCAAsCQCACQRhqIAFNBEAgACACakEIaiIDIAEgAmsiAUF4aiIENgIAIARBfHEgA2pBfGpBByABazYCACADAn8gAygCAEF4aiIBQf8ATQRAIAFBA3ZBf2oMAQsgAWchBCABQR0gBGt2QQRzIARBAnRrQe4AaiABQf8fTQ0AGiABQR4gBGt2QQJzIARBAXRrQccAaiIBQT8gAUE/SRsLIgFBBHQiBEGwDGo2AgQgAyAEQbgMaiIEKAIANgIIIAQgAzYCACADKAIIIAM2AgRBuBRBuBQpAwBCgQAgAa2GhDcDACAAIAJBCGoiAjYCACACQXxxIABqQXxqIAI2AgAMAQsgACABakF8aiABNgIACyAAQQRqBSADCwuGgICAAAAgABAHC9mCgIAAAQV/IAAEQCAAQXxqIgMoAgAiBCEBIAMhAiAAQXhqKAIAIgBBf0wEQCAAIANqIgIoAgUiASACQQlqIgUoAgA2AgggBSgCACABNgIEIAQgAEF/c2ohASACQQFqIQILIAMgBGoiACgCACIDIAAgA2pBfGooAgBHBEAgACgCBCIEIAAoAgg2AgggACgCCCAENgIEIAEgA2ohAQsgAiABNgIAIAFBfHEgAmpBfGogAUF/czYCACACAn8gAigCAEF4aiIBQf8ATQRAIAFBA3ZBf2oMAQsgAWchACABQR0gAGt2QQRzIABBAnRrQe4AaiABQf8fTQ0AGiABQR4gAGt2QQJzIABBAXRrQccAaiIBQT8gAUE/SRsLIgFBBHQiAEGwDGo2AgQgAiAAQbgMaiIAKAIANgIIIAAgAjYCACACKAIIIAI2AgRBuBRBuBQpAwBCgQAgAa2GhDcDAAsLhoCAgAAAIAAQCguagICAAAEBfyAAIgEQByIABEAgAEEAIAEQAhoLIAALC4WAgIAAgICAgAA=","AGFzbQEAAAABmICAgACDgICAAGAEf39/fwF/YAN/f38AYAJ/fwACtYCAgACCgICAAAlfd2FzbV9kZXAIX2Z1bmNfMTgAAglfd2FzbV9kZXAJX21lbW9yeV8wAgGAAoCAAgOJgICAAISAgIAAAQEAAASFgICAAICAgIAABYWAgIAAgICAgAAGkICAgACCgICAAH8BQQALfwBBkAwLB5mAgIAAgYCAgAARX3dhc21fZGVwX2Z1bmNfMjQABAmFgICAAICAgIAACsqcgIAAhICAgACHjoCAAAERfyMBKAIAQTBrIgMkACMBIwA2AgAgACgCBCEFIAMgASgAACIENgIoIAMgBCAFKAIAcyIENgIoIAMgASgABCAFKAIEcyIHNgIkIAMgASgACCAFKAIIcyIINgIgIAEoAAwhBiADIAVBEGoiATYCLCADIAYgBSgCDHMiBTYCHCAAKAIAIgBBBE4EQCAAQQF2IQsDQCAHQRZ2QfwHcUGAzwBqKAIAIARBDnZB/AdxQYDHAGooAgAgBUEGdkH8B3FBgD9qKAIAIAhB/wFxQQJ0QYA3aigCACABKAIIc3NzcyIKQRZ2QfwHcUGAzwBqKAIAIARBFnZB/AdxQYDPAGooAgAgBUEOdkH8B3FBgMcAaigCACAIQQZ2QfwHcUGAP2ooAgAgB0H/AXFBAnRBgDdqKAIAIAEoAgRzc3NzIglBDnZB/AdxQYDHAGooAgAgBUEWdkH8B3FBgM8AaigCACAIQQ52QfwHcUGAxwBqKAIAIAdBBnZB/AdxQYA/aigCACAEQf8BcUECdEGAN2ooAgAgASgCAHNzc3MiBkEGdkH8B3FBgD9qKAIAIAhBFnZB/AdxQYDPAGooAgAgB0EOdkH8B3FBgMcAaigCACAEQQZ2QfwHcUGAP2ooAgAgBUH/AXFBAnRBgDdqKAIAIAEoAgxzc3NzIgBB/wFxQQJ0QYA3aigCACABKAIcc3NzcyEFIAlBFnZB/AdxQYDPAGooAgAgBkEOdkH8B3FBgMcAaigCACAAQQZ2QfwHcUGAP2ooAgAgCkH/AXFBAnRBgDdqKAIAIAEoAhhzc3NzIQggBkEWdkH8B3FBgM8AaigCACAAQQ52QfwHcUGAxwBqKAIAIApBBnZB/AdxQYA/aigCACAJQf8BcUECdEGAN2ooAgAgASgCFHNzc3MhByAAQRZ2QfwHcUGAzwBqKAIAIApBDnZB/AdxQYDHAGooAgAgCUEGdkH8B3FBgD9qKAIAIAZB/wFxQQJ0QYA3aigCACABKAIQc3NzcyEEIAFBIGohASALQQJKIQwgC0F/aiELIAwNAAsgAyAJNgIUIAMgBjYCGCADIAo2AhAgAyAANgIMIAMgBDYCKCADIAc2AiQgAyAINgIgIAMgBTYCHCADIAE2AiwLIAMgBUEWdkH8B3FBgM8AaigCACAIQQ52QfwHcUGAxwBqKAIAIAdBBnZB/AdxQYA/aigCACAEQf8BcUECdEGAN2ooAgAgASgCAHNzc3MiADYCGCADIARBFnZB/AdxQYDPAGooAgAgBUEOdkH8B3FBgMcAaigCACAIQQZ2QfwHcUGAP2ooAgAgB0H/AXFBAnRBgDdqKAIAIAEoAgRzc3NzIgY2AhQgAyAHQRZ2QfwHcUGAzwBqKAIAIARBDnZB/AdxQYDHAGooAgAgBUEGdkH8B3FBgD9qKAIAIAhB/wFxQQJ0QYA3aigCACABKAIIc3NzcyIJNgIQIAMgCEEWdkH8B3FBgM8AaigCACAHQQ52QfwHcUGAxwBqKAIAIARBBnZB/AdxQYA/aigCACAFQf8BcUECdEGAN2ooAgAgASgCDHNzc3MiBDYCDCADIAEoAhAgAEH/AXFBgBVqLQAAcyIHIAZBCHZB/wFxQYAVai0AAEEIdHMiCCAJQRB2Qf8BcUGAFWotAABBEHRzIgUgBEEYdkGAFWotAABBGHRzIgo2AiggAyABKAIUIAZB/wFxQYAVai0AAHMiCyAJQQh2Qf8BcUGAFWotAABBCHRzIgwgBEEQdkH/AXFBgBVqLQAAQRB0cyIRIABBGHZBgBVqLQAAQRh0cyISNgIkIAZBGHZBgBVqLQAAIQ0gAEEQdkH/AXFBgBVqLQAAIQ4gBEEIdkH/AXFBgBVqLQAAIQ8gCUH/AXFBgBVqLQAAIRAgASgCGCETIAMgAUEgajYCLCADIA9BCHQgECATcyIPcyIQIA5BEHRzIg4gDUEYdHMiDTYCICADIAEoAhwgBEH/AXFBgBVqLQAAcyIBIABBCHZB/wFxQYAVai0AAEEIdHMiBCAGQRB2Qf8BcUGAFWotAABBEHRzIgAgCUEYdkGAFWotAABBGHRzIgY2AhwgAiAAQRB2OgAOIAIgBEEIdjoADSACIAE6AAwgAiANQRh2OgALIAIgDkEQdjoACiACIBBBCHY6AAkgAiAPOgAIIAIgEkEYdjoAByACIBFBEHY6AAYgAiAMQQh2OgAFIAIgCzoABCACIApBGHY6AAMgAiAFQRB2OgACIAIgCEEIdjoAASACIAc6AAAgAiAGQRh2OgAPIANBKGpBBBAAIANBJGpBBBAAIANBIGpBBBAAIANBHGpBBBAAIANBGGpBBBAAIANBFGpBBBAAIANBEGpBBBAAIANBDGpBBBAAIANBLGpBBBAAIANBMGokACMBIwA2AgAL/42AgAABEX8jASgCAEEwayIDJAAjASMANgIAIAAoAgQhBSADIAEoAAAiBDYCKCADIAQgBSgCAHMiBDYCKCADIAEoAAQgBSgCBHMiBzYCJCADIAEoAAggBSgCCHMiCDYCICABKAAMIQYgAyAFQRBqIgE2AiwgAyAGIAUoAgxzIgU2AhwgACgCACIAQQROBEAgAEEBdiELA0AgB0EWdkH8B3FBgC9qKAIAIAhBDnZB/AdxQYAnaigCACAFQQZ2QfwHcUGAH2ooAgAgBEH/AXFBAnRBgBdqKAIAIAEoAgBzc3NzIgpBFnZB/AdxQYAvaigCACAIQRZ2QfwHcUGAL2ooAgAgBUEOdkH8B3FBgCdqKAIAIARBBnZB/AdxQYAfaigCACAHQf8BcUECdEGAF2ooAgAgASgCBHNzc3MiCUEOdkH8B3FBgCdqKAIAIAVBFnZB/AdxQYAvaigCACAEQQ52QfwHcUGAJ2ooAgAgB0EGdkH8B3FBgB9qKAIAIAhB/wFxQQJ0QYAXaigCACABKAIIc3NzcyIGQQZ2QfwHcUGAH2ooAgAgBEEWdkH8B3FBgC9qKAIAIAdBDnZB/AdxQYAnaigCACAIQQZ2QfwHcUGAH2ooAgAgBUH/AXFBAnRBgBdqKAIAIAEoAgxzc3NzIgBB/wFxQQJ0QYAXaigCACABKAIcc3NzcyEFIABBFnZB/AdxQYAvaigCACAKQQ52QfwHcUGAJ2ooAgAgCUEGdkH8B3FBgB9qKAIAIAZB/wFxQQJ0QYAXaigCACABKAIYc3NzcyEIIAZBFnZB/AdxQYAvaigCACAAQQ52QfwHcUGAJ2ooAgAgCkEGdkH8B3FBgB9qKAIAIAlB/wFxQQJ0QYAXaigCACABKAIUc3NzcyEHIAlBFnZB/AdxQYAvaigCACAGQQ52QfwHcUGAJ2ooAgAgAEEGdkH8B3FBgB9qKAIAIApB/wFxQQJ0QYAXaigCACABKAIQc3NzcyEEIAFBIGohASALQQJKIQwgC0F/aiELIAwNAAsgAyAJNgIUIAMgCjYCGCADIAY2AhAgAyAANgIMIAMgBDYCKCADIAc2AiQgAyAINgIgIAMgBTYCHCADIAE2AiwLIAMgB0EWdkH8B3FBgC9qKAIAIAhBDnZB/AdxQYAnaigCACAFQQZ2QfwHcUGAH2ooAgAgBEH/AXFBAnRBgBdqKAIAIAEoAgBzc3NzIgA2AhggAyAIQRZ2QfwHcUGAL2ooAgAgBUEOdkH8B3FBgCdqKAIAIARBBnZB/AdxQYAfaigCACAHQf8BcUECdEGAF2ooAgAgASgCBHNzc3MiBjYCFCADIAVBFnZB/AdxQYAvaigCACAEQQ52QfwHcUGAJ2ooAgAgB0EGdkH8B3FBgB9qKAIAIAhB/wFxQQJ0QYAXaigCACABKAIIc3NzcyIJNgIQIAMgBEEWdkH8B3FBgC9qKAIAIAdBDnZB/AdxQYAnaigCACAIQQZ2QfwHcUGAH2ooAgAgBUH/AXFBAnRBgBdqKAIAIAEoAgxzc3NzIgQ2AgwgAyABKAIQIABB/wFxQYDXAGotAABzIgcgBEEIdkH/AXFBgNcAai0AAEEIdHMiCCAJQRB2Qf8BcUGA1wBqLQAAQRB0cyIFIAZBGHZBgNcAai0AAEEYdHMiCjYCKCADIAEoAhQgBkH/AXFBgNcAai0AAHMiCyAAQQh2Qf8BcUGA1wBqLQAAQQh0cyIMIARBEHZB/wFxQYDXAGotAABBEHRzIhEgCUEYdkGA1wBqLQAAQRh0cyISNgIkIARBGHZBgNcAai0AACENIABBEHZB/wFxQYDXAGotAAAhDiAGQQh2Qf8BcUGA1wBqLQAAIQ8gCUH/AXFBgNcAai0AACEQIAEoAhghEyADIAFBIGo2AiwgAyAPQQh0IBAgE3MiD3MiECAOQRB0cyIOIA1BGHRzIg02AiAgAyABKAIcIARB/wFxQYDXAGotAABzIgEgCUEIdkH/AXFBgNcAai0AAEEIdHMiBCAGQRB2Qf8BcUGA1wBqLQAAQRB0cyIGIABBGHZBgNcAai0AAEEYdHMiADYCHCACIAZBEHY6AA4gAiAEQQh2OgANIAIgAToADCACIA1BGHY6AAsgAiAOQRB2OgAKIAIgEEEIdjoACSACIA86AAggAiASQRh2OgAHIAIgEUEQdjoABiACIAxBCHY6AAUgAiALOgAEIAIgCkEYdjoAAyACIAVBEHY6AAIgAiAIQQh2OgABIAIgBzoAACACIABBGHY6AA8gA0EoakEEEAAgA0EkakEEEAAgA0EgakEEEAAgA0EcakEEEAAgA0EYakEEEAAgA0EUakEEEAAgA0EQakEEEAAgA0EMakEEEAAgA0EsakEEEAAgA0EwaiQAIwEjADYCAAufgICAAAAgAUEBRgRAIAAgAiADEAFBAA8LIAAgAiADEAJBAAuMgICAAAAgACABIAIgAxADCwuFgICAAICAgIAA","AGFzbQEAAAABrICAgACHgICAAGADf39/AX9gAX8AYAABf2ABfwF/YAR/f39/AX9gAn9/AX9gAn9/AAKggYCAAIeAgIAACV93YXNtX2RlcAdfZnVuY180AAAJX3dhc21fZGVwCF9mdW5jXzE1AAEJX3dhc21fZGVwCF9mdW5jXzE3AAMJX3dhc21fZGVwCF9mdW5jXzE4AAYJX3dhc21fZGVwCF9mdW5jXzM2AAQJX3dhc21fZGVwCV9tZW1vcnlfMAIBgAKAgAIJX3dhc21fZGVwCF90YWJsZV8wAXABCwsDkYCAgACMgICAAAAAAAACAQAFAQUABASFgICAAICAgIAABYWAgIAAgICAgAAGkICAgACCgICAAH8BQQALfwBBkAwLB5GBgIAAh4CAgAARX3dhc21fZGVwX2Z1bmNfMjUABxFfd2FzbV9kZXBfZnVuY18yNgAIEV93YXNtX2RlcF9mdW5jXzI3AAkRX3dhc21fZGVwX2Z1bmNfMjgAChFfd2FzbV9kZXBfZnVuY18yOQALEV93YXNtX2RlcF9mdW5jXzMzAA0RX3dhc21fZGVwX2Z1bmNfMzgAEAmFgICAAICAgIAACpacgIAAjICAgADCjICAAAEMfyMBKAIAQYAQayIHJAAjASMANgIAAkAgAAJ/QQogAkGAAUYNABogAkGAAkcEQEFgIQggAkHAAUcNAkEMDAELQQ4LIgk2AgBBwBQtAABFBEBBASEDA0AgByADQQJ0aiAENgIAIAdBgAhqIARBAnRqIAM2AgAgA0EYdEEfdUEbcSADQQF0Qf4BcSADc3MhAyAEQQFqIgRBgAJHDQALQfAUQpuAgIDgBjcDAEHoFELAgICAgBA3AwBB4BRCkICAgIAENwMAQdgUQoSAgICAATcDAEHQFEKBgICAoAA3AwBBgBVB4wA6AABB49cAQQA6AABBASEDA0AgA0GAFWpBACAHIANBAnRqKAIAa0ECdCAHakH8D2ooAgAiBCAEQQF0IARBB3ZyQf8BcSIEcyAEQQF0Qf4BcSIGIARBB3ZyIgRzIARBAXRB/gFxIgQgBkEHdnIiBnMgBkEBdEH+AXEgBEEHdnJzQeMAcyIEOgAAIARBgNcAaiADOgAAIANBAWoiA0GAAkcNAAtBACEGIAcoAiwhCiAHKAI0IQsgBygCJCEMIAcoAjghDQNAIAZBAnQiA0GAP2ogBkGAFWotAAAiBEEQdCAEQQh0ciAEQRh0QR91QRtxIARBAXRB/gFxcyIFciIIQQh0IAQgBXMiBXIiDjYCACADQYA3aiAFQRh0IAhyNgIAIANBgMcAaiAEIA5BCHRyIgU2AgAgA0GAzwBqIAQgBUEIdHI2AgBBACEEQQAhBSAGQYDXAGotAAAiCARAIAdBgAhqIAcgCEECdGooAgAiBSAMakH/AW9BAnRqKAIAQQh0IAdBgAhqIAUgDWpB/wFvQQJ0aigCAHMgB0GACGogBSALakH/AW9BAnRqKAIAQRB0cyEEIAdBgAhqIAUgCmpB/wFvQQJ0aigCACEFCyADQYAXaiAFQRh0IARzIgU2AgAgA0GAH2ogBEEIdCAFQRh2ciIENgIAIANBgCdqIARBCHc2AgAgA0GAL2ogBEEQdzYCACAGQQFqIgZBgAJHDQALQcAUQQE6AAALIAAgAEEIaiIDNgIEIAJBBXYiBQRAQQAhBgNAIAAgBkECdCIEaiABIARqLQAAIAEgBEEBcmotAABBCHRyIAEgBEECcmotAABBEHRyIAEgBEEDcmotAABBGHRyNgIIIAZBAWoiBiAFRw0ACwtBACEIAkACQAJAIAlBdmoOBQADAQMCAwsgAygCACEBQQAhBgNAIAMgAygCDCIEQQh2Qf8BcUGAFWotAAAgBkECdEHQFGooAgAgAXNzIARBEHZB/wFxQYAVai0AAEEIdHMgBEEYdkGAFWotAABBEHRzIARB/wFxQYAVai0AAEEYdHMiATYCECADIAEgAygCBHMiBTYCFCADIAMoAgggBXMiBTYCGCADIAQgBXM2AhwgA0EQaiEDIAZBAWoiBkEKRw0ACwwCCyADKAIAIQFBACEGA0AgAyADKAIUIgRBCHZB/wFxQYAVai0AACAGQQJ0QdAUaigCACABc3MgBEEQdkH/AXFBgBVqLQAAQQh0cyAEQRh2QYAVai0AAEEQdHMgBEH/AXFBgBVqLQAAQRh0cyIBNgIYIAMgASADKAIEcyIFNgIcIAMgAygCCCAFcyIFNgIgIAMgAygCDCAFcyIFNgIkIAMgAygCECAFcyIFNgIoIAMgBCAFczYCLCADQRhqIQMgBkEBaiIGQQhHDQALDAELIAMoAgAhBkEAIQUDQCADIAMoAhwiBEEIdkH/AXFBgBVqLQAAIAVBAnRB0BRqKAIAIAZzcyAEQRB2Qf8BcUGAFWotAABBCHRzIARBGHZBgBVqLQAAQRB0cyAEQf8BcUGAFWotAABBGHRzIgY2AiAgAyAGIAMoAgRzIgE2AiQgAyADKAIIIAFzIgE2AiggAyADKAIMIAFzIgE2AiwgAyADKAIQIAFB/wFxQYAVai0AAHMgAUEIdkH/AXFBgBVqLQAAQQh0cyABQRB2Qf8BcUGAFWotAABBEHRzIAFBGHZBgBVqLQAAQRh0cyIBNgIwIAMgASADKAIUcyIBNgI0IAMgAygCGCABcyIBNgI4IAMgASAEczYCPCADQSBqIQMgBUEBaiIFQQdHDQALCyAHQYAQaiQAIwEjADYCACAIC82FgIAAAQR/IwEoAgBBoAJrIgMkACMBIwA2AgAgA0EIakEAQZgCEAAaIAAgAEEIajYCBCADQQhqIAEgAhAFIgVFBEAgACADKAIIIgQ2AgAgACADKAIMIgYgBEEEdGoiAigCADYCCCAAIAIoAgQ2AgwgACACKAIINgIQIAAgAigCDDYCFCAAQRhqIQAgAkFwaiEBIARBAkgEfyACQRBqBQNAIAAgASgCACICQQh2Qf8BcUGAFWotAABBAnRBgB9qKAIAIAJB/wFxQYAVai0AAEECdEGAF2ooAgBzIAJBEHZB/wFxQYAVai0AAEECdEGAJ2ooAgBzIAJBGHZBgBVqLQAAQQJ0QYAvaigCAHM2AgAgACABKAIEIgJBCHZB/wFxQYAVai0AAEECdEGAH2ooAgAgAkH/AXFBgBVqLQAAQQJ0QYAXaigCAHMgAkEQdkH/AXFBgBVqLQAAQQJ0QYAnaigCAHMgAkEYdkGAFWotAABBAnRBgC9qKAIAczYCBCAAIAEoAggiAkEIdkH/AXFBgBVqLQAAQQJ0QYAfaigCACACQf8BcUGAFWotAABBAnRBgBdqKAIAcyACQRB2Qf8BcUGAFWotAABBAnRBgCdqKAIAcyACQRh2QYAVai0AAEECdEGAL2ooAgBzNgIIIAAgASgCDCICQQh2Qf8BcUGAFWotAABBAnRBgB9qKAIAIAJB/wFxQYAVai0AAEECdEGAF2ooAgBzIAJBEHZB/wFxQYAVai0AAEECdEGAJ2ooAgBzIAJBGHZBgBVqLQAAQQJ0QYAvaigCAHM2AgwgAUFwaiEBIABBEGohACAEQQJKIQIgBEF/aiEEIAINAAsgBiIBQSBqCyECIAAgASgCADYCACAAIAJBZGooAgA2AgQgACACQWhqKAIANgIIIAAgAkFsaigCADYCDAsgA0EIakGYAhADIANBoAJqJAAjASMANgIAIAULioCAgAAAIAAgASACEAULioCAgAAAIAAgASACEAYLmoCAgAABAX9BmAIQAiIABEAgAEEAQZgCEAAaCyAAC5aAgIAAAQF/IAAiAQRAIAFBmAIQAwsgABABC4yAgIAAACAAQQIgASACEBAL2ICAgAABA38CQEHUCSgCACICBEBB0AkhAwNAIAMhBAJAIAIoAhwoAgAgAEcNACACKAIIIAFHDQAgAigCBEEBRg0DCyAEQQhqIQMgBCgCDCICDQALC0EAIQILIAILqYCAgAABAX8gAARAIAAoAjQiAQRAIAEgACgCACgCHCgCFBEBAAsgAEE4EAMLC+2AgIAAAQF/IAFFBEBBgL5+DwsgAEKAADcCACAAQoAANwIwIABCgAA3AiggAEKAADcCICAAQoAANwIYIABCgAA3AhAgAEKAADcCCCAAIAEoAhwoAhARAgAiAjYCNCACRQRAQYC9fg8LIAAgATYCAEEAC86AgIAAAQF/AkAgACgCACIDRQ0AIAMtABRBAnFFBEAgAygCCCACRw0BCyAAQQE2AgggACACNgIEIAAoAjQgASACIAMoAhwoAggRAAAPC0GAvn4LuoaAgAACAn8QfiMBKAIAQSBrIgQkACMBIwA2AgBBbCEFAkAgASADEAwiAUUNACABKAIYQRBHDQAgABANIAAgARAOIgUNACAAIAIgAxAPIgUNACAEQoAANwMQIARCgAA3AxggBEEANgIMIAAgBEEQaiAEQRBqIARBDGoQBCIFRQRAIAQxAB8hCCAEMQAeIQYgBDEAGyELIAQxABohCSAEMQAZIQwgBDEAGCENIAQxAB0hDiAEMQAcIQ8gBDEAFyEKIAQxABYhByAEMQATIRAgBDEAEiERIAQxABEhEiAEMQAQIRMgBDEAFSEUIAQxABQhFSAAQoAANwO4ASAAQoAANwM4IAAgCiAUQpAAhiAVQpgAhoQgECASQpAAhiATQpgAhoQgEUKIAIaEhEKgAIaEIAdCiACGhIQiBzcD+AEgACAIIA5CkACGIA9CmACGhCALIAxCkACGIA1CmACGhCAJQogAhoSEQqAAhoQgBkKIAIaEhCIGNwN4IAAgB0KBAIgiCSAIQoEAg0KAgICAgICAgOF/foUiCzcD2AEgACAKQr8AhiAGQoEAiIQiCDcDWCAAIAlCvwCGIAhCgQCIhCIKNwNIIAAgC0KBAIgiDCAIQoEAg0KAgICAgICAgOF/foUiCTcDyAEgACAIIAqFIhA3A2ggAEFAayAMQr8AhiAKQoEAiIQiDDcDACAAIAkgC4UiETcD6AEgACAKQoEAg0KAgICAgICAgOF/fiAJQoEAiIUiDTcDwAEgACAKIAyFIg43A1AgACAIIAyFIhI3A2AgACAJIA2FIg83A9ABIAAgCyANhSITNwPgASAAIAcgDYU3A4ACIAAgCCAOhSINNwNwIAAgCyAPhSIUNwPwASAAIAcgCYU3A4gCIAAgBiAMhTcDgAEgACAGIAqFNwOIASAAIAcgD4U3A5ACIAAgBiAOhTcDkAEgACAHIAuFNwOYAiAAIAYgCIU3A5gBIAAgByAThTcDoAIgACAGIBKFNwOgASAAIAcgEYU3A6gCIAAgBiAQhTcDqAEgACAHIBSFNwOwAiAAIAYgDYU3A7ABCyAEQSBqJAAjASMANgIAIAUPCyAEQSBqJAAjASMANgIAIAULC4WAgIAAgICAgAA=","AGFzbQEAAAABqYCAgACHgICAAGADf39/AX9gAX8AYAABf2ABfwF/YAR/f39/AX9gAABgAn9/AAKsgoCAAI6AgIAACV93YXNtX2RlcAdfZnVuY18xAAUJX3dhc21fZGVwB19mdW5jXzQAAAlfd2FzbV9kZXAIX2Z1bmNfMTUAAQlfd2FzbV9kZXAIX2Z1bmNfMTcAAwlfd2FzbV9kZXAIX2Z1bmNfMTgABglfd2FzbV9kZXAIX2Z1bmNfMjQABAlfd2FzbV9kZXAIX2Z1bmNfMjUAAAlfd2FzbV9kZXAIX2Z1bmNfMjYAAAlfd2FzbV9kZXAIX2Z1bmNfMjcAAglfd2FzbV9kZXAIX2Z1bmNfMjgAAQlfd2FzbV9kZXAIX2Z1bmNfMjkAAAlfd2FzbV9kZXAIX2Z1bmNfMzMAAQlfd2FzbV9kZXAIX2Z1bmNfMzgABAlfd2FzbV9kZXAIX3RhYmxlXzABcAELCwOJgICAAISAgIAAAgEBAQSFgICAAICAgIAABYWAgIAAgICAgAAGhYCAgACAgICAAAfqgICAAIWAgIAAGV9faW5kaXJlY3RfZnVuY3Rpb25fdGFibGUBABBtYmVkdGxzX2djbV9pbml0AA8SbWJlZHRsc19nY21fc2V0a2V5AAwQbWJlZHRsc19nY21fZnJlZQAQC19pbml0aWFsaXplAAAJlICAgACBgICAAABBAQsKAAEFBgcICQoNDgrVgICAAISAgIAAlICAgAABAX9BgAMQAyIABEAgABAPCyAAC4qAgIAAACAAEBAgABACC4yAgIAAACAAQQBBgAMQARoLkoCAgAAAIAAEQCAAEAsgAEGAAxAECwsLhYCAgACAgICAAA=="]}')},function(e,t,n){"use strict";n(69),n(35),n(122),n(165),Object.defineProperty(t,"__esModule",{value:!0}),t.cookieSet=function(e,t,n){o(e);var r=new Date;r.setTime(r.getTime()+24*n*60*60*1e3);var i="expires="+r.toUTCString();document.cookie=e+"="+t+"; "+i+A},t.cookieGet=function(e){for(var t=e+"=",n="",A=0,o=document.cookie.split(";"),i=0;i<o.length;i++){for(var a=o[i];" "===a.charAt(0);)a=a.substring(1);0===a.indexOf(t)&&(n=a.substring(t.length,a.length),A++)}A>1&&r.updateCounter("Siege:Csd:DuplicateCookieDetected",1);return n},t.cookieDelete=o;var r=new(n(28).Logger),A="; path=/"+("https:"===window.location.protocol?"; secure":"");function o(e){document.cookie=e+"=; expires=Thu, 01 Jan 1970 00:00:01 GMT"+A,document.cookie=e+"=; expires=Thu, 01 Jan 1970 00:00:01 GMT; domain="+location.hostname+A}},function(e,t,n){"use strict";function r(e,t,n,r,A,o,i){try{var a=e[o](i),u=a.value}catch(c){return void n(c)}a.done?t(u):Promise.resolve(u).then(r,A)}function A(e){return function(){var t=this,n=arguments;return new Promise((function(A,o){var i=e.apply(t,n);function a(e){r(i,A,o,a,u,"next",e)}function u(e){r(i,A,o,a,u,"throw",e)}a(undefined)}))}}n(16),n(71),n(7),n(12),n(74),n(75),n(76),n(77),n(78),n(79),n(80),n(81),n(82),n(83),n(84),n(85),n(86),n(87),n(88),n(89),n(90),n(91),n(92),n(93),n(94),n(95),n(96),n(97),Object.defineProperty(t,"__esModule",{value:!0}),t.rsaGenerateKey=function(){return u.apply(this,arguments)},t.rsaImportKey=function(e){return c.apply(this,arguments)},t.rsaWrap=function(e,t){return s.apply(this,arguments)},t.rsaUnwrap=function(e,t,n,r,A){return f.apply(this,arguments)},n(18);var o="RSA-OAEP",i=new Uint8Array([1,0,1]),a=["encrypt","decrypt"];function u(){return(u=A(regeneratorRuntime.mark((function e(){var t,n,r=arguments;return regeneratorRuntime.wrap((function(e){for(;;)switch(e.prev=e.next){case 0:return t=r.length>0&&r[0]!==undefined&&r[0],n=r.length>1&&r[1]!==undefined?r[1]:a,e.abrupt("return",crypto.subtle.generateKey({name:o,modulusLength:2048,publicExponent:i,hash:"SHA-256"},t,n));case 3:case"end":return e.stop()}}),e)})))).apply(this,arguments)}function c(){return(c=A(regeneratorRuntime.mark((function e(t){var n,r,A=arguments;return regeneratorRuntime.wrap((function(e){for(;;)switch(e.prev=e.next){case 0:return n=A.length>1&&A[1]!==undefined&&A[1],r=A.length>2&&A[2]!==undefined?A[2]:a,e.abrupt("return",crypto.subtle.importKey("jwk",t,{name:o,hash:"SHA-256"},n,r));case 3:case"end":return e.stop()}}),e)})))).apply(this,arguments)}function s(){return(s=A(regeneratorRuntime.mark((function e(t,n){var r;return regeneratorRuntime.wrap((function(e){for(;;)switch(e.prev=e.next){case 0:return r={name:o,hash:{name:"SHA-256"}},e.abrupt("return",crypto.subtle.wrapKey("raw",n,t,r));case 2:case"end":return e.stop()}}),e)})))).apply(this,arguments)}function f(){return(f=A(regeneratorRuntime.mark((function e(t,n,r,A,i){var a;return regeneratorRuntime.wrap((function(e){for(;;)switch(e.prev=e.next){case 0:return a={name:o,hash:{name:"SHA-256"}},e.abrupt("return",crypto.subtle.unwrapKey("raw",n,t,a,r,i,A));case 2:case"end":return e.stop()}}),e)})))).apply(this,arguments)}},function(e,t,n){"use strict";function r(e,t){for(var n=0;n<t.length;n++){var r=t[n];r.enumerable=r.enumerable||!1,r.configurable=!0,"value"in r&&(r.writable=!0),Object.defineProperty(e,r.key,r)}}function A(e){if(function(e){if(o(e))return"SCRIPT"===e.tagName;return!1}(e)){if(!e.parentNode)throw new Error("Script element has no parent node");e.parentNode.replaceChild(function(e){var t=document.createElement("script");t.text=e.innerHTML;for(var n=e.attributes.length-1;n>=0;n--)t.setAttribute(e.attributes[n].name,e.attributes[n].value);return t}(e),e)}else for(var t=0,n=e.childNodes;t<n.length;)A(n[t++]);return e}function o(e){return e.nodeType===e.ELEMENT_NODE}n(119),n(17),Object.defineProperty(t,"__esModule",{value:!0}),t.NodeDisplay=void 0;var i=function(){function e(){!function(e,t){if(!(e instanceof t))throw new TypeError("Cannot call a class as a function")}(this,e)}var t,n,i;return t=e,(n=[{key:"display",value:function(e,t){var n='<span id="siege-csd-replacement-start"></span>'.concat(t,'<span id="siege-csd-replacement-end"></span>'),r=e.parentNode;if(!r)throw new Error("Element to be replaced does not have parent node");e.outerHTML=n;for(var i=r.childNodes,a=[],u=!1,c=[],s=0;s<i.length;s++){var f=i[s];if(o(f))if(u){if("siege-csd-replacement-end"===f.id){c.push(f);break}a.push(f)}else"siege-csd-replacement-start"===f.id&&(c.push(f),u=!0)}for(var g=0,l=c;g<l.length;g++){var d=l[g];d.parentNode.removeChild(d)}for(var p=0,y=a;p<y.length;p++)A(y[p])}}])&&r(t.prototype,n),i&&r(t,i),e}();t.NodeDisplay=i},function(e,t,n){"use strict";n(17),n(7),n(12),Object.defineProperty(t,"__esModule",{value:!0}),t.CompatibilityValidator=void 0,n(18);var r=n(126),A=n(127),o=n(123),i=n(174),a=n(175),u=n(168);function c(e,t,n,r,A,o,i){try{var a=e[o](i),u=a.value}catch(c){return void n(c)}a.done?t(u):Promise.resolve(u).then(r,A)}function s(e){return function(){var t=this,n=arguments;return new Promise((function(r,A){var o=e.apply(t,n);function i(e){c(o,r,A,i,a,"next",e)}function a(e){c(o,r,A,i,a,"throw",e)}i(undefined)}))}}function f(e,t){for(var n=0;n<t.length;n++){var r=t[n];r.enumerable=r.enumerable||!1,r.configurable=!0,"value"in r&&(r.writable=!0),Object.defineProperty(e,r.key,r)}}function g(e,t,n){return t in e?Object.defineProperty(e,t,{value:n,enumerable:!0,configurable:!0,writable:!0}):e[t]=n,e}var l=function(){function e(){!function(e,t){if(!(e instanceof t))throw new TypeError("Cannot call a class as a function")}(this,e),g(this,"TEST_TEXT","Test crypto capabilites"),g(this,"KEY_ID_PREFIX","TEST_KEY"),g(this,"storage",new a.LocalStorage),g(this,"keyCache",new i.KeyCache(this.storage))}var t,n,c,l,d,p,y,h;return t=e,(n=[{key:"assertEncryptDecrypt",value:(h=s(regeneratorRuntime.mark((function I(e){var t,n,r;return regeneratorRuntime.wrap((function(o){for(;;)switch(o.prev=o.next){case 0:return t=new A.AesWasmCrypto(this.keyCache),o.next=3,t.encrypt(e,this.TEST_TEXT);case 3:if(n=o.sent,r=t.decrypt(n),n){o.next=7;break}throw new Error("Browser could not encrypt the payload");case 7:if(r===this.TEST_TEXT){o.next=9;break}throw new Error("Decryption payload does not match the original text when encrypting with a random key");case 9:case"end":return o.stop()}}),I,this)}))),function(e){return h.apply(this,arguments)})},{key:"validateAesCrypto",value:(y=s(regeneratorRuntime.mark((function C(){var e,t;return regeneratorRuntime.wrap((function(n){for(;;)switch(n.prev=n.next){case 0:return e=this.KEY_ID_PREFIX+(0,u.generateUid)(),n.next=3,(0,r.aesGenerateKey)();case 3:return t=n.sent,this.storage.put(e,t),n.prev=5,n.next=8,this.assertEncryptDecrypt(e);case 8:return n.prev=8,this.storage.removeKeys([e]),n.finish(8);case 11:case"end":return n.stop()}}),C,this,[[5,,8,11]])}))),function(){return y.apply(this,arguments)})},{key:"validateLibUsageUsingCryptoEngine",value:(p=s(regeneratorRuntime.mark((function B(){var e;return regeneratorRuntime.wrap((function(t){for(;;)switch(t.prev=t.next){case 0:return t.next=2,(0,u.encryptPayloadWithActiveKey)(this.TEST_TEXT);case 2:if(e=t.sent,(0,o.getCryptoEngineSingleton)().decrypt(e)===this.TEST_TEXT){t.next=7;break}throw new Error("Decryption payload doesn't match the original text");case 7:case"end":return t.stop()}}),B,this)}))),function(){return p.apply(this,arguments)})},{key:"validateBeforeInstall",value:(d=s(regeneratorRuntime.mark((function E(){return regeneratorRuntime.wrap((function(e){for(;;)switch(e.prev=e.next){case 0:return e.next=2,this.validateAesCrypto();case 2:case"end":return e.stop()}}),E,this)}))),function(){return d.apply(this,arguments)})},{key:"validateAfterInstall",value:(l=s(regeneratorRuntime.mark((function v(){return regeneratorRuntime.wrap((function(e){for(;;)switch(e.prev=e.next){case 0:return e.next=2,this.validateLibUsageUsingCryptoEngine();case 2:case"end":return e.stop()}}),v,this)}))),function(){return l.apply(this,arguments)})}])&&f(t.prototype,n),c&&f(t,c),e}();t.CompatibilityValidator=l},function(e,t,n){"use strict";Object.defineProperty(t,"__esModule",{value:!0}),t.reloadPage=function(){window.location.reload()}},function(e,t,n){"use strict";n(35),n(7),n(45),Object.defineProperty(t,"__esModule",{value:!0}),t.resetDecryptionCounter=function(){A=1},t.decryptInPlace=function(e,t,n,o,i,a){1===A&&(n.startTimer("Decrypt:Overall"),n.startTimer("Decrypt:FromStartToSecondPayload"));if(n.startTimer("Decrypt:Payload:"+A.toString()),n.incrementCounter("Siege:Csd:Decrypt:Payloads"),1===A)try{(0,r.cookieManagerGet)().kid!==t.kid&&n.incrementCounter("Siege:Csd:Decrypt:UsingNonActiveKey",1)}catch(f){n.incrementCounter("Siege:Csd:Decrypt:BadKeyCookie",1)}var u=i.decrypt(t),c=document.getElementById(e);if(null===c)throw new Error("Can't find element to insert the decrypt result");o.display(c,u),n.stopAndSendTimer("Decrypt:Payload:"+A.toString()),n.stopAndSendTimer("Decrypt:Overall"),2===A&&n.stopAndSendTimer("Decrypt:FromStartToSecondPayload");A++;var s=null==a?void 0:a.callSource;s!==undefined&&""!==s&&n.incrementCounter("Siege:Csd:Decrypt:CallSource:".concat(s))};var r=n(46),A=1}])}));
+});
+try {
+  window.uet('cf', 'Siege:Csd:LibraryEval', {wb: 1});
+  window.uex('ld', 'Siege:Csd:LibraryEval', {wb: 1});
+  window.uet('bb', 'Siege:Csd:LibLoadToDecrypt1Start', {wb: 1});
+} catch (e) {}
+
+</script>
+
+<div class="csd-encrypted-sensitive" id="fa8d49a7-b319-4718-a3f6-5768e015f960">
+	<script type="text/javascript">
+		(function(payload) {
+			var elementId = "fa8d49a7-b319-4718-a3f6-5768e015f960";
+			
+				try {
+					window.uet("cf", "Siege:Csd:LibLoadToDecrypt1Start", {wb: 1});
+					window.uex("ld", "Siege:Csd:LibLoadToDecrypt1Start", {wb: 1});
+				} catch (e) {}
+			
+			if (!window.SiegeClientSideDecryption) {
+				if (!window.csdFallbackDone) {
+					try {
+						ue.count("Siege:Csd:SafeFallback:missing-library", 1);
+					} catch (e) {}
+					window.location.href = "?_encoding\u003DUTF8\u0026disableCsd\u003Dmissing-library\u0026orderID\u003D113-0788486-7971417";
+					window.csdFallbackDone = true;
+				}
+				return;
+			}
+			SiegeClientSideDecryption.decryptInElementWithId(elementId, payload, {callSource: "now"});
+		})({"ct":"NRUonKWnXrUDJgJfHuI1fSYMIPn8SxUdKR/q/oT+LhMlFpQqPJWkRqVC4Y0k2FFE3Ag61A==","iv":"03sStSKTQ6xDS46a","kid":"bb4a41"})
+	</script>
+	<noscript><meta http-equiv="refresh" content="0;url=?_encoding=UTF8&amp;disableCsd=no-js&amp;orderID=113-0788486-7971417" /></noscript>
+</div>
+
+        <br/>
+        
+<div class="csd-encrypted-sensitive" id="79ec154c-1e00-42c2-8cdf-cd1f06045c4b">
+	<script type="text/javascript">
+		(function(payload) {
+			var elementId = "79ec154c-1e00-42c2-8cdf-cd1f06045c4b";
+			
+			if (!window.SiegeClientSideDecryption) {
+				if (!window.csdFallbackDone) {
+					try {
+						ue.count("Siege:Csd:SafeFallback:missing-library", 1);
+					} catch (e) {}
+					window.location.href = "?_encoding\u003DUTF8\u0026disableCsd\u003Dmissing-library\u0026orderID\u003D113-0788486-7971417";
+					window.csdFallbackDone = true;
+				}
+				return;
+			}
+			SiegeClientSideDecryption.decryptInElementWithId(elementId, payload, {callSource: "now"});
+		})({"ct":"OfGMzfW1jqYG+NJhc8/Astcy7CjHaAwhaCMafMPdwFV1Rrgk4xGkaOcdrSFb5c7vBP7PEJ7ce3nupHHZBDrOo3IL0wCFd20SaFo=","iv":"po3TpqSFh9TlF2kE","kid":"bb4a41"})
+	</script>
+	<noscript><meta http-equiv="refresh" content="0;url=?_encoding=UTF8&amp;disableCsd=no-js&amp;orderID=113-0788486-7971417" /></noscript>
+</div>
+
+    </span>
+</div>
+
+
+<script type="a-state" data-a-state="{&quot;key&quot;:&quot;delivery-instructions-data-map&quot;}">{"orderId":"113-0788486-7971417","isDeliveryInstructionsEditable":false,"isUpdateDeliveryInstructionsEnabled":false}</script>
+
+</div>
+
+        
+            <div id="f3_food_WfmInStoreOrderSummary" class="odp-widget-wrapper celwidget" cel_widget_id="f3_food_WfmInStoreOrderSummary">
+
+
+
+
+
+<!-- WFM Color Palette: https://design.amazon.com/styleguide/B4997FAE703u/whole-foods-market/visual-guidelines/colors/ -->
+
+<style type="text/css">
+    #provide_feedback_button {
+        border-radius: 3px;
+    }
+</style>
+
+<!-- Order Totals -->
+<div class="a-row a-spacing-base">
+    <span class="a-size-medium a-text-bold">
+        Purchase Summary
+    </span>
+</div>
+<div class="a-row a-spacing-base">
+    <span class="a-size-small a-color-tertiary">
+        Order #: 113-0788486-7971417
+    </span>
+    <br/>
+    
+        <span class="a-size-small a-color-tertiary">
+            Purchased Sunday, February 18, 2024
+        </span>
+    
+</div>
+<div class="a-row a-spacing-medium">
+    <table class="a-normal">
+        <tr class="ufpo-order-totals-padding-row"></tr>
+
+        <!-- subtotal -->
+        <tr id="wfm-subtotal-row">
+            <td class="a-span9">
+                <span id="wfm-subtotal-label" class="a-text-bold">
+                    Item Subtotal
+                </span>
+            </td>
+            <td class="a-span3 a-text-right a-align-center">
+                <span id="wfm-subtotal-amount" class="a-text-bold">
+                    $64.15
+                </span>
+            </td>
+        </tr>
+
+        <!-- total savings -->
+        <tr id="wfm-total-savings-row">
+            <td class="a-span9">
+                <span id="wfm-total-savings-label" class="a-color-success a-text-bold">
+                    Total Savings
+                </span>
+            </td>
+            <td class="a-span3 a-text-right a-align-center">
+                <span id="wfm-total-savings-amount" class="a-color-success a-text-bold">
+                    -$3.16
+                </span>
+            </td>
+        </tr>
+
+        <!-- total taxes -->
+        
+            <tr id="wfm-tax-total-row">
+                <td class="a-span9 a-align-center">
+                    <span id="wfm-tax-total-label" class="a-text-bold">
+                        Tax and Fees
+                    </span>
+                </td>
+                <td class="a-span3 a-text-right a-align-center a-text-bold">
+                    <span id="wfm-tax-total-amount">
+                        $1.96
+                    </span>
+                </td>
+            </tr>
+        
+
+
+        <!-- taxes list -->
+        
+            
+            <tr id="wfm-AUSTIN, CITY OF-row" class="wfm-tax-breakout-row">
+                <td class="a-span9 a-align-center">
+                    <ul class="a-unordered-list a-vertical">
+                        <li id="wfm-AUSTIN, CITY OF-label" class="a-list-more a-align-center"><span class="a-list-item a-size-mini a-color-tertiary">
+                            AUSTIN, CITY OF
+                        </span></li>
+                    </ul>
+                </td>
+                <td class="a-span3 a-color-tertiary a-text-right a-align-center">
+                    <span id="wfm-AUSTIN, CITY OF-amount">
+                        $1.96
+                    </span>
+                </td>
+            </tr>
+        
+
+        <!-- grand total -->
+        <tr id="wfm-grand-total-row">
+            <td class="a-span9 a-align-center">
+                <span id="wfm-grand-total-label" class="a-text-bold">
+                    Grand Total
+                </span>
+            </td>
+            <td class="a-span3 a-text-right a-align-center a-text-bold">
+                <span id="wfm-grand-total-amount">
+                    $62.95
+                </span>
+            </td>
+        </tr>
+    </table>
+</div>
+
+<!-- Payment Method - Conditionally render the section if the card tail is available -->
+
+
+<!-- Provide Feedback -->
+<hr aria-hidden="true" class="a-divider-normal"/>
+
+<table class="a-normal">
+    <tr id="wfm-feedback">
+        <td class="a-span7 a-align-center">
+            <span id="wfm-feedback-label">
+                How was your trip?
+            </span>
+        </td>
+        <td class="a-span5 a-text-right a-align-center a-text-bold">
+            
+            
+                
+                
+                    
+                
+            
+            
+                
+            
+            
+                
+            
+            
+                
+            
+            
+                
+            
+            
+                
+            
+            <span id="provide_feedback_button" class="a-button a-button-base"><span class="a-button-inner"><a href="https://wholefoods.co1.qualtrics.com/jfe/form/SV_daIhabGWWMKDaZM?Country=US&amp;Q_Language=EN&amp;VERSION=WFUS&amp;WFDIGR=1&amp;TransactionID=GSUC22EYHC&amp;StoreNumber=10316&amp;TimeShopped=1&amp;CheckoutType=3&amp;DateShopped=2024-02-18" target="_blank" rel="noopener" class="a-button-text">
+                Provide Feedback
+            </a></span></span>
+        </td>
+    </tr>
+</table>
+
+</div>
+
+        
+         <div class="odp-widget-wrapper hidden"></div> 
+    </div>
+
+    <div id="od-ad-container">
+        
+            <div id="f3_food_OrderIdBarcode" class="odp-widget-wrapper celwidget" cel_widget_id="f3_food_OrderIdBarcode">
+
+
+<div>
+    <div>
+        
+            
+
+            
+            
+
+            
+            <div id="wfm-groceries-banner" class="a-image-container a-dynamic-image-container" style="width:100%; height:190px;">
+                <a class="a-link-normal" href="/wfm?_ref=dr_wfm_ad_banner">
+                    <img alt="" src="https://m.media-amazon.com/images/G/01/WholeFoodsMarket/NewGroceryImage0522.jpg"/>
+                </a>
+            </div>
+        
+        
+            <div id="itemized-receipt-barcode-image-container" class="a-image-container a-dynamic-image-container" style="width:100%; height:70px;">
+                <img alt="" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAW4AAAAtCAIAAAABexauAAAMgUlEQVR4XqXPMY7FMAwD0X//S+8WagYa0hAQVs4jHcC/P+WHUNqmtT5T7Ezb2C0XpzT3H9Yn08at9cbxLcoXZ+he+sw0n7gdiQ/njO1b6GwvYmfYtv3dLYyXe5FePYlXmtjdcuMzZSWo7/g+N631mWJn2sZuuTiluf+wPpk2bq03jm9RvjhD99JnpvnE7Uh8OGds30JnexE7w7bt725hvNyL9OpJvNLE7pYbnykrQX3H97lprc8UO9M2dsvFKc39h/XJtHFrvXF8i/LFGbqXPjPNJ25H4sM5Y/sWOtuL2Bm2bX93C+PlXqRXT+KVJna33PhMWQnqO77PTWt9ptiZtrFbLk5p7j+sT6aNW+uN41uUL87QvfSZaT5xOxIfzhnbt9DZXsTOsG37u1sYL/civXoSrzSxu+XGZ8pKUN/xfW5a6zPFzrSN3XJxSnP/YX0ybdxabxzfonxxhu6lz0zziduR+HDO2L6FzvYidoZt29/dwni5F+nVk3ilid0tNz5TVoL6ju9z01qfKXambeyWi1Oa+w/rk2nj1nrj+BblizN0L31mmk/cjsSHc8b2LXS2F7EzbNv+7hbGy71Ir57EK03sbrnxmbIS1Hd8n5vW+kyxM21jt1yc0tx/WJ9MG7fWG8e3KF+coXvpM9N84nYkPpwztm+hs72InWHb9ne3MF7uRXr1JF5pYnfLjc+UlaC+4/vctNZnip1pG7vl4pTm/sP6ZNq4td44vkX54gzdS5+Z5hO3I/HhnLF9C53tRewM27a/u4Xxci/SqyfxShO7W258pqwE9R3f56a1PlPsTNvYLRenNPcf1ifTxq31xvEtyhdn6F76zDSfuB2JD+eM7VvobC9iZ9i2/d0tjJd7kV49iVea2N1y4zNlJajv+D43rfWZYmfaxm65OKW5/7A+mTZurTeOb1G+OEP30mem+cTtSHw4Z2zfQmd7ETvDtu3vbmG83Iv06km80sTulhufKStBfcf3uWmtzxQ70zZ2y8Upzf2H9cm0cWu9cXyL8sUZupc+M80nbkfiwzlj+xY624vYGbZtf3cL4+VepFdP4pUmdrfc+ExZCeo7vs9Na32m2Jm2sVsuTmnuP6xPpo1b643jW5QvztC99JlpPnE7Eh/OGdu30NlexM6wbfu7Wxgv9yK9ehKvNLG75cZnykpQ3/F9blrrM8XOtI3dcnFKc/9hfTJt3FpvHN+ifHGG7qXPTPOJ25H4cM7YvoXO9iJ2hm3b393CeLkX6dWTeKWJ3S03PlNWgvqO73PTWp8pdqZt7JaLU5r7D+uTaePWeuP4FuWLM3QvfWaaT9yOxIdzxvYtdLYXsTNs2/7uFsbLvUivnsQrTexuufGZshLUd3yfm9b6TLEzbWO3XJzS3H9Yn0wbt9Ybx7coX5yhe+kz03zidiQ+nDO2b6GzvYidYdv2d7cwXu5FevUkXmlid8uNz5SVoL7j+9y01meKnWkbu+XilOb+w/pk2ri13ji+RfniDN1Ln5nmE7cj8eGcsX0Lne1F7Azbtr+7hfFyL9KrJ/FKE7tbbnymrAT1Hd/nprU+U+xM29gtF6c09x/WJ9PGrfXG8S3KF2foXvrMNJ+4HYkP54ztW+hsL2Jn2Lb93S2Ml3uRXj2JV5rY3XLjM2UlqO/4Pjet9ZliZ9rGbrk4pbn/sD6ZNm6tN45vUb44Q/fSZ6b5xO1IfDhnbN9CZ3sRO8O27e9uYbzci/TqSbzSxO6WG58pK0F9x/e5aa3PFDvTNnbLxSnN/Yf1ybRxa71xfIvyxRm6lz4zzSduR+LDOWP7Fjrbi9gZtm1/dwvj5V6kV0/ilSZ2t9z4TFkJ6ju+z01rfabYmbaxWy5Oae4/rE+mjVvrjeNblC/O0L30mWk+cTsSH84Z27fQ2V7EzrBt+7tbGC/3Ir16Eq80sbvlxmfKSlDf8X1uWuszxc60jd1ycUpz/2F9Mm3cWm8c36J8cYbupc9M84nbkfhwzti+hc72InaGbdvf3cJ4uRfp1ZN4pYndLTc+U1aC+o7vc9Nanyl2pm3slotTmvsP65Np49Z64/gW5YszdC99ZppP3I7Eh3PG9i10thexM2zb/u4Wxsu9SK+exCtN7G658ZmyEtR3fJ+b1vpMsTNtY7dcnNLcf1ifTBu31hvHtyhfnKF76TPTfOJ2JD6cM7ZvobO9iJ1h2/Z3tzBe7kV69SReaWJ3y43PlJWgvuP73LTWZ4qdaRu75eKU5v7D+mTauLXeOL5F+eIM3UufmeYTtyPx4ZyxfQud7UXsDNu2v7uF8XIv0qsn8UoTu1tufKasBPUd3+emtT5T7Ezb2C0XpzT3H9Yn08at9cbxLcoXZ+he+sw0n7gdiQ/njO1b6GwvYmfYtv3dLYyXe5FePYlXmtjdcuMzZSWo7/g+N631mWJn2sZuuTiluf+wPpk2bq03jm9RvjhD99JnpvnE7Uh8OGds30JnexE7w7bt725hvNyL9OpJvNLE7pYbnykrQX3H97lprc8UO9M2dsvFKc39h/XJtHFrvXF8i/LFGbqXPjPNJ25H4sM5Y/sWOtuL2Bm2bX93C+PlXqRXT+KVJna33PhMWQnqO77PTWt9ptiZtrFbLk5p7j+sT6aNW+uN41uUL87QvfSZaT5xOxIfzhnbt9DZXsTOsG37u1sYL/civXoSrzSxu+XGZ8pKUN/xfW5a6zPFzrSN3XJxSnP/YX0ybdxabxzfonxxhu6lz0zziduR+HDO2L6FzvYidoZt29/dwni5F+nVk3ilid0tNz5TVoL6ju9z01qfKXambeyWi1Oa+w/rk2nj1nrj+BblizN0L31mmk/cjsSHc8b2LXS2F7EzbNv+7hbGy71Ir57EK03sbrnxmbIS1Hd8n5vW+kyxM21jt1yc0tx/WJ9MG7fWG8e3KF+coXvpM9N84nYkPpwztm+hs72InWHb9ne3MF7uRXr1JF5pYnfLjc+UlaC+4/vctNZnip1pG7vl4pTm/sP6ZNq4td44vkX54gzdS5+Z5hO3I/HhnLF9C53tRewM27a/u4Xxci/SqyfxShO7W258pqwE9R3f56a1PlPsTNvYLRenNPcf1ifTxq31xvEtyhdn6F76zDSfuB2JD+eM7VvobC9iZ9i2/d0tjJd7kV49iVea2N1y4zNlJajv+D43rfWZYmfaxm65OKW5/7A+mTZurTeOb1G+OEP30mem+cTtSHw4Z2zfQmd7ETvDtu3vbmG83Iv06km80sTulhufKStBfcf3uWmtzxQ70zZ2y8Upzf2H9cm0cWu9cXyL8sUZupc+M80nbkfiwzlj+xY624vYGbZtf3cL4+VepFdP4pUmdrfc+ExZCeo7vs9Na32m2Jm2sVsuTmnuP6xPpo1b643jW5QvztC99JlpPnE7Eh/OGdu30NlexM6wbfu7Wxgv9yK9ehKvNLG75cZnykpQ3/F9blrrM8XOtI3dcnFKc/9hfTJt3FpvHN+ifHGG7qXPTPOJ25H4cM7YvoXO9iJ2hm3b393CeLkX6dWTeKWJ3S03PlNWgvqO73PTWp8pdqZt7JaLU5r7D+uTaePWeuP4FuWLM3QvfWaaT9yOxIdzxvYtdLYXsTNs2/7uFsbLvUivnsQrTexuufGZshLUd3yfm9b6TLEzbWO3XJzS3H9Yn0wbt9Ybx7coX5yhe+kz03zidiQ+nDO2b6GzvYidYdv2d7cwXu5FevUkXmlid8uNz5SVoL7j+9y01meKnWkbu+XilOb+w/pk2ri13ji+RfniDN1Ln5nmE7cj8eGcsX0Lne1F7Azbtr+7hfFyL9KrJ/FKE7tbbnymrAT1Hd/nprU+U+xM29gtF6c09x/WJ9PGrfXG8S3KF2foXvrMNJ+4HYkP54ztW+hsL2Jn2Lb93S2Ml3uRXj2JV5rY3XLjM2UlqO/4Pjet9ZliZ9rGbrk4pbn/sD6ZNm6tN45vUb44Q/fSZ6b5xO1IfDhnbN9CZ3sRO8O27e9uYbzci/TqSbzSxO6WG58pK0F9x/e5aa3PFDvTNnbLxSnN/Yf1ybRxa71xfIvyxRm6lz4zzSduR+LDOWP7Fjrbi9gZtm1/dwvj5V6kV0/ilSZ2t9z4TFkJ6ju+z01rfabYmbaxWy5Oae4/rE+mjVvrjeNblC/O0L30mWk+cTsSH84Z27fQ2V7EzrBt+7tbGC/3Ir16Eq80sbvlxmfKSlDf8X1uWuszxc60jd1ycUpz/2F9Mm3cWm8c36J8cYbupc9M84nbkfhwzti+hc72InaGbdvf3cJ4uRfp1ZN4pYndLTc+U1b+AdI1JiAEGQ3/AAAAAElFTkSuQmCC"/>
+            </div>
+        
+        
+            <div id="barcodeId-text-container" style="width:100%; text-align:center">
+                <span id="barcode-text-label">
+                    63011031695356992021720240
+                </span>
+            </div>
+        
+        
+            <div id="transactionId-text-container" style="width:100%; text-align:center">
+                <span id="transactionId-text-label">
+                    GSUC22EYHC
+                </span>
+            </div>
+        
+    </div>
+</div>
+
+
+</div>
+
+        
+    </div>
+</div>
+
+
+
+<script>
+    if (typeof uet == 'function')  { uet('af'); }
+</script>
+
+<!--&&&Portal&Delimiter&&&--><!-- sp:end-feature:host-atf -->
+<!-- sp:feature:nav-btf -->
+<!-- NAVYAAN BTF START -->
+
+
+
+
+
+
+  <script type='text/javascript'>(function ($Nav) {
+"use strict";
+
+if (typeof $Nav === 'undefined' || $Nav === null || typeof $Nav.when !== 'function') {
+    return;
+}
+
+$Nav.when('$', 'data', 'flyout.yourAccount', 'sidepanel.csYourAccount',
+          'config')
+    .run("BuyitAgain-YourAccount-SidePanel",
+    function ($, data, yaFlyout, csYourAccount, config) {
+        if (config.disableBuyItAgain) {
+            return;
+        }
+        var render = function (data) {
+            if (data.dramResult) {
+                var widgetHtml = data.dramResult;
+                navbar.sidePanel({
+                    flyoutName: 'yourAccount',
+                    data: {html: widgetHtml}
+                });
+            }
+        };
+
+        var renderBuyItAgain = function (biaData) {
+            if (csYourAccount) {
+                csYourAccount.register(render, biaData);
+            } else {
+                render(biaData);
+            }
+        };
+
+        var truncateAndRestructureYaFlyout = function() {
+            if (window.P) {
+                P.when('A', 'a-truncate').execute(function(A, truncate) {
+                    var truncateElements = A.$('.a-truncate');
+                    A.each(truncateElements, function(element) {
+                        truncate.get(element).update();
+                    });
+                    var recommendationsWidget = document.getElementById('bia-hcb-widget');
+                    if (recommendationsWidget) { 
+                        var navFlyout = recommendationsWidget.parentElement;
+                        var navFlyoutPaddingBottom = parseInt(window.getComputedStyle(navFlyout).getPropertyValue('padding-bottom'));
+                        var navFlyoutContentHeight = navFlyout.clientHeight - navFlyoutPaddingBottom;
+                        while (recommendationsWidget.offsetHeight > navFlyoutContentHeight && recommendationsWidget.offsetHeight > 0){
+                            var recommendations = recommendationsWidget.querySelectorAll('.biaNavFlyoutFaceout');
+                            if (recommendations.length <= 1) {
+                                break;
+                            }
+                            var lastRecommendation = recommendations[recommendations.length - 1];
+                            lastRecommendation.parentElement.removeChild(lastRecommendation);
+                        }
+                    }
+               });
+            }
+        };
+
+        yaFlyout.sidePanel.onData(truncateAndRestructureYaFlyout);
+        yaFlyout.onShow(truncateAndRestructureYaFlyout);
+
+    yaFlyout.onRender(function() {
+            $.ajax({
+                url: '/gp/bia/external/bia-hcb-ajax-handler.html',
+                data: {"biaHcbRid":"0B5GGA052RDJB96RMAEG"},
+                dataType: 'json',
+                timeout: 4*1000,
+                success: renderBuyItAgain,
+                error: function (jqXHR, textStatus, errorThrown) {
+                }
+            });
+        });
+    });
+})(window.$Nav);</script>
+
+
+<script type="text/javascript">
+  window.$Nav && $Nav.when("data").run(function (data) {
+    data({
+      "accountListContent": { "html": "<div id='nav-al-container'><div id='nav-al-profile' class='nav-flyout-content nav-flyout-accessibility'></div><div id='nav-al-wishlist' class='nav-al-column nav-tpl-itemList nav-flyout-content nav-flyout-accessibility'><div class='nav-title' id='nav-al-title' role='heading' aria-level='6'>Your Lists</div><ul><li><a href='/hz/wishlist/ls?triggerElementID=createList&ref_=nav_ListFlyout_navFlyout_createList_lv_redirect' class='nav-link nav-item'><span class='nav-text'>Create a List</span></a></li><li><a href='/registries?ref_=nav_ListFlyout_find' class='nav-link nav-item'><span class='nav-text'>Find a List or Registry</span></a></li><li><a href='/your-books?ref=yb_ip_ysb_d&tabView=saved_books' class='nav-link nav-item'><span class='nav-text'>Your Saved Books</span></a></li></ul></div><div id='nav-al-your-account' class='nav-al-column nav-template nav-flyout-content nav-tpl-itemList nav-flyout-accessibility'><div class='nav-title' role='heading' aria-level='6'>Your Account</div><ul><li><a href='/gp/css/homepage.html?ref_=nav_AccountFlyout_ya' class='nav-link nav-item'><span class='nav-text'>Account</span></a></li><li><a id='nav_prefetch_yourorders' href='/gp/css/order-history?ref_=nav_AccountFlyout_orders' class='nav-link nav-item'><span class='nav-text'>Orders</span></a></li><li><a href='/hz/mobile/mission?ref_=nav_AccountFlyout_ci_mcx_mi_d_nf' class='nav-link nav-item'><span class='nav-text'>Keep Shopping For</span></a></li><li><a href='/gp/yourstore?ref_=nav_AccountFlyout_recs' class='nav-link nav-item'><span class='nav-text'>Recommendations</span></a></li><li><a href='/your-returns?ingress=navm_account_flyout&ref_=nav_AccountFlyout_returns' class='nav-link nav-item'><span class='nav-text'>Returns</span></a></li><li><a href='/gp/history?ref_=nav_AccountFlyout_browsinghistory' class='nav-link nav-item'><span class='nav-text'>Browsing History</span></a></li><li><a href='https://www.amazon.com/slc/hub?ref_=nav_AccountFlyout_sl_ph_navflyout' class='nav-link nav-item'><span class='nav-text'>Your Shopping preferences</span></a></li><li><a href='/b/?node=12766669011&ld=AZUSSOA-yaflyout&ref_=nav_AccountFlyout_cs_sell' class='nav-link nav-item'><span class='nav-text'>Start a Selling Account</span></a></li><li><a href='https://www.amazon.com/credit/landing?ref_=nav_AccountFlyout_ya_amazon_cc_landing_ms' class='nav-link nav-item'><span class='nav-text'>Amazon Credit Cards</span></a></li><li><a href='https://www.amazon.com/your-product-safety-alerts?ref_=nav_AccountFlyout_flyout_bsx_ypsa' class='nav-link nav-item'><span class='nav-text'>Recalls and Product Safety Alerts</span></a></li><li><a href='/gp/video/watchlist?ref_=nav_AccountFlyout_ywl' class='nav-link nav-item'><span class='nav-text'>Watchlist</span></a></li><li><a href='/gp/video/library?ref_=nav_AccountFlyout_yvl' class='nav-link nav-item'><span class='nav-text'>Video Purchases & Rentals</span></a></li><li><a href='/gp/kindle/ku/ku_central?ref_=nav_AccountFlyout_ku' class='nav-link nav-item'><span class='nav-text'>Kindle Unlimited</span></a></li><li><a href='/hz/mycd/myx?pageType=content&ref_=nav_AccountFlyout_myk' class='nav-link nav-item'><span class='nav-text'>Content Library</span></a></li><li><a href='https://www.amazon.com/hz/mycd/digital-console/alldevices?pageType=devices&ref_=nav_accountFlyOut_manage_devices' class='nav-link nav-item'><span class='nav-text'>Devices</span></a></li><li><a href='/gp/subscribe-and-save/manager/viewsubscriptions?ref_=nav_AccountFlyout_sns' class='nav-link nav-item'><span class='nav-text'>Subscribe & Save Items</span></a></li><li><a href='/hz5/yourmembershipsandsubscriptions?ref_=nav_AccountFlyout_digital_subscriptions' class='nav-link nav-item'><span class='nav-text'>Memberships & Subscriptions</span></a></li><li><a href='/gp/subs/primeclub/account/homepage.html?ref_=nav_AccountFlyout_prime' class='nav-link nav-item'><span class='nav-text'>Prime Membership</span></a></li><li><a href='https://health.amazon.com/?ref_=nav_yc_ahi_homepage' class='nav-link nav-item'><span class='nav-text'>Medical Care & Pharmacy</span></a></li><li><a href='https://music.amazon.com?ref=nav_youraccount_cldplyr' class='nav-link nav-item'><span class='nav-text'>Music Library</span></a></li><li><a href='/gp/browse.html?node=11261610011&ref_=nav_AccountFlyout_b2b_reg_bottom' class='nav-link nav-item'><span class='nav-text'>Create Your Free Business Account</span></a></li><li><a href='https://www.amazon.com/hz/contact-us?ref_=nav_AccountFlyout_CS' class='nav-link nav-item'><span class='nav-text'>Customer Service</span></a></li></ul></div></div>" },
+      "tooltipContent": { "html": "" },
+      "signinContent": { "html": "<div id='nav-signin-tooltip'><a href='https://www.amazon.com/ap/signin?openid.return_to=https%3A%2F%2Fwww.amazon.com%2Ffopo%2Forder-details%2Fref%3Dppx_hzod_rd_dt_b_fresh_fopo_rd%2F%3F_encoding%3DUTF8%26_encoding%3DUTF8%26orderID%3D113-0788486-7971417%26ref_%3Dnav_custrec_signin&openid.identity=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0%2Fidentifier_select&openid.assoc_handle=usflex&openid.mode=checkid_setup&openid.claimed_id=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0%2Fidentifier_select&openid.ns=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0' class='nav-action-signin-button' data-nav-role='signin' data-nav-ref='nav_custrec_signin'><span class='nav-action-inner'>Sign in</span></a><div class='nav-signin-tooltip-footer'>New customer? <a href='https://www.amazon.com/ap/register?openid.return_to=https%3A%2F%2Fwww.amazon.com%2Ffopo%2Forder-details%2Fref%3Dppx_hzod_rd_dt_b_fresh_fopo_rd%2F%3F_encoding%3DUTF8%26_encoding%3DUTF8%26orderID%3D113-0788486-7971417%26ref_%3Dnav_custrec_newcust&openid.identity=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0%2Fidentifier_select&openid.assoc_handle=usflex&openid.mode=checkid_setup&openid.claimed_id=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0%2Fidentifier_select&openid.ns=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0' class='nav-a' aria-label='New to Amazon? Start here to create an account'>Start here.</a></div></div>" },
+      "templates": {"itemList":"<# var hasColumns = (function () {  var checkColumns = function (_items) {    if (!_items) {      return false;    }    for (var i=0; i<_items.length; i++) {      if (_items[i].columnBreak || (_items[i].items && checkColumns(_items[i].items))) {        return true;      }    }    return false;  };  return checkColumns(items);}()); #><# if(hasColumns) { #>  <# if(items[0].image && items[0].image.src) { #>    <div class='nav-column nav-column-first nav-column-image'>  <# } else if (items[0].greeting) { #>    <div class='nav-column nav-column-first nav-column-greeting'>  <# } else { #>    <div class='nav-column nav-column-first'>  <# } #><# } #><# var renderItems = function(items) { #>  <# jQuery.each(items, function (i, item) { #>    <# if(hasColumns && item.columnBreak) { #>      <# if(item.image && item.image.src) { #>        </div><div class='nav-column nav-column-notfirst nav-column-break nav-column-image'>      <# } else if (item.greeting) { #>        </div><div class='nav-column nav-column-notfirst nav-column-break nav-column-greeting'>      <# } else { #>        </div><div class='nav-column nav-column-notfirst nav-column-break'>      <# } #>    <# } #>    <# if(item.dividerBefore) { #>      <div class='nav-divider'></div>    <# } #>    <# if(item.text || item.content) { #>      <# if(item.url) { #>        <a href='<#=item.url #>' class='nav-link      <# } else {#>        <span class='      <# } #>      <# if(item.panelKey) { #>        nav-hasPanel      <# } #>      <# if(item.items) { #>        nav-title      <# } #>      <# if(item.decorate == 'carat') { #>        nav-carat      <# } #>      <# if(item.decorate == 'nav-action-button') { #>        nav-action-button      <# } #>      nav-item'      <# if(item.extra) { #>        <#=item.extra #>      <# } #>      <# if(item.id) { #>        id='<#=item.id #>'      <# } #>      <# if(item.dataNavRole) { #>        data-nav-role='<#=item.dataNavRole #>'      <# } #>      <# if(item.dataNavRef) { #>        data-nav-ref='<#=item.dataNavRef #>'      <# } #>      <# if(item.panelKey) { #>        data-nav-panelkey='<#=item.panelKey #>'        role='navigation'        aria-label='<#=item.text#>'      <# } #>      <# if(item.subtextKey) { #>        data-nav-subtextkey='<#=item.subtextKey #>'      <# } #>      <# if(item.image && item.image.height > 16) { #>        style='line-height:<#=item.image.height #>px;'      <# } #>      >      <# if(item.decorate == 'carat') { #>        <i class='nav-icon'></i>      <# } #>      <# if(item.image && item.image.src) { #>        <img class='nav-image' src='<#=item.image.src #>' style='height:<#=item.image.height #>px; width:<#=item.image.width #>px;' />      <# } #>      <# if(item.text) { #>        <span class='nav-text<# if(item.classname) { #> <#=item.classname #><# } #>'><#=item.text#><# if(item.badgeText) { #>          <span class='nav-badge'><#=item.badgeText#></span>        <# } #></span>      <# } else if (item.content) { #>        <span class='nav-content'><# jQuery.each(item.content, function (j, cItem) { #><# if(cItem.url && cItem.text) { #><a href='<#=cItem.url #>' class='nav-a'><#=cItem.text #></a><# } else if (cItem.text) { #><#=cItem.text#><# } #><# }); #></span>      <# } #>      <# if(item.subtext) { #>        <span class='nav-subtext'><#=item.subtext #></span>      <# } #>      <# if(item.url) { #>        </a>      <# } else {#>        </span>      <# } #>    <# } #>    <# if(item.image && item.image.src) { #>      <# if(item.url) { #>        <a href='<#=item.url #>'>       <# } #>      <img class='nav-image'      <# if(item.id) { #>        id='<#=item.id #>'      <# } #>      src='<#=item.image.src #>' <# if (item.alt) { #> alt='<#= item.alt #>'<# } #>/>      <# if(item.url) { #>        </a>       <# } #>    <# } #>    <# if(item.items) { #>      <div class='nav-panel'> <# renderItems(item.items); #> </div>    <# } #>  <# }); #><# }; #><# renderItems(items); #><# if(hasColumns) { #>  </div><# } #>","subnav":"<# if (obj && obj.type === 'vertical') { #>  <# jQuery.each(obj.rows, function (i, row) { #>    <# if (row.flyoutElement === 'button') { #>      <div class='nav_sv_fo_v_button'        <# if (row.elementStyle) { #>          style='<#= row.elementStyle #>'        <# } #>      >        <a href='<#=row.url #>' class='nav-action-button nav-sprite'>          <#=row.text #>        </a>      </div>    <# } else if (row.flyoutElement === 'list' && row.list) { #>      <# jQuery.each(row.list, function (j, list) { #>        <div class='nav_sv_fo_v_column <#=(j === 0) ? 'nav_sv_fo_v_first' : '' #>'>          <ul class='<#=list.elementClass #>'>          <# jQuery.each(list.linkList, function (k, link) { #>            <# if (k === 0) { link.elementClass += ' nav_sv_fo_v_first'; } #>            <li class='<#=link.elementClass #>'>              <# if (link.url) { #>                <a href='<#=link.url #>' class='nav_a'><#=link.text #></a>              <# } else { #>                <span class='nav_sv_fo_v_span'><#=link.text #></span>              <# } #>            </li>          <# }); #>          </ul>        </div>      <# }); #>    <# } else if (row.flyoutElement === 'link') { #>      <# if (row.topSpacer) { #>        <div class='nav_sv_fo_v_clear'></div>      <# } #>      <div class='<#=row.elementClass #>'>        <a href='<#=row.url #>' class='nav_sv_fo_v_lmargin nav_a'>          <#=row.text #>        </a>      </div>    <# } #>  <# }); #><# } else if (obj) { #>  <div class='nav_sv_fo_scheduled'>    <#= obj #>  </div><# } #>","htmlList":"<# jQuery.each(items, function (i, item) { #>  <div class='nav-item'>    <#=item #>  </div><# }); #>"}
+    })
+  })
+</script>
+
+<script type="text/javascript">
+  window.$Nav && $Nav.declare('config.flyoutURL', null);
+  window.$Nav && $Nav.declare('btf.lite');
+  window.$Nav && $Nav.declare('btf.full');
+  window.$Nav && $Nav.declare('btf.exists');
+  (window.AmazonUIPageJS ? AmazonUIPageJS : P).register('navCF');
+</script>
+
+<script type="text/javascript">
+      window.$Nav && $Nav.when('$').run('CBIMarketplaceRedirectOverlayNavyaan', function($) {
+        $.ajax({
+            type: 'POST',
+            url: '/cross_border_interstitial_sp/render',
+            data: JSON.stringify({
+                marketplaceId: 'ATVPDKIKX0DER',
+                localCountryCode: 'US',
+                   customerId: 'AEXAMPLE00000',
+                sessionId: '147\x2D7999693\x2D6862434',
+                deviceType: 'DESKTOP',
+                referrer: '',
+                url: '\x2Ffopo\x2Forder\x2Ddetails\x2Fref\x3Dppx_hzod_rd_dt_b_fresh_fopo_rd',
+                pageType: 'F3OmnichannelPostOrder',
+                languageOfPreference: 'en_US',
+                queryParams: {},
+                interstitialRequestType: 'CBI',
+                weblabTreatmentMap: {"CBI_355055":"C","NARX_INTERSTITIAL_NEW_CX_372291":"C","NARX_INTERSTITIAL_AUI_MIGRATION_446901":"C","TEST_ACS_CONFIGURATION_486322":"C","CROSS_BORDER_INTERSTITIAL_ACS_SHADOW_TESTING_486317":"C","INTERSTITIAL_PROTOTYPE_IP_ADDRESS_BR_598850":"C","NARX_INTERSTITIAL_LAMBDA_CLOUD_AUTH_880645":"C","CBI_ROBOT_MITIGATION_943387":"C","CBI_REDISPLAY_INTERSTITIAL_1008859":"C","CROSS_BORDER_INTERSTITIAL_GEOLOCATION_US_SA_1417380":"C"}
+            }),
+            contentType: "application/json",
+            dataType: "html",
+            success: function(data) {
+                if (data) {
+                    $('body').append(data);
+                }
+            }
+        });
+      });
+  </script>
+  
+<!-- NAVYAAN BTF END -->
+<!-- sp:end-feature:nav-btf -->
+<!-- sp:feature:host-btf -->
+
+
+<!-- Page BTF -->
+<!-- sp:end-feature:host-btf -->
+<!-- sp:feature:aui-preload -->
+<!-- sp:end-feature:aui-preload -->
+<!-- sp:feature:nav-footer -->
+
+  <!-- NAVYAAN FOOTER START -->
+  <!-- WITH MOZART -->
+
+<div id='rhf' class='copilot-secure-display' style='clear: both;' role='complementary' aria-label='Your recently viewed items and featured recommendations'> <div class='rhf-frame' style='display: none;'> <br> <div id='rhf-container'> <div class='rhf-loading-outer'> <table class='rhf-loading-middle'> <tr> <td class='rhf-loading-inner'> <img src='https://m.media-amazon.com/images/G/01/personalization/ybh/loading-4x-gray._CB485916920_.gif'> </td> </tr> </table> </div> <div id='rhf-context'> <script type='application/json'> { "rhfHandlerParams":{"currentPageType":"F3OmnichannelPostOrder","currentSubPageType":"OrderDetails","excludeAsin":"","fieldKeywords":"","k":"","keywords":"","search":"","auditEnabled":"","previewCampaigns":"","forceWidgets":"","searchAlias":""} } </script> </div> </div> <noscript> <div class='rhf-border'> <div class='rhf-header'> Your recently viewed items and featured recommendations </div> <div class='rhf-footer'> <div class='rvi-container'> <div class='ybh-edit'> <div class='ybh-edit-arrow'> &#8250; </div> <div class='ybh-edit-link'> <a href='/gp/history'> View or edit your browsing history </a> </div> </div> <span class='no-rvi-message'> After viewing product detail pages, look here to find an easy way to navigate back to pages you are interested in. </span> </div> </div> </div> </noscript> <div id='rhf-error' style='display: none;'> <div class='rhf-border'> <div class='rhf-header'> Your recently viewed items and featured recommendations </div> <div class='rhf-footer'> <div class='rvi-container'> <div class='ybh-edit'> <div class='ybh-edit-arrow'> &#8250; </div> <div class='ybh-edit-link'> <a href='/gp/history'> View or edit your browsing history </a> </div> </div> <span class='no-rvi-message'> After viewing product detail pages, look here to find an easy way to navigate back to pages you are interested in. </span> </div> </div> </div> </div> <br> </div> </div>
+<div class="navLeftFooter nav-sprite-v1" id="navFooter">
+  <button id="navBackToTop" class="navFooterBackToTopText" aria-label="Back to top"><div class="navFooterBackToTop">Back to top</div></button>
+  
+<div class="navFooterVerticalColumn navAccessibility" role="presentation">
+  <div class="navFooterVerticalRow navAccessibility">
+        <div class="navFooterLinkCol navAccessibility">
+          <div class="navFooterColHead" role="heading" aria-level="6">Get to Know Us</div>
+        <ul>
+            <li class="nav_first">
+              <a href="https://www.amazon.jobs" class="nav_a">Careers</a>
+            </li>
+            <li >
+              <a href="https://email.aboutamazon.com/l/637851/2020-10-29/pd87g?utm_source=gateway&utm_medium=amazonfooters&utm_campaign=newslettersubscribers&utm_content=amazonnewssignup" class="nav_a">Amazon Newsletter</a>
+            </li>
+            <li >
+              <a href="https://www.aboutamazon.com/?utm_source=gateway&utm_medium=footer&token=about" class="nav_a">About Amazon</a>
+            </li>
+            <li >
+              <a href="https://www.amazon.com/b?node=15701038011&ie=UTF8" class="nav_a">Accessibility</a>
+            </li>
+            <li >
+              <a href="https://sustainability.aboutamazon.com/?utm_source=gateway&utm_medium=footer&ref_=susty_footer" class="nav_a">Sustainability</a>
+            </li>
+            <li >
+              <a href="https://www.amazon.com/pr" class="nav_a">Press Center</a>
+            </li>
+            <li >
+              <a href="https://www.amazon.com/ir" class="nav_a">Investor Relations</a>
+            </li>
+            <li >
+              <a href="/gp/browse.html?node=2102313011&ref_=footer_devices" class="nav_a">Amazon Devices</a>
+            </li>
+            <li class="nav_last ">
+              <a href="https://www.amazon.science" class="nav_a">Amazon Science</a>
+            </li>
+        </ul>
+      </div>
+        <div class="navFooterColSpacerInner navAccessibility"></div>
+        <div class="navFooterLinkCol navAccessibility">
+          <div class="navFooterColHead" role="heading" aria-level="6">Make Money with Us</div>
+        <ul>
+            <li class="nav_first">
+              <a href="https://sell.amazon.com/?ld=AZFSSOA_FTSELL-C&ref_=footer_soa" class="nav_a">Sell on Amazon</a>
+            </li>
+            <li >
+              <a href="https://developer.amazon.com" class="nav_a">Sell apps on Amazon</a>
+            </li>
+            <li >
+              <a href="https://supply.amazon.com" class="nav_a">Supply to Amazon</a>
+            </li>
+            <li >
+              <a href="https://sell.amazon.com/brand-registry?ld=AZUSSOA_ABR-FT" class="nav_a">Protect & Build Your Brand</a>
+            </li>
+            <li >
+              <a href="https://affiliate-program.amazon.com/" class="nav_a">Become an Affiliate</a>
+            </li>
+            <li >
+              <a href="https://dspjobhub.com/" class="nav_a">Become a Delivery Driver</a>
+            </li>
+            <li >
+              <a href="https://logistics.amazon.com/marketing?utm_source=amzn&utm_medium=footer&utm_campaign=home" class="nav_a">Start a Package Delivery Business</a>
+            </li>
+            <li >
+              <a href="https://advertising.amazon.com/?ref=ext_amzn_ftr" class="nav_a">Advertise Your Products</a>
+            </li>
+            <li >
+              <a href="/gp/seller-account/mm-summary-page.html?ld=AZFooterSelfPublish&topic=200260520&ref_=footer_publishing" class="nav_a">Self-Publish with Us</a>
+            </li>
+            <li >
+              <a href="https://www.amazon.com/b?node=216188543011" class="nav_a">Become an Amazon Hub Partner</a>
+            </li>
+            <li class="nav_last nav_a_carat">
+              <span class="nav_a_carat" aria-hidden="true">›</span><a href="/b/?node=18190131011&ld=AZUSSOA-seemore&ref_=footer_seemore" class="nav_a">See More Ways to Make Money</a>
+            </li>
+        </ul>
+      </div>
+        <div class="navFooterColSpacerInner navAccessibility"></div>
+        <div class="navFooterLinkCol navAccessibility">
+          <div class="navFooterColHead" role="heading" aria-level="6">Amazon Payment Products</div>
+        <ul>
+            <li class="nav_first">
+              <a href="/iss/credit/rewardscardmember?plattr=CBFOOT&ref_=footer_cbcc" class="nav_a">Amazon Visa</a>
+            </li>
+            <li >
+              <a href="/credit/storecard/member?plattr=PLCCFOOT&ref_=footer_plcc" class="nav_a">Amazon Store Card</a>
+            </li>
+            <li >
+              <a href="/dp/product/B084KP3NG6?plattr=SCFOOT&ref_=footer_ACB" class="nav_a">Amazon Secured Card</a>
+            </li>
+            <li >
+              <a href="/dp/B0DVBL912R?plattr=ACOMFO&ie=UTF-8" class="nav_a">Amazon Business Card</a>
+            </li>
+            <li >
+              <a href="https://www.amazon.com/hp/shopwithpoints/servicing" class="nav_a">Shop with Points</a>
+            </li>
+            <li >
+              <a href="/gp/browse.html?node=3561432011&ref_=footer_ccmp" class="nav_a">Credit Card Marketplace</a>
+            </li>
+            <li >
+              <a href="/gp/browse.html?node=10232440011&ref_=footer_reload_us" class="nav_a">Reload Your Balance</a>
+            </li>
+            <li >
+              <a href="https://www.amazon.com/b/?node=2238192011&ref=shop_footer_payments_gc_desktop" class="nav_a">Gift Cards</a>
+            </li>
+            <li >
+              <a href="/gp/browse.html?node=388305011&ref_=footer_tfx" class="nav_a">Amazon Currency Converter</a>
+            </li>
+            <li class="nav_last ">
+              <a href="/gp/browse.html?node=20338459011&ref_=footer_cbcc_fin" class="nav_a">Promotional Financing</a>
+            </li>
+        </ul>
+      </div>
+        <div class="navFooterColSpacerInner navAccessibility"></div>
+        <div class="navFooterLinkCol navAccessibility">
+          <div class="navFooterColHead" role="heading" aria-level="6">Let Us Help You</div>
+        <ul>
+            <li class="nav_first">
+              <a href="https://www.amazon.com/gp/css/homepage.html?ref_=footer_ya" class="nav_a">Your Account</a>
+            </li>
+            <li >
+              <a href="https://www.amazon.com/gp/css/order-history?ref_=footer_yo" class="nav_a">Your Orders</a>
+            </li>
+            <li >
+              <a href="/gp/help/customer/display.html?nodeId=468520&ref_=footer_shiprates" class="nav_a">Shipping Rates & Policies</a>
+            </li>
+            <li >
+              <a href="/gp/prime?ref_=footer_prime" class="nav_a">Amazon Prime</a>
+            </li>
+            <li >
+              <a href="/gp/css/returns/homepage.html?ref_=footer_hy_f_4" class="nav_a">Returns & Replacements</a>
+            </li>
+            <li >
+              <a href="/hz/mycd/myx?ref_=footer_myk" class="nav_a">Manage Your Content and Devices</a>
+            </li>
+            <li >
+              <a href="https://www.amazon.com/product-safety-alerts?ref_=footer_bsx_ypsa" class="nav_a">Recalls and Product Safety Alerts</a>
+            </li>
+            <li >
+              <a href="/registries?ref_=nav_footer_registry_giftlist_desktop" class="nav_a">Registry & Gift List</a>
+            </li>
+            <li class="nav_last ">
+              <a href="/gp/help/customer/display.html?nodeId=508510&ref_=footer_gw_m_b_he" class="nav_a">Help</a>
+            </li>
+        </ul>
+      </div>
+  </div>
+</div>
+<div class="nav-footer-line"></div>
+
+  <div class="navFooterLine navFooterLinkLine navFooterPadItemLine">
+    <span>
+      <div class="navFooterLine navFooterLogoLine">
+        <a  aria-label="Amazon US Home"   lang="en"  href="/?ref_=footer_logo">
+        <div class="nav-logo-base nav-sprite"></div>
+        </a>
+      </div>
+</span>
+    
+      <span class="icp-container-desktop"><div
+          class="navFooterLine">
+<style type="text/css">
+  #icp-touch-link-language { display: none; }
+</style>
+
+
+<div class="icp-button" id="icp-touch-link-language" >
+<a href="/customer-preferences/edit?ie=UTF8&preferencesReturnUrl=%2F&ref_=footer_lang" class="icp-language-link" aria-label="Choose a language for shopping. Current selection is English. ">
+  <div class="icp-nav-globe-img-2 icp-button-globe-2"></div><span class="icp-color-base">English</span>
+</a>
+<button class="nav-arrow icp-up-down-arrow" aria-controls="nav-flyout-icp-footer-flyout" aria-label="Expand to Change Language or Country"></button>
+</div>
+
+<style type="text/css">
+#icp-touch-link-country { display: none; }
+</style>
+<a href="/customer-preferences/country?ie=UTF8&preferencesReturnUrl=%2F&ref_=footer_icp_cp" role="button" aria-label="Choose a country/region for shopping. The current selection is United States." class="icp-button" id="icp-touch-link-country">
+  <span class="icp-flag-3 icp-flag-3-us"></span><span class="icp-color-base">United States</span>
+</a>
+</div></span>
+    
+  </div>
+  
+  
+  <div class="navFooterLine navFooterLinkLine navFooterDescLine" role="navigation" aria-label="More on Amazon">
+    <div class="navFooterMoreOnAmazon navFooterMoreOnAmazonWrapper" aria-label="More on Amazon">
+      <ul>
+<li class="navFooterDescItem"><a href=https://music.amazon.com?ref=dm_aff_amz_com class="nav_a"><h5 class="navFooterDescItem_heading">Amazon Music</h5><span class="navFooterDescText">Stream millions<br>of songs</span></a></li><li class="navFooterDescSpacer" aria-hidden="true" style="width: 3%"></li>
+<li class="navFooterDescItem"><a href=https://advertising.amazon.com/?ref=footer_advtsing_amzn_com class="nav_a"><h5 class="navFooterDescItem_heading">Amazon Ads</h5><span class="navFooterDescText">Reach customers<br>wherever they<br>spend their time</span></a></li><li class="navFooterDescSpacer" aria-hidden="true" style="width: 3%"></li>
+<li class="navFooterDescItem"><a href=https://www.6pm.com class="nav_a"><h5 class="navFooterDescItem_heading">6pm</h5><span class="navFooterDescText">Score deals<br>on fashion brands</span></a></li><li class="navFooterDescSpacer" aria-hidden="true" style="width: 3%"></li>
+<li class="navFooterDescItem"><a href=https://www.abebooks.com class="nav_a"><h5 class="navFooterDescItem_heading">AbeBooks</h5><span class="navFooterDescText">Books, art<br>& collectibles</span></a></li><li class="navFooterDescSpacer" aria-hidden="true" style="width: 3%"></li>
+<li class="navFooterDescItem"><a href=https://www.acx.com/ class="nav_a"><h5 class="navFooterDescItem_heading">ACX </h5><span class="navFooterDescText">Audiobook Publishing<br>Made Easy</span></a></li><li class="navFooterDescSpacer" aria-hidden="true" style="width: 3%"></li>
+<li class="navFooterDescItem"><a href=https://sell.amazon.com/?ld=AZUSSOA-footer-aff&ref_=footer_sell class="nav_a"><h5 class="navFooterDescItem_heading">Sell on Amazon</h5><span class="navFooterDescText">Start a Selling Account</span></a></li><li class="navFooterDescSpacer" aria-hidden="true" style="width: 3%"></li>
+<li class="navFooterDescItem"><a href=https://www.veeqo.com/?utm_source=amazon&utm_medium=website&utm_campaign=footer class="nav_a"><h5 class="navFooterDescItem_heading">Veeqo</h5><span class="navFooterDescText">Shipping Software<br>Inventory Management</span></a></li></ul>
+
+<ul>
+<li class="navFooterDescItem"><a href=/business?ref_=footer_retail_b2b class="nav_a"><h5 class="navFooterDescItem_heading">Amazon Business</h5><span class="navFooterDescText">Everything For<br>Your Business</span></a></li><li class="navFooterDescSpacer" aria-hidden="true" style="width: 3%"></li>
+<li class="navFooterDescItem"><a href=/alm/storefront?almBrandId=QW1hem9uIEZyZXNo&ref_=footer_aff_fresh class="nav_a"><h5 class="navFooterDescItem_heading">Amazon Fresh</h5><span class="navFooterDescText">Groceries & More<br>Right To Your Door</span></a></li><li class="navFooterDescSpacer" aria-hidden="true" style="width: 3%"></li>
+<li class="navFooterDescItem"><a href=/gp/browse.html?node=20338496011&ref_=footer_amazonglobal class="nav_a"><h5 class="navFooterDescItem_heading">AmazonGlobal</h5><span class="navFooterDescText">Ship Orders<br>Internationally</span></a></li><li class="navFooterDescSpacer" aria-hidden="true" style="width: 3%"></li>
+<li class="navFooterDescItem"><a href=/services?ref_=footer_services class="nav_a"><h5 class="navFooterDescItem_heading">Home Services</h5><span class="navFooterDescText">Experienced Pros<br>Happiness Guarantee</span></a></li><li class="navFooterDescSpacer" aria-hidden="true" style="width: 3%"></li>
+<li class="navFooterDescItem"><a href=https://aws.amazon.com/what-is-cloud-computing/?sc_channel=EL&sc_campaign=amazonfooter class="nav_a"><h5 class="navFooterDescItem_heading">Amazon Web Services</h5><span class="navFooterDescText">Scalable Cloud<br>Computing Services</span></a></li><li class="navFooterDescSpacer" aria-hidden="true" style="width: 3%"></li>
+<li class="navFooterDescItem"><a href=https://www.audible.com class="nav_a"><h5 class="navFooterDescItem_heading">Audible</h5><span class="navFooterDescText">Listen to Books & Original<br>Audio Performances</span></a></li><li class="navFooterDescSpacer" aria-hidden="true" style="width: 3%"></li>
+<li class="navFooterDescItem"><a href=https://www.boxofficemojo.com/?ref_=amzn_nav_ftr class="nav_a"><h5 class="navFooterDescItem_heading">Box Office Mojo</h5><span class="navFooterDescText">Find Movie<br>Box Office Data</span></a></li></ul>
+
+<ul>
+<li class="navFooterDescItem"><a href=https://www.goodreads.com class="nav_a"><h5 class="navFooterDescItem_heading">Goodreads</h5><span class="navFooterDescText">Book reviews<br>& recommendations</span></a></li><li class="navFooterDescSpacer" aria-hidden="true" style="width: 3%"></li>
+<li class="navFooterDescItem"><a href=https://www.imdb.com class="nav_a"><h5 class="navFooterDescItem_heading">IMDb</h5><span class="navFooterDescText">Movies, TV<br>& Celebrities</span></a></li><li class="navFooterDescSpacer" aria-hidden="true" style="width: 3%"></li>
+<li class="navFooterDescItem"><a href=https://pro.imdb.com?ref_=amzn_nav_ftr class="nav_a"><h5 class="navFooterDescItem_heading">IMDbPro</h5><span class="navFooterDescText">Get Info Entertainment<br>Professionals Need</span></a></li><li class="navFooterDescSpacer" aria-hidden="true" style="width: 3%"></li>
+<li class="navFooterDescItem"><a href=https://kdp.amazon.com class="nav_a"><h5 class="navFooterDescItem_heading">Kindle Direct Publishing</h5><span class="navFooterDescText">Indie Digital & Print Publishing<br>Made Easy
+</span></a></li><li class="navFooterDescSpacer" aria-hidden="true" style="width: 3%"></li>
+<li class="navFooterDescItem"><a href=/gp/browse.html?node=13234696011&ref_=_gno_p_foot class="nav_a"><h5 class="navFooterDescItem_heading">Amazon Photos</h5><span class="navFooterDescText">Unlimited Photo Storage<br>Free With Prime</span></a></li><li class="navFooterDescSpacer" aria-hidden="true" style="width: 3%"></li>
+<li class="navFooterDescItem"><a href=https://videodirect.amazon.com/home/landing class="nav_a"><h5 class="navFooterDescItem_heading">Prime Video Direct</h5><span class="navFooterDescText">Video Distribution<br>Made Easy</span></a></li><li class="navFooterDescSpacer" aria-hidden="true" style="width: 3%"></li>
+<li class="navFooterDescItem"><a href=https://www.shopbop.com class="nav_a"><h5 class="navFooterDescItem_heading">Shopbop</h5><span class="navFooterDescText">Designer<br>Fashion Brands</span></a></li></ul>
+
+<ul>
+<li class="navFooterDescItem"><a href=/gp/browse.html?node=10158976011&ref_=footer_wrhsdls class="nav_a"><h5 class="navFooterDescItem_heading">Amazon Resale</h5><span class="navFooterDescText">Great Deals on<br>Quality Used Products </span></a></li><li class="navFooterDescSpacer" aria-hidden="true" style="width: 3%"></li>
+<li class="navFooterDescItem"><a href=https://www.wholefoodsmarket.com class="nav_a"><h5 class="navFooterDescItem_heading">Whole Foods Market</h5><span class="navFooterDescText">America’s Healthiest<br>Grocery Store</span></a></li><li class="navFooterDescSpacer" aria-hidden="true" style="width: 3%"></li>
+<li class="navFooterDescItem"><a href=https://www.woot.com/ class="nav_a"><h5 class="navFooterDescItem_heading">Woot!</h5><span class="navFooterDescText">Deals and <br>Shenanigans</span></a></li><li class="navFooterDescSpacer" aria-hidden="true" style="width: 3%"></li>
+<li class="navFooterDescItem"><a href=https://www.zappos.com class="nav_a"><h5 class="navFooterDescItem_heading">Zappos</h5><span class="navFooterDescText">Shoes &<br>Clothing</span></a></li><li class="navFooterDescSpacer" aria-hidden="true" style="width: 3%"></li>
+<li class="navFooterDescItem"><a href=https://ring.com class="nav_a"><h5 class="navFooterDescItem_heading">Ring</h5><span class="navFooterDescText">Smart Home<br>Security Systems
+</span></a></li><li class="navFooterDescSpacer" aria-hidden="true" style="width: 3%"></li>
+<li class="navFooterDescItem"><a href=https://eero.com/ class="nav_a"><h5 class="navFooterDescItem_heading">eero WiFi</h5><span class="navFooterDescText">Stream 4K Video<br>in Every Room</span></a></li><li class="navFooterDescSpacer" aria-hidden="true" style="width: 3%"></li>
+<li class="navFooterDescItem"><a href=https://blinkforhome.com/?ref=nav_footer class="nav_a"><h5 class="navFooterDescItem_heading">Blink</h5><span class="navFooterDescText">Smart Security<br>for Every Home
+</span></a></li></ul>
+
+<ul>
+<li class="navFooterDescItem" aria-hidden="true">&nbsp;</li>
+<li class="navFooterDescSpacer" aria-hidden="true" style="width: 3%"></li>
+<li class="navFooterDescItem"><a href=https://shop.ring.com/pages/neighbors-app class="nav_a"><h5 class="navFooterDescItem_heading">Neighbors App </h5><span class="navFooterDescText"> Real-Time Crime<br>& Safety Alerts
+</span></a></li><li class="navFooterDescSpacer" aria-hidden="true" style="width: 3%"></li>
+<li class="navFooterDescItem"><a href=https://www.pillpack.com class="nav_a"><h5 class="navFooterDescItem_heading">PillPack</h5><span class="navFooterDescText">Pharmacy Simplified</span></a></li><li class="navFooterDescSpacer" aria-hidden="true" style="width: 3%"></li>
+<li class="navFooterDescItem"><a href=/gp/browse.html?node=12653393011&ref_=footer_usrenew class="nav_a"><h5 class="navFooterDescItem_heading">Amazon Renewed</h5><span class="navFooterDescText">Refurbished tech<br>you can trust</span></a></li><li class="navFooterDescSpacer" aria-hidden="true" style="width: 3%"></li>
+<li class="navFooterDescItem"><a href=https://www.amazon.com/luna/landing-page?ref_=tmp_retail_footer class="nav_a"><h5 class="navFooterDescItem_heading">Amazon Luna</h5><span class="navFooterDescText">Video games from the cloud,<br>no console required</span></a></li><li class="navFooterDescSpacer" aria-hidden="true" style="width: 3%"></li>
+<li class="navFooterDescItem" aria-hidden="true">&nbsp;</li>
+<li class="navFooterDescSpacer" aria-hidden="true" style="width: 3%"></li>
+<li class="navFooterDescItem" aria-hidden="true">&nbsp;</li>
+</ul>
+
+    </div>
+  </div>
+
+  
+<div class="navFooterLine navFooterLinkLine navFooterPadItemLine navFooterCopyright">
+  <ul><li class="nav_first"><a href="/gp/help/customer/display.html?nodeId=508088&ref_=footer_cou" id="" class="nav_a">Conditions of Use</a> </li><li ><a href="/gp/help/customer/display.html?nodeId=GX7NJQ4ZB8MHFRNJ&ref_=footer_privacy" id="" class="nav_a">Privacy Notice</a> </li><li ><a href="/gp/help/customer/display.html?ie=UTF8&nodeId=TnACMrGVghHocjL8KB&ref_=footer_consumer_health_data_privacy" id="" class="nav_a">Consumer Health Data Privacy Disclosure</a> </li><li ><a href="/privacyprefs?ref_=footer_iba" id="" class="nav_a">Your Ads Privacy Choices</a> </li><li class="nav_last"><span id="nav-icon-ccba" class="nav-sprite"></span> </li></ul><span>© 1996-2026, Amazon.com, Inc. or its affiliates</span>
+</div>
+
+  
+</div>
+<div id="sis_pixel_r2" aria-hidden="true" style="height:1px; position: absolute; left: -1000000px; top: -1000000px;"></div><script>(function(a,b){a.attachEvent?a.attachEvent("onload",b):a.addEventListener&&a.addEventListener("load",b,!1)})(window,function(){setTimeout(function(){var el=document.getElementById("sis_pixel_r2");el&&(el.innerHTML='<iframe id="DAsis" src="//s.amazon-adsystem.com/iu3?d=amazon.com&slot=navFooter&a1=Pa0H5rShnQkRIq8WlkMU8f8DQ&a2=01016709f6cafa43f22654d7671acf3924df37dbcdf60879b9dbe25c7920f0251b8f&old_oo=0&ts=1781011804643&s=AYbst1XxdGRX_b2P2yqtUDxeAbSiG9b8Wwbyekudj33T&gdpr_consent=&gdpr_consent_avl=&cb=1781011804643" width="1" height="1" frameborder="0" marginwidth="0" marginheight="0" scrolling="no" tabindex="-1" sandbox></iframe>');var event=new Event("SISPixelCardLoaded");document.dispatchEvent(event);},300)});</script>
+
+  <!-- NAVYAAN FOOTER END -->
+
+<!-- sp:end-feature:nav-footer -->
+<!-- sp:feature:configured-sitewide-assets -->
+<script>
+(window.AmazonUIPageJS ? AmazonUIPageJS : P).when('afterLoad').execute(function() {
+  (window.AmazonUIPageJS ? AmazonUIPageJS : P).load.js('https://m.media-amazon.com/images/I/41L1IVbo18L.js?AUIClients/BotCXMetricsCollectionJSAsset#1387102-T1');
+});
+</script>
+<script>
+(window.AmazonUIPageJS ? AmazonUIPageJS : P).when('afterLoad').execute(function() {
+  (window.AmazonUIPageJS ? AmazonUIPageJS : P).load.js('https://m.media-amazon.com/images/I/41bvOomAKpL.js?AUIClients/LatencyInteractiveAsset');
+});
+</script>
+<script>
+(window.AmazonUIPageJS ? AmazonUIPageJS : P).when('afterLoad').execute(function() {
+  (window.AmazonUIPageJS ? AmazonUIPageJS : P).load.js('https://m.media-amazon.com/images/I/31K7r4R7c1L.js?AUIClients/BotDetectionJSSignalCollectionAsset');
+});
+</script>
+<script>
+(window.AmazonUIPageJS ? AmazonUIPageJS : P).when('afterLoad').execute(function() {
+'use strict';(function(c,z,A){var B=c.ue||{},v=function(){},l=function(c){return function(g,u){u||(u="ERROR");g=g&&g.stack&&g.message?g:JSON.stringify(g);c({logLevel:u,attribution:"MSAVowelsJavascriptAssets",message:g})}}(c.ueLogError||v),t=function(c){return function(g,u){c("MSAVowelsJavascriptAssets:"+g,u)}}(B.count||v),C=function(c){return function(){try{return c.apply(this,arguments)}catch(g){l(g,"FATAL")}}},x=function(){var l=Array.prototype.slice.call(arguments,0);l[0]=C(l[0]);return c.setTimeout.apply(null,
+l)},w=function(){t("invoked",1);var v=function(c,g){c={events:[{data:c}]};c=JSON.stringify(c);g="https://unagi-na.amazon.com/1/events/"+g;navigator&&navigator.sendBeacon?navigator.sendBeacon(g,c):fetch(g,{method:"POST",body:c}).catch(function(c){l(c,"WARN")})},g=function(c){v(c,"com.amazon.Vowels.ClientMetrics")};x(function(){function u(){for(var a=new URLSearchParams,b=0;b<arguments.length;b++){var d=arguments[b],h;for(h in d)a.set(h,d[h])}return a.toString()}function D(){for(var a={},b=0;b<arguments.length;b++){var d=
+arguments[b],h;for(h in d)a[h]=d[h]}return a}function w(a){a=a||0;return 0<=a&&a<=Number.MAX_SAFE_INTEGER?a:0}function B(){var a=/(https:\/\/www\.amazon\.[a-zA-Z]*(?:\.[a-zA-Z]*)?)/i;return H&&I&&a.test(H)?I:"Unknown"}function C(){for(var a={},b=z.querySelectorAll("img"),d=0;d<b.length;d++){var h=J.exec(b[d].currentSrc||b[d].src);if(h){var e=h[1];h=h[2];a[e]||(a[e]={t:h,err_count:0,tot_count:0});a[e].tot_count+=1;b[d].complete&&0===b[d].naturalWidth&&(a[e].err_count+=1)}}return a}function O(a){for(var b=
+{pg_siz:0,m_siz:0,pg_esiz:0,m_esiz:0,ai_siz:0,ai_esiz:0,weblab_metrics:{resource_count:0,id:{}},amazonimage_weblab_metrics:{resource_count:0,id:{}},c_stat:{bc:0}},d=/^https:.*\.(?:(?:ssl-)?images|media)-amazon\.com\/images\//i,h=/^https:\/\/m\.media-amazon\.com\/images\/I\/.*(?:\?aicid=|_AIweblab)/i,e=0;e<a.length;e++){var f=a[e],c=f.name,k=w(f.transferSize),g=w(f.encodedBodySize);b.pg_siz+=k;b.pg_esiz+=g;if(d.test(c)){b.m_siz+=k;b.m_esiz+=g;var m=f;f=b.c_stat;if(E(m)){if("serverTiming"in m&&m.serverTiming&&
+0!==m.serverTiming.length){for(var n=null,l=null,r=null,p=0;p<m.serverTiming.length&&(!n||!l||"Hit"===l&&!r);p++){var q=m.serverTiming[p],y=q.name;"provider"===y&&q.description?n=q.description.toUpperCase():"cdn-cache-hit"===y?l="Hit":"cdn-cache-miss"===y?l="Miss":"cdn-hit-layer"===y&&q.description&&(r=q.description)}m=n||l?{cdn_name:n||"u",cache_status:l||"Unknown",cache_layer:r}:null}else m=null;m&&(n=m.cdn_name,f[n]||(f[n]={no_cs:0,h:0,m:0,ly:{}}),"Hit"===m.cache_status?(f[n].h++,m.cache_layer&&
+(f[n].ly[m.cache_layer]=(f[n].ly[m.cache_layer]||0)+1)):"Miss"===m.cache_status?f[n].m++:f[n].no_cs++)}else f.bc++}h.test(c)&&(b.ai_siz+=k,b.ai_esiz+=g,k=b.amazonimage_weblab_metrics,f=J.exec(c))&&(k.resource_count+=1,g=f[1],f=f[2],k.id[g]||(k.id[g]=f));k=b.weblab_metrics;if(c=P.exec(c))k.resource_count+=1,g=c[1],k.id[g]||(k.id[g]=c[2])}return b}function Q(a,b){if(a&&0!==a.length){var d={pg_siz:0,m_siz:0,pg_esiz:0,m_esiz:0,ai_siz:0,ai_esiz:0,fcp:0,lcp:0,pg_type:B(),dpr:c.devicePixelRatio||0,csm_markers:R(),
+cdn:b,weblab_resource_count:0,weblab:{},ai_weblab_resource_count:0,ai_weblab:{},page_resource_count:a.length};b=p.getEntriesByType("paint");for(var h=0;h<b.length;h++)if("first-contentful-paint"===b[h].name){d.fcp=b[h].startTime;break}var e=O(a),f=C();if(c.PerformanceObserver){var g=new c.PerformanceObserver(function(a){a=a.getEntries();if(0!==a.length){var b=a[a.length-1];a.forEach(function(a){a.element&&"IMG"===a.element.tagName&&b.startTime<a.startTime&&(b=a)});d.lcp=b.startTime;g.disconnect()}});
+try{g.observe({type:"largest-contentful-paint",buffered:!0})}catch(k){}}x(function(){d.pg_siz=e.pg_siz;d.m_siz=e.m_siz;d.ai_siz=e.ai_siz;d.pg_esiz=e.pg_esiz;d.m_esiz=e.m_esiz;d.ai_esiz=e.ai_esiz;d.weblab_resource_count=e.weblab_metrics.resource_count;d.weblab=e.weblab_metrics.id;d.ai_weblab_resource_count=e.amazonimage_weblab_metrics.resource_count;d.ai_weblab=e.amazonimage_weblab_metrics.id;d.c_stat=e.c_stat;d.ai_img_metrics=f;var a=D(F,d);v(a,"com.amazon.Vowels.PageWeightMetrics")},1E3)}}function R(){if(!c.ue||
+!c.ue.markers)return{};var a=c.ue.markers,b=a.tc,d={};Object.keys(a).forEach(function(h){var e=a[h];d[h]=e&&b?Math.max(0,e-b):A});return d}function K(a,b){var d=a.name,h=a.startTime||0,e=a.connectEnd||0,f=a.connectStart||0,c=a.domainLookupEnd||0,k=a.domainLookupStart||0,l=a.requestStart||0,m=a.responseEnd||0,n=a.responseStart||0,p=a.secureConnectionStart||0,u=a.transferSize||0,t=a.duration||0;0>=t&&0<h&&0<m&&(t=m-h);var q={src:d,sy:b+".2023-05-05"};0<=d.indexOf("/images/G/01/msa/vowels/metrics")?
+q.l=r(t):(0<u&&(q.siz=u),0<n-l&&0<n&&0<l&&(q.ttf=r(n-l)),0<m-n&&0<m&&0<n&&(q.con=r(m-n)),0<t&&(q.dur=r(t)));0<c-k&&0<c&&0<k&&(q.dns=r(c-k));0<e-f&&0<e&&0<f&&(q.tcp=r(e-f));0<e-p&&0<e&&0<p&&(q.tls=r(e-p));"serverTiming"in a&&a.serverTiming.slice(0,15).forEach(function(a){var b="st_"+a.name,d=a.description.substring(0,Math.min(64,a.description.length));q[b]=encodeURIComponent(a.duration+";"+d)});a=D(F,q);g(a)}function L(a){var b=D(F,{src:a,error:1}),d=p.now();return fetch(a).then(function(c){var e=
+p.now();var f=c.headers.get("x-cache")||"";f=0<=f.indexOf("cloudfront")?"c":0<=f.indexOf("akamai")?"a":0<=f.indexOf("fastly")?"f":"u";if(!c.ok)throw b.l=r(e-d),b.status=c.status,b.sy=f+".2023-05-05",M(f,b),b;c={name:a,duration:e-d};e=p.getEntriesByName(a);K(1===e.length?e[0]:c,f);return{cdn:f,url:a}},function(a){b.message=a.message;b.sy="u.2023-05-05";M("u",b);throw a;})}function M(a,b){try{var d=new URL(b.src)}catch(e){throw e;}var c=b.status;"u"===a?S(d,c).then(function(a){a.forEach(function(a){b.sy=
+a+".2023-05-05";g(b)})}):g(b)}function S(a,b){var d=[];a=[G(a,"f"),G(a,"c"),G(a,"a")];return c.Promise.all(a.map(T)).then(function(a){a.forEach(function(a){"fulfilled"===a.status?b&&a.value.statusCode===b&&d.push(a.value.cdn):b===A&&d.push(a.reason)});return 0<d.length?d:["u"]}).catch(function(a){l(a,"FATAL")})}function T(a){return a.then(function(a){return{value:a,status:"fulfilled"}},function(a){return{reason:a,status:"rejected"}})}function G(a,b){a.hostname=U[b];return fetch(a).then(function(a){return{cdn:b,
+statusCode:a.status}}).catch(function(a){l(a,"WARN");throw b;})}function E(a){return 0<a.transferSize&&a.transferSize>=a.encodedBodySize}function V(a){for(var b=new RegExp("^https://(.*.(images|ssl-images|media)-amazon.com|"+c.location.hostname+")/images/","i"),d={},h=0,e="",f,g,k=a.length-1;0<=k;k--)E(a[k])&&(f=b.exec(String(a[k].name)))&&3===f.length&&(f=f[1],g=d[f]=(d[f]||0)+1,g>h&&(e=f,h=g));return e}var N=navigator.userAgent,r=Math.round,p=c.performance,H=c.location.origin,I=c.ue_pty,P=/^https:\/\/.*?(?:images|ssl-images|media)-amazon\.com\/images\/W\/([^-]+)-([^/]+)\//i,
+J=/_AIweblab(\d+)(?:,|%2C)(T\d)_/i,F={s:z.domain,u:c.location.pathname,tz:N},U={a:"a.media-amazon.com",c:"c.media-amazon.com",f:"f.media-amazon.com"},W=c.URLSearchParams&&c.fetch&&c.Promise;p&&"function"===typeof p.getEntriesByName&&"function"===typeof p.getEntriesByType&&"function"===typeof p.now&&0>N.toLowerCase().indexOf("firefox")&&W?function(){var a=p.getEntriesByType("resource"),b=V(a)||"m.media-amazon.com";L("https://"+b+"/images/G/01/msa/vowels/metrics.jpg?"+u({time:+new Date,rand:r(1E6*Math.random()).toString()})).then(function(){var a=
+"STID"+r(1E6*Math.random()).toString()+"-"+ +new Date;return L("https://"+b+"/images/G/01/msa/vowels/metrics._"+a+"_.jpg")}).then(function(d){d=d.cdn;t("cdn:"+d,1);if(a===A||0>=a.length)var c=0;else{c="https://"+b+"/images/";var e,f=0;for(e=0;e<a.length&&3>f;e++){var g=a[e];var k=g.name;!E(g)||0!==k.indexOf(c)||0<k.indexOf("/images/G/01/msa/vowels/metrics")||(K(g,d),f++)}c=f}t("resourceCount",c);Q(a,d)},function(a){t("resourceError",1);a instanceof TypeError&&a.message&&a.message.includes("Failed to fetch")?
+l(a,"WARN"):l(a,"ERROR")}).catch(function(a){l(a,"FATAL")})}():t("unsupportedBrowser",1)},4E3)};"loading"!==z.readyState?x(w,1E3):c.addEventListener&&c.addEventListener("DOMContentLoaded",function(){x(w,1E3)});t("registered",1)})(window,document);
+});
+</script>
+<script>
+(window.AmazonUIPageJS ? AmazonUIPageJS : P).when('afterLoad').execute(function() {
+  (window.AmazonUIPageJS ? AmazonUIPageJS : P).load.js('https://m.media-amazon.com/images/I/511wnkyCr7L.js?AUIClients/AmazonLightsaberPageAssets#1334498-T1.1279464-T1');
+});
+</script>
+<link rel="stylesheet" href="https://m.media-amazon.com/images/I/11ZxbGB3PBL.css?AUIClients/WebFlowIngressJs" />
+<script>
+(window.AmazonUIPageJS ? AmazonUIPageJS : P).when('afterLoad').execute(function() {
+  (window.AmazonUIPageJS ? AmazonUIPageJS : P).load.js('https://m.media-amazon.com/images/I/21a1o3dUMiL.js?AUIClients/WebFlowIngressJs');
+});
+</script>
+<script>
+(window.AmazonUIPageJS ? AmazonUIPageJS : P).when('afterLoad').execute(function() {
+  (window.AmazonUIPageJS ? AmazonUIPageJS : P).load.js('https://m.media-amazon.com/images/I/11yU05wG9HL.js?AUIClients/RufusAutomationsDesktop');
+});
+</script>
+<script>
+(window.AmazonUIPageJS ? AmazonUIPageJS : P).when('afterLoad').execute(function() {
+  (window.AmazonUIPageJS ? AmazonUIPageJS : P).load.js('https://m.media-amazon.com/images/I/11hjEQigGEL.js?AUIClients/RufusDeepResearchDesktop');
+});
+</script>
+<!-- sp:end-feature:configured-sitewide-assets -->
+<!-- sp:feature:customer-behavior-js -->
+<script type="text/javascript">if (window.ue && ue.tag) { ue.tag('FWCIMEnabled'); }</script>
+<script type="text/javascript">window.fwcimData = { customerId: 'AEXAMPLE00000' };</script>
+<script>
+(window.AmazonUIPageJS ? AmazonUIPageJS : P).when('afterLoad').execute(function() {
+  (window.AmazonUIPageJS ? AmazonUIPageJS : P).load.js('https://m.media-amazon.com/images/I/81kCF8wuZEL.js?AUIClients/FWCIMAssets');
+});
+</script>
+<!-- sp:end-feature:customer-behavior-js -->
+<!-- sp:feature:csm:body-close -->
+<div id='be' style="display:none;visibility:hidden;"><form name='ue_backdetect' action="get"><input type="hidden" name='ue_back' value='1' /></form>
+
+
+<script type="text/javascript">
+window.ue_ibe = (window.ue_ibe || 0) + 1;
+if (window.ue_ibe === 1) {
+(function(e,c){function h(b,a){f.push([b,a])}function g(b,a){if(b){var c=e.head||e.getElementsByTagName("head")[0]||e.documentElement,d=e.createElement("script");d.async="async";d.src=b;d.setAttribute("crossorigin","anonymous");a&&a.onerror&&(d.onerror=a.onerror);a&&a.onload&&(d.onload=a.onload);c.insertBefore(d,c.firstChild)}}function k(){ue.uels=g;for(var b=0;b<f.length;b++){var a=f[b];g(a[0],a[1])}ue.deffered=1}var f=[];c.ue&&(ue.uels=h,c.ue.attach&&c.ue.attach("load",k))})(document,window);
+
+
+if (window.ue && window.ue.uels) {
+        var cel_widgets = [ { "c":"celwidget" },{ "s":"#nav-swmslot > div", "id_gen":function(elem, index){ return 'nav_sitewide_msg'; } } ];
+
+                ue.uels("https://images-na.ssl-images-amazon.com/images/I/215h87l68bL.js");
+}
+var ue_mbl=ue_csm.ue.exec(function(g,b){function m(c){a=c||{};b.AMZNPerformance=a;a.transition=a.transition||{};a.timing=a.timing||{};if(b.csa){var d;a.timing.transitionStart&&(d=a.timing.transitionStart);a.timing.processStart&&(d=a.timing.processStart);d&&(csa("PageTiming")("mark","nativeTransitionStart",d),csa("PageTiming")("mark","transitionStart",d))}g.ue.exec(n,"csm-android-check")()&&a.tags instanceof Array&&(c=-1!=a.tags.indexOf("usesAppStartTime")||a.transition.type?!a.transition.type&&-1<
+a.tags.indexOf("usesAppStartTime")?"warm-start":void 0:"view-transition",c&&(a.transition.type=c));"reload"===f._nt&&g.ue_orct||"intrapage-transition"===f._nt?e&&e.timing&&e.timing.navigationStart?a.timing.transitionStart=e.timing.navigationStart:delete a.timing.transitionStart:"undefined"===typeof f._nt&&e&&e.timing&&e.timing.navigationStart&&b.history&&"function"===typeof b.History&&"object"===typeof b.history&&b.history.length&&1!=b.history.length&&(a.timing.transitionStart=e.timing.navigationStart);
+c=a.transition;d=f._nt?f._nt:void 0;c.subType=d;b.ue&&b.ue.tag&&b.ue.tag("has-AMZNPerformance");f.isl&&b.uex&&b.uex("at","csm-timing");p()}function q(a){b.ue&&b.ue.count&&b.ue.count("csm-cordova-plugin-failed",1)}function n(){return b.cordova&&b.cordova.platformId&&"android"==b.cordova.platformId}function p(){try{b.P.register("AMZNPerformance",function(){return a})}catch(c){}}function l(){if(!a)return"";ue_mbl.cnt=null;var c=a.timing,d=a.transition,d=["mts",h(c.transitionStart),"mps",h(c.processStart),
+"mtt",d.type,"mtst",d.subType,"mtlt",d.launchType];b.ue&&b.ue.tag&&(c.fr_ovr&&b.ue.tag("fr_ovr"),c.fcp_ovr&&b.ue.tag("fcp_ovr"),d.push("fr_ovr",h(c.fr_ovr),"fcp_ovr",h(c.fcp_ovr)));for(var c="",e=0;e<d.length;e+=2){var f=d[e],g=d[e+1];"undefined"!==typeof g&&(c+="&"+f+"="+g)}return c}function h(a){if("undefined"!==typeof a&&"undefined"!==typeof k)return a-k}function r(b,d){a&&(k=d,a.timing.transitionStart=b,a.transition.type="view-transition",a.transition.subType="ajax-transition",a.transition.launchType=
+"normal",ue_mbl.cnt=l)}var f=g.ue||{},k=g.ue_t0,e=b.performance,a;if(b.P&&b.P.when&&b.P.register)return b.P.when("CSMPlugin").execute(function(a){a.buildAMZNPerformance&&a.buildAMZNPerformance({successCallback:m,failCallback:q})}),{cnt:l,ajax:r}},"mobile-timing")(ue_csm,ue_csm.window);
+
+(function(d){d._uess=function(){var a="";screen&&screen.width&&screen.height&&(a+="&sw="+screen.width+"&sh="+screen.height);var b=function(a){var b=document.documentElement["client"+a];return"CSS1Compat"===document.compatMode&&b||document.body["client"+a]||b},c=b("Width"),b=b("Height");c&&b&&(a+="&vw="+c+"&vh="+b);return a}})(ue_csm);
+
+(function(a){function d(a){c&&c("log",a)}var b=document.ue_backdetect,c=a.csa&&a.csa("Errors",{producerId:"csa",logOptions:{ent:"all"}});a.ue_err.buffer&&c&&(a.ue_err.buffer.forEach(d),a.ue_err.buffer.push=d);b&&b.ue_back&&a.ue&&(a.ue.bfini=b.ue_back.value);a.uet&&a.uet("be");a.onLdEnd&&(window.addEventListener?window.addEventListener("load",a.onLdEnd,!1):window.attachEvent&&window.attachEvent("onload",a.onLdEnd));a.ueh&&a.ueh(0,window,"load",a.onLd,1);a.ue&&a.ue.tag&&(a.ue_furl?(b=a.ue_furl.replace(/\./g,
+"-"),a.ue.tag(b)):a.ue.tag("nofls"))})(ue_csm);
+
+(function(g,h){function d(a,d){var b={};if(!e||!f)try{var c=h.sessionStorage;c?a&&("undefined"!==typeof d?c.setItem(a,d):b.val=c.getItem(a)):f=1}catch(g){e=1}e&&(b.e=1);return b}var b=g.ue||{},a="",f,e,c,a=d("csmtid");f?a="NA":a.e?a="ET":(a=a.val,a||(a=b.oid||"NI",d("csmtid",a)),c=d(b.oid),c.e||(c.val=c.val||0,d(b.oid,c.val+1)),b.ssw=d);b.tabid=a})(ue_csm,ue_csm.window);
+
+(function(a){var e={rc:1,hob:1,hoe:1,ntd:1,rd_:1,_rd:1};"function"===typeof window.addEventListener&&window.addEventListener("pageshow",function(b){if(b&&b.persisted&&(b=+new Date,b={clickTime:b-1,pageVisible:b},"object"===typeof b&&"object"===typeof a.ue.markers&&"object"===typeof a.ue&&"function"===typeof a.uex)){if("function"===typeof a.uet){for(var c in a.ue.markers)!a.ue.markers.hasOwnProperty(c)||c in e||a.uet(c,void 0,void 0,b.pageVisible);a.uet("tc",void 0,void 0,b.clickTime);a.uet("ty",void 0,
+void 0,b.clickTime+2)}(c=document.ue_backdetect)&&c.ue_back&&(a.ue.bfini=+c.ue_back.value+1);a.ue.isBFonMshop=!0;a.ue.isBFCache=!0;a.ue.t0=b.clickTime;a.ue.viz=["visible:0"];"function"===typeof a.ue.tag&&(a.ue.tag("cacheSourceMemory"),a.ue.tag("history-navigation-page-cache"));c=ue_csm.csa&&ue_csm.csa("SPA");var d=ue_csm.csa&&ue_csm.csa("PageTiming");c&&d&&(c("newPage",{transitionType:"history-navigation-page-cache"},{keepPageAttributes:!0}),d("mark","transitionStart",b.clickTime));"function"===typeof a.uex&&
+a.uex("ld",void 0,void 0,a.ue.t.ld);delete a.ue.isBFonMshop;delete a.ue.isBFCache}})})(ue_csm);
+
+ue_csm.ue.exec(function(e,f){var a=e.ue||{},b=a._wlo,d;if(a.ssw){d=a.ssw("CSM_previousURL").val;var c=f.location,b=b?b:c&&c.href?c.href.split("#")[0]:void 0;c=(b||"")===a.ssw("CSM_previousURL").val;!c&&b&&a.ssw("CSM_previousURL",b);d=c?"reload":d?"intrapage-transition":"first-view"}else d="unknown";a._nt=d},"NavTypeModule")(ue_csm,window);
+ue_csm.ue.exec(function(c,a){function g(a){a.run(function(e){d.tag("csm-feature-"+a.name+":"+e);d.isl&&c.uex("at")})}if(a.addEventListener)for(var d=c.ue||{},f=[{name:"touch-enabled",run:function(b){var e=function(){a.removeEventListener("touchstart",c,!0);a.removeEventListener("mousemove",d,!0)},c=function(){b("true");e()},d=function(){b("false");e()};a.addEventListener("touchstart",c,!0);a.addEventListener("mousemove",d,!0)}}],b=0;b<f.length;b++)g(f[b])},"csm-features")(ue_csm,window);
+
+
+(function(a,e){function d(a){b&&b("recordCounter",a.c,a.v)}var c=e.images,b;a.ue_act?(b=a.csa&&a.csa("Metrics",{producerId:"csa",dimensions:{type:a.ue_act}}))&&b("recordMetric","actorType",1):b=a.csa&&a.csa("Metrics",{producerId:"csa"});c&&c.length&&a.ue.count("totalImages",c.length);a.ue.cv.buffer&&b&&(a.ue.cv.buffer.forEach(d),a.ue.cv.buffer.push=d)})(ue_csm,document);
+(function(b){function c(){var f=[];a.log&&a.log.isStub&&a.log.replay(function(a){d(f,a)});a.clog&&a.clog.isStub&&a.clog.replay(function(a){d(f,a)});f.length&&(a._flhs+=1,p&&(a._lpn.csm=(a._lpn.csm||0)+1),q(f))}function h(){a.log&&a.log.isStub&&(a.onflush&&a.onflush.replay&&a.onflush.replay(function(a){a[0]()}),a.onunload&&a.onunload.replay&&a.onunload.replay(function(a){a[0]()}),c())}function d(b,g){var c=g[1],e=g[0],d={};a._lpn[c]=(a._lpn[c]||0)+1;d[c]=e;b.push(d)}function q(a){if(k)a=l(a),b.navigator.sendBeacon(m,
+a);else{a=l(a);var c=new b[e];c.open("POST",m,!0);c.setRequestHeader&&c.setRequestHeader("Content-type","text/plain");c.send(a)}}function l(a){return JSON.stringify({rid:b.ue_id,sid:b.ue_sid,mid:b.ue_mid,mkt:b.ue_mkt,sn:b.ue_sn,reqs:a})}var e="XMLHttpRequest",p=1===b.ue_ddq,a=b.ue,r=b[e]&&"withCredentials"in new b[e],k=b.navigator&&b.navigator.sendBeacon,m="//"+b.ue_furl+"/1/batch/1/OE/",n=b.ue_fci_ft||5E3;a&&(r||k)&&(a._flhs=a._flhs||0,a._lpn=a._lpn||{},a.attach&&(a.attach("beforeunload",a.exec(h,
+"fcli-bfu")),a.attach("pagehide",a.exec(h,"fcli-ph"))),n&&b.setTimeout(a.exec(c,"fcli-t"),n),a._ffci=a.exec(c))})(window);
+
+
+(function(k,c){function l(a,b){return a.filter(function(a){return a.initiatorType==b})}function f(a,c){if(b.t[a]){var g=b.t[a]-b._t0,e=c.filter(function(a){return 0!==a.responseEnd&&m(a)<g}),f=l(e,"script"),h=l(e,"link"),k=l(e,"img"),n=e.map(function(a){return a.name.split("/")[2]}).filter(function(a,b,c){return a&&c.lastIndexOf(a)==b}),q=e.filter(function(a){return a.duration<p}),s=g-Math.max.apply(null,e.map(m))<r|0;"af"==a&&(b._afjs=f.length);return a+":"+[e[d],f[d],h[d],k[d],n[d],q[d],s].join("-")}}
+function m(a){return a.responseEnd-(b._t0-c.timing.navigationStart)}function n(){var a=c[h]("resource"),d=f("cf",a),g=f("af",a),a=f("ld",a);delete b._rt;b._ld=b.t.ld-b._t0;b._art&&b._art();return[d,g,a].join("_")}var p=20,r=50,d="length",b=k.ue,h="getEntriesByType";b._rre=m;b._rt=c&&c.timing&&c[h]&&n})(ue_csm,window.performance);
+
+
+(function(c,d){var b=c.ue,a=d.navigator;b&&b.tag&&a&&(a=a.connection||a.mozConnection||a.webkitConnection)&&a.type&&b.tag("netInfo:"+a.type)})(ue_csm,window);
+
+
+(function(c,d){function h(a,b){for(var c=[],d=0;d<a.length;d++){var e=a[d],f=b.encode(e);if(e[k]){var g=b.metaSep,e=e[k],l=b.metaPairSep,h=[],m=void 0;for(m in e)e.hasOwnProperty(m)&&h.push(m+"="+e[m]);e=h.join(l);f+=g+e}c.push(f)}return c.join(b.resourceSep)}function s(a){var b=a[k]=a[k]||{};b[t]||(b[t]=c.ue_mid);b[u]||(b[u]=c.ue_sid);b[f]||(b[f]=c.ue_id);b.csm=1;a="//"+c.ue_furl+"/1/"+a[v]+"/1/OP/"+a[w]+"/"+a[x]+"/"+h([a],y);if(n)try{n.call(d[p],a)}catch(g){c.ue.sbf=1,(new Image).src=a}else(new Image).src=
+a}function q(){g&&g.isStub&&g.replay(function(a,b,c){a=a[0];b=a[k]=a[k]||{};b[f]=b[f]||c;s(a)});l.impression=s;g=null}if(!(1<c.ueinit)){var k="metadata",x="impressionType",v="foresterChannel",w="programGroup",t="marketplaceId",u="session",f="requestId",p="navigator",l=c.ue||{},n=d[p]&&d[p].sendBeacon,r=function(a,b,c,d){return{encode:d,resourceSep:a,metaSep:b,metaPairSep:c}},y=r("","?","&",function(a){return h(a.impressionData,z)}),z=r("/",":",",",function(a){return a.featureName+":"+h(a.resources,
+A)}),A=r(",","@","|",function(a){return a.id}),g=l.impression;n?q():(l.attach("load",q),l.attach("beforeunload",q));try{d.P&&d.P.register&&d.P.register("impression-client",function(){})}catch(B){c.ueLogError(B,{logLevel:"WARN"})}}})(ue_csm,window);
+
+
+
+var ue_pty = "F3OmnichannelPostOrder";
+
+var ue_spty = "OrderDetails";
+
+
+
+var ue_adb = 4;
+var ue_adb_rtla = 1;
+ue_csm.ue.exec(function(y,a){function t(){if(d&&f){var a;a:{try{a=d.getItem(g);break a}catch(c){}a=void 0}if(a)return b=a,!0}return!1}function u(){if(a.fetch)fetch(m).then(function(a){if(!a.ok)throw Error(a.statusText);return a.text?a.text():null}).then(function(b){b?(-1<b.indexOf("window.ue_adb_chk = 1")&&(a.ue_adb_chk=1),n()):h()})["catch"](h);else e.uels(m,{onerror:h,onload:n})}function h(){b=k;l();if(f)try{d.setItem(g,b)}catch(a){}}function n(){b=1===a.ue_adb_chk?p:k;l();if(f)try{d.setItem(g,
+b)}catch(c){}}function q(){a.ue_adb_rtla&&c&&0<c.ec&&!1===r&&(c.elh=null,ueLogError({m:"Hit Info",fromOnError:1},{logLevel:"INFO",adb:b}),r=!0)}function l(){e.tag(b);e.isl&&a.uex&&uex("at",b);s&&s.updateCsmHit("adb",b);c&&0<c.ec?q():a.ue_adb_rtla&&c&&(c.elh=q)}function v(){return b}if(a.ue_adb){a.ue_fadb=a.ue_fadb||10;var e=a.ue,k="adblk_yes",p="adblk_no",m="https://m.media-amazon.com/images/G/01/csm/showads.v2.js?adspot_=1",b="adblk_unk",d;a:{try{d=a.localStorage;break a}catch(z){}d=void 0}var g=
+"csm:adb",c=a.ue_err,s=e.cookie,f=void 0!==a.localStorage,w=Math.random()>1-1/a.ue_fadb,r=!1,x=t();w||!x?u():l();a.ue_isAdb=v;a.ue_isAdb.unk="adblk_unk";a.ue_isAdb.no=p;a.ue_isAdb.yes=k}},"adb")(document,window);
+
+
+
+
+(function(c,l,m){function h(a){if(a)try{if(a.id)return"//*[@id='"+a.id+"']";var b,d=1,e;for(e=a.previousSibling;e;e=e.previousSibling)e.nodeName===a.nodeName&&(d+=1);b=d;var c=a.nodeName;1!==b&&(c+="["+b+"]");a.parentNode&&(c=h(a.parentNode)+"/"+c);return c}catch(f){return"DETACHED"}}function f(a){if(a&&a.getAttribute)return a.getAttribute(k)?a.getAttribute(k):f(a.parentElement)}var k="data-cel-widget",g=!1,d=[];(c.ue||{}).isBF=function(){try{var a=JSON.parse(localStorage["csm-bf"]||"[]"),b=0<=a.indexOf(c.ue_id);
+a.unshift(c.ue_id);a=a.slice(0,20);localStorage["csm-bf"]=JSON.stringify(a);return b}catch(d){return!1}}();c.ue_utils={getXPath:h,getFirstAscendingWidget:function(a,b){c.ue_cel&&c.ue_fem?!0===g?b(f(a)):d.push({element:a,callback:b}):b()},notifyWidgetsLabeled:function(){if(!1===g){g=!0;for(var a=f,b=0;b<d.length;b++)if(d[b].hasOwnProperty("callback")&&d[b].hasOwnProperty("element")){var c=d[b].callback,e=d[b].element;"function"===typeof c&&"function"===typeof a&&c(a(e))}d=null}},extractStringValue:function(a){if("string"===
+typeof a)return a}}})(ue_csm,window,document);
+
+
+(function(a){a.ue_cel||(a.ue_cel=function(){function m(a,r){r?r.r=u:r={r:u,c:1};D||(!ue_csm.ue_sclog&&r.clog&&b.clog?b.clog(a,r.ns||s,r):r.glog&&b.glog?b.glog(a,r.ns||s,r):b.log(a,r.ns||s,r))}function n(a,b){"function"===typeof p&&p("log",{schemaId:t+".RdCSI.1",eventType:a,clientData:b},{ent:{page:["requestId"]}})}function c(){var a=q.length;if(0<a){for(var r=[],c=0;c<a;c++){var d=q[c].api;d.ready()?(d.on({ts:b.d,ns:s}),g.push(q[c]),m({k:"mso",n:q[c].name,t:b.d()})):r.push(q[c])}q=r}}function f(){if(!f.executed){for(var a=
+0;a<g.length;a++)g[a].api.off&&g[a].api.off({ts:b.d,ns:s});B();m({k:"eod",t0:b.t0,t:b.d()},{c:1,il:1});f.executed=1;for(a=0;a<g.length;a++)q.push(g[a]);g=[];d(v);d(A)}}function B(a){m({k:"hrt",t:b.d()},{c:1,il:1,n:a});y=Math.min(w,e*y);z()}function z(){d(A);A=k(function(){B(!0)},y)}function x(){f.executed||B()}var l=a.window,k=l.setTimeout,d=l.clearTimeout,e=1.5,w=l.ue_cel_max_hrt||3E4,t="robotdetection",q=[],g=[],s=a.ue_cel_ns||"cel",v,A,b=a.ue,F=a.uet,C=a.uex,u=b.rid,D=a.ue_dsbl_cel,h=l.csa,p,y=
+l.ue_cel_hrt_int||3E3,E=l.requestAnimationFrame||function(a){a()};h&&(p=h("Events",{producerId:t}));if(b.isBF)m({k:"bft",t:b.d()});else{"function"==typeof F&&F("bb","csmCELLSframework",{wb:1});k(c,0);b.onunload(f);if(b.onflush)b.onflush(x);v=k(f,6E5);z();"function"==typeof C&&C("ld","csmCELLSframework",{wb:1});return{registerModule:function(a,r){q.push({name:a,api:r});m({k:"mrg",n:a,t:b.d()});c()},reset:function(a){m({k:"rst",t0:b.t0,t:b.d()});q=q.concat(g);g=[];for(var r=q.length,e=0;e<r;e++)q[e].api.off(),
+q[e].api.reset();u=a||b.rid;c();d(v);v=k(f,6E5);f.executed=0},timeout:function(a,b){return k(function(){E(function(){f.executed||a()})},b)},log:m,csaEventLog:n,off:f}}}())})(ue_csm);
+(function(a){a.ue_pdm||!a.ue_cel||a.ue.isBF||(a.ue_pdm=function(){function m(){try{var b=d.screen;if(b){var c={w:b.width,aw:b.availWidth,h:b.height,ah:b.availHeight,cd:b.colorDepth,pd:b.pixelDepth};g&&g.w===c.w&&g.h===c.h&&g.aw===c.aw&&g.ah===c.ah&&g.pd===c.pd&&g.cd===c.cd||(g=c,g.t=t(),g.k="sci",F(g),D&&h("sci",{h:(g.h||"0")+""}))}var k=e.body||{},f=e.documentElement||{},n={w:Math.max(k.scrollWidth||0,k.offsetWidth||0,f.clientWidth||0,f.scrollWidth||0,f.offsetWidth||0),h:Math.max(k.scrollHeight||
+0,k.offsetHeight||0,f.clientHeight||0,f.scrollHeight||0,f.offsetHeight||0)};s&&s.w===n.w&&s.h===n.h||(s=n,s.t=t(),s.k="doi",F(s));w=a.ue_cel.timeout(m,q);A+=1}catch(p){d.ueLogError&&ueLogError(p,{attribution:"csm-cel-page-module",logLevel:"WARN"})}}function n(){x("ebl","default",!1)}function c(){x("efo","default",!0)}function f(){x("ebl","app",!1)}function B(){x("efo","app",!0)}function z(){d.setTimeout(function(){e[E]?x("ebl","pageviz",!1):x("efo","pageviz",!0)},0)}function x(a,b,c){v!==c&&(F({k:a,
+t:t(),s:b},{ff:!0===c?0:1}),D&&h(a,{t:(t()||"0")+"",s:b}));v=c}function l(){b.attach&&(p&&b.attach(y,z,e),G&&P.when("mash").execute(function(a){a&&a.addEventListener&&(a.addEventListener("appPause",f),a.addEventListener("appResume",B))}),b.attach("blur",n,d),b.attach("focus",c,d))}function k(){b.detach&&(p&&b.detach(y,z,e),G&&P.when("mash").execute(function(a){a&&a.removeEventListener&&(a.removeEventListener("appPause",f),a.removeEventListener("appResume",B))}),b.detach("blur",n,d),b.detach("focus",
+c,d))}var d=a.window,e=a.document,w,t,q,g,s,v=null,A=0,b=a.ue,F=a.ue_cel.log,C=a.uet,u=a.uex,D=d.csa,h=a.ue_cel.csaEventLog,p=!!b.pageViz,y=p&&b.pageViz.event,E=p&&b.pageViz.propHid,G=d.P&&d.P.when;"function"==typeof C&&C("bb","csmCELLSpdm",{wb:1});return{on:function(a){q=a.timespan||500;t=a.ts;l();a=d.location;F({k:"pmd",o:a.origin,p:a.pathname,t:t()});m();"function"==typeof u&&u("ld","csmCELLSpdm",{wb:1})},off:function(a){clearTimeout(w);k();b.count&&b.count("cel.PDM.TotalExecutions",A)},ready:function(){return e.body&&
+a.ue_cel&&a.ue_cel.log},reset:function(){g=s=null}}}(),a.ue_cel&&a.ue_cel.registerModule("page module",a.ue_pdm))})(ue_csm);
+(function(a){a.ue_vpm||!a.ue_cel||a.ue.isBF||(a.ue_vpm=function(){function m(){var a=z(),b={w:k.innerWidth,h:k.innerHeight,x:k.pageXOffset,y:k.pageYOffset};c&&c.w==b.w&&c.h==b.h&&c.x==b.x&&c.y==b.y||(b.t=a,b.k="vpi",c=b,e(c,{clog:1}),s&&v("vpi",{t:(c.t||"0")+"",h:(c.h||"0")+"",y:(c.y||"0")+"",w:(c.w||"0")+"",x:(c.x||"0")+""}));f=0;x=z()-a;l+=1}function n(){f||(f=a.ue_cel.timeout(m,B))}var c,f,B,z,x=0,l=0,k=a.window,d=a.ue,e=a.ue_cel.log,w=a.uet,t=a.uex,q=d.attach,g=d.detach,s=k.csa,v=a.ue_cel.csaEventLog;
+"function"==typeof w&&w("bb","csmCELLSvpm",{wb:1});return{on:function(a){z=a.ts;B=a.timespan||100;m();q&&(q("scroll",n),q("resize",n));"function"==typeof t&&t("ld","csmCELLSvpm",{wb:1})},off:function(a){clearTimeout(f);g&&(g("scroll",n),g("resize",n));d.count&&(d.count("cel.VPI.TotalExecutions",l),d.count("cel.VPI.TotalExecutionTime",x),d.count("cel.VPI.AverageExecutionTime",x/l))},ready:function(){return a.ue_cel&&a.ue_cel.log},reset:function(){c=void 0},getVpi:function(){return c}}}(),a.ue_cel&&
+a.ue_cel.registerModule("viewport module",a.ue_vpm))})(ue_csm);
+(function(a){if(!a.ue_fem&&a.ue_cel&&a.ue_utils){var m=a.ue||{},n=a.window,c=n.document;!m.isBF&&!a.ue_fem&&c.querySelector&&n.getComputedStyle&&[].forEach&&(a.ue_fem=function(){function f(a,b){return a>b?3>a-b:3>b-a}function B(a,b){var c=n.pageXOffset,d=n.pageYOffset,k;a:{try{if(a){var e=a.getBoundingClientRect(),g,m=0===a.offsetWidth&&0===a.offsetHeight;c:{for(var h=a.parentNode,p=e.left||0,w=e.top||0,q=e.width||0,s=e.height||0;h&&h!==document.body;){var l;d:{try{var r=void 0;if(h)var t=h.getBoundingClientRect(),
+r={x:t.left||0,y:t.top||0,w:t.width||0,h:t.height||0};else r=void 0;l=r;break d}catch(I){}l=void 0}var u=window.getComputedStyle(h),v="hidden"===u.overflow,x=v||"hidden"===u.overflowX,y=v||"hidden"===u.overflowY,z=w+s-1<l.y+1||w+1>l.y+l.h-1;if((p+q-1<l.x+1||p+1>l.x+l.w-1)&&x||z&&y){g=!0;break c}h=h.parentNode}g=!1}k={x:e.left+c||0,y:e.top+d||0,w:e.width||0,h:e.height||0,d:(m||g)|0}}else k=void 0;break a}catch(J){}k=void 0}if(k&&!a.cel_b)a.cel_b=k,D({n:a.getAttribute(A),w:a.cel_b.w,h:a.cel_b.h,d:a.cel_b.d,
+x:a.cel_b.x,y:a.cel_b.y,t:b,k:"ewi",cl:a.className},{clog:1});else{if(c=k)c=a.cel_b,d=k,c=d.d===c.d&&1===d.d?!1:!(f(c.x,d.x)&&f(c.y,d.y)&&f(c.w,d.w)&&f(c.h,d.h)&&c.d===d.d);c&&(a.cel_b=k,D({n:a.getAttribute(A),w:a.cel_b.w,h:a.cel_b.h,d:a.cel_b.d,x:a.cel_b.x,y:a.cel_b.y,t:b,k:"ewi"},{clog:1}))}}function z(d,e){var f;f=d.c?c.getElementsByClassName(d.c):d.id?[c.getElementById(d.id)]:c.querySelectorAll(d.s);d.w=[];for(var g=0;g<f.length;g++){var h=f[g];if(h){if(!h.getAttribute(A)){var l=h.getAttribute("cel_widget_id")||
+(d.id_gen||u)(h,g)||h.id;h.setAttribute(A,l)}d.w.push(h);k(Q,h,e)}}!1===C&&(F++,F===b.length&&(C=!0,a.ue_utils.notifyWidgetsLabeled()))}function x(a,b){h.contains(a)||D({n:a.getAttribute(A),t:b,k:"ewd"},{clog:1})}function l(a){K.length&&ue_cel.timeout(function(){if(s){for(var b=R(),c=!1;R()-b<g&&!c;){for(c=S;0<c--&&0<K.length;){var d=K.shift();T[d.type](d.elem,d.time)}c=0===K.length}U++;l(a)}},0)}function k(a,b,c){K.push({type:a,elem:b,time:c})}function d(a,c){for(var d=0;d<b.length;d++)for(var e=
+b[d].w||[],h=0;h<e.length;h++)k(a,e[h],c)}function e(){M||(M=a.ue_cel.timeout(function(){M=null;var c=v();d(W,c);for(var e=0;e<b.length;e++)k(X,b[e],c);0===b.length&&!1===C&&(C=!0,a.ue_utils.notifyWidgetsLabeled());l(c)},q))}function w(){M||N||(N=a.ue_cel.timeout(function(){N=null;var a=v();d(Q,a);l(a)},q))}function t(){return y&&E&&h&&h.contains&&h.getBoundingClientRect&&v}var q=50,g=4.5,s=!1,v,A="data-cel-widget",b=[],F=0,C=!1,u=function(){},D=a.ue_cel.log,h,p,y,E,G=n.MutationObserver||n.WebKitMutationObserver||
+n.MozMutationObserver,r=!!G,H,I,O="DOMAttrModified",L="DOMNodeInserted",J="DOMNodeRemoved",N,M,K=[],U=0,S=null,W="removedWidget",X="updateWidgets",Q="processWidget",T,V=n.performance||{},R=V.now&&function(){return V.now()}||function(){return Date.now()};"function"==typeof uet&&uet("bb","csmCELLSfem",{wb:1});return{on:function(d){function k(){if(t()){T={removedWidget:x,updateWidgets:z,processWidget:B};if(r){var a={attributes:!0,subtree:!0};H=new G(w);I=new G(e);H.observe(h,a);I.observe(h,{childList:!0,
+subtree:!0});I.observe(p,a)}else y.call(h,O,w),y.call(h,L,e),y.call(h,J,e),y.call(p,L,w),y.call(p,J,w);e()}}h=c.body;p=c.head;y=h.addEventListener;E=h.removeEventListener;v=d.ts;b=a.cel_widgets||[];S=d.bs||5;m.deffered?k():m.attach&&m.attach("load",k);"function"==typeof uex&&uex("ld","csmCELLSfem",{wb:1});s=!0},off:function(){t()&&(I&&(I.disconnect(),I=null),H&&(H.disconnect(),H=null),E.call(h,O,w),E.call(h,L,e),E.call(h,J,e),E.call(p,L,w),E.call(p,J,w));m.count&&m.count("cel.widgets.batchesProcessed",
+U);s=!1},ready:function(){return a.ue_cel&&a.ue_cel.log},reset:function(){b=a.cel_widgets||[]}}}(),a.ue_cel&&a.ue_fem&&a.ue_cel.registerModule("features module",a.ue_fem))}})(ue_csm);
+(function(a){!a.ue_mcm&&a.ue_cel&&a.ue_utils&&!a.ue.isBF&&(a.ue_mcm=function(){function m(a,d){var e=a.srcElement||a.target||{},f={k:n,w:(d||{}).ow||(B.body||{}).scrollWidth,h:(d||{}).oh||(B.body||{}).scrollHeight,t:(d||{}).ots||c(),x:a.pageX,y:a.pageY,p:l.getXPath(e),n:e.nodeName};z&&"function"===typeof z.now&&a.timeStamp&&(f.dt=(d||{}).odt||z.now()-a.timeStamp,f.dt=parseFloat(f.dt.toFixed(2)));a.button&&(f.b=a.button);e.href&&(f.r=l.extractStringValue(e.href));e.id&&(f.i=e.id);e.className&&e.className.split&&
+(f.c=e.className.split(/\s+/));x(f,{c:1})}var n="mcm",c,f=a.window,B=f.document,z=f.performance,x=a.ue_cel.log,l=a.ue_utils;return{on:function(k){c=k.ts;a.ue_cel_stub&&a.ue_cel_stub.replayModule(n,m);f.addEventListener&&f.addEventListener("mousedown",m,!0)},off:function(a){f.addEventListener&&f.removeEventListener("mousedown",m,!0)},ready:function(){return a.ue_cel&&a.ue_cel.log},reset:function(){}}}(),a.ue_cel&&a.ue_cel.registerModule("mouse click module",a.ue_mcm))})(ue_csm);
+(function(a){a.ue_mmm||!a.ue_cel||a.ue.isBF||(a.ue_mmm=function(m){function n(a,b){var c={x:a.pageX||a.x||0,y:a.pageY||a.y||0,t:l()};!b&&p&&(c.t-p.t<B||c.x==p.x&&c.y==p.y)||(p=c,u.push(c))}function c(){if(u.length){F=H.now();for(var a=0;a<u.length;a++){var c=u[a],d=a;y=u[h];E=c;var e=void 0;if(!(e=2>d)){e=void 0;a:if(u[d].t-u[d-1].t>f)e=0;else{for(e=h+1;e<d;e++){var g=y,k=E,l=u[e];G=(k.x-g.x)*(g.y-l.y)-(g.x-l.x)*(k.y-g.y);if(G*G/((k.x-g.x)*(k.x-g.x)+(k.y-g.y)*(k.y-g.y))>z){e=0;break a}}e=1}e=!e}(r=
+e)?h=d-1:D.pop();D.push(c)}C=H.now()-F;s=Math.min(s,C);v=Math.max(v,C);A=(A*b+C)/(b+1);b+=1;q({k:x,e:D,min:Math.floor(1E3*s),max:Math.floor(1E3*v),avg:Math.floor(1E3*A)},{c:1});u=[];D=[];h=0}}var f=100,B=20,z=25,x="mmm1",l,k,d=a.window,e=d.document,w=d.setInterval,t=a.ue,q=a.ue_cel.log,g,s=1E3,v=0,A=0,b=0,F,C,u=[],D=[],h=0,p,y,E,G,r,H=m&&m.now&&m||Date.now&&Date||{now:function(){return(new Date).getTime()}};return{on:function(a){l=a.ts;k=a.ns;t.attach&&t.attach("mousemove",n,e);g=w(c,3E3)},off:function(a){k&&
+(p&&n(p,!0),c());clearInterval(g);t.detach&&t.detach("mousemove",n,e)},ready:function(){return a.ue_cel&&a.ue_cel.log},reset:function(){u=[];D=[];h=0;p=null}}}(window.performance),a.ue_cel&&a.ue_cel.registerModule("mouse move module",a.ue_mmm))})(ue_csm);
+
+
+
+ue_csm.ue.exec(function(b,c){var e=function(){},f=function(){return{send:function(b,d){if(d&&b){var a;if(c.XDomainRequest)a=new XDomainRequest,a.onerror=e,a.ontimeout=e,a.onprogress=e,a.onload=e,a.timeout=0;else if(c.XMLHttpRequest){if(a=new XMLHttpRequest,!("withCredentials"in a))throw"";}else a=void 0;if(!a)throw"";a.open("POST",b,!0);a.setRequestHeader&&a.setRequestHeader("Content-type","text/plain");a.send(d)}},isSupported:!0}}(),g=function(){return{send:function(c,d){if(c&&d)if(navigator.sendBeacon(c,
+d))b.ue_sbuimp&&b.ue&&b.ue.ssw&&b.ue.ssw("eelsts","scs");else throw"";},isSupported:!!navigator.sendBeacon&&!(c.cordova&&c.cordova.platformId&&"ios"==c.cordova.platformId)}}();b.ue._ajx=f;b.ue._sBcn=g},"Transportation-clients")(ue_csm,window);
+ue_csm.ue.exec(function(b,l){function B(){for(var a=0;a<arguments.length;a++){var c=arguments[a];try{var g;if(c.isSupported){var f=t.buildPayload(k,e);g=c.send(J,f)}else throw dummyException;return g}catch(d){}}a={m:"All supported clients failed",attribution:"CSMSushiClient_TRANSPORTATION_FAIL",f:"sushi-client.js",logLevel:"ERROR"};b.ue_err.buffer&&b.ue_err.buffer.push(a)}function m(){if(e.length){for(var a=0;a<n.length;a++)n[a]();B(d._sBcn||{},d._ajx||{});e=[];h={};k={};u=v=q=w=0}}function K(){var a=
+new Date,c=function(a){return 10>a?"0"+a:a};return Date.prototype.toISOString?a.toISOString():a.getUTCFullYear()+"-"+c(a.getUTCMonth()+1)+"-"+c(a.getUTCDate())+"T"+c(a.getUTCHours())+":"+c(a.getUTCMinutes())+":"+c(a.getUTCSeconds())+"."+String((a.getUTCMilliseconds()/1E3).toFixed(3)).slice(2,5)+"Z"}function x(a){try{return JSON.stringify(a)}catch(c){}return null}function C(a,c,g,f){var p=!1;f=f||{};r++;if(r==D){var s={m:"Max number of Sushi Logs exceeded",f:"sushi-client.js",logLevel:"ERROR",attribution:"CSMSushiClient_MAX_CALLS"};
+b.ue_err.buffer&&b.ue_err.buffer.push(s)}if(s=!(r>=D))(s=a&&-1<a.constructor.toString().indexOf("Object")&&c&&-1<c.constructor.toString().indexOf("String")&&g&&-1<g.constructor.toString().indexOf("String"))||L++;s&&(d.count&&d.count("Event:"+g,1),a.producerId=a.producerId||c,a.schemaId=a.schemaId||g,a.timestamp=K(),c=Date.now?Date.now():+new Date,g=Math.random().toString().substring(2,12),a.messageId=b.ue_id+"-"+c+"-"+g,f&&!f.ssd&&(a.sessionId=a.sessionId||b.ue_sid,a.requestId=a.requestId||b.ue_id,
+a.obfuscatedMarketplaceId=a.obfuscatedMarketplaceId||b.ue_mid),(c=x(a))?(c=c.length,(e.length==M||q+c>N)&&m(),q+=c,a={data:t.compressEvent(a)},e.push(a),(f||{}).n?0===E?m():u||(u=l.setTimeout(m,E)):v||(v=l.setTimeout(m,O)),p=!0):p=!1);!p&&b.ue_int&&console.error("Invalid JS Nexus API call");return p}function F(){if(!G){for(var a=0;a<y.length;a++)y[a]();for(a=0;a<n.length;a++)n[a]();e.length&&(b.ue_sbuimp&&b.ue&&b.ue.ssw&&(a=x({dct:k,evt:e}),b.ue.ssw("eeldata",a),b.ue.ssw("eelsts","unk")),B(d._sBcn||
+{}));G=!0}}function H(a){y.push(a)}function I(a){n.push(a)}var D=1E3,M=499,N=524288,z=function(){},d=b.ue||{},P=b.uex||z;(b.uet||z)("bb","ue_sushi_v1",{wb:1});var J=b.ue_surl||"https://unagi-na.amazon.com/1/events/com.amazon.csm.nexusclient.gamma",Q=["messageId","timestamp"],A="#",e=[],h={},k={},q=0,w=0,L=0,r=0,y=[],n=[],G=!1,u,v,E=void 0===b.ue_hpsi?1E3:b.ue_hpsi,O=void 0===b.ue_lpsi?1E4:b.ue_lpsi,t=function(){function a(a){h[a]=A+w++;k[h[a]]=a;return h[a]}function c(b){if(!(b instanceof Function)){if(b instanceof
+Array){for(var f=[],d=b.length,e=0;e<d;e++)f[e]=c(b[e]);return f}if(b instanceof Object){f={};for(d in b)b.hasOwnProperty(d)&&(f[h[d]?h[d]:a(d)]=-1===Q.indexOf(d)?c(b[d]):b[d]);return f}return"string"===typeof b&&(b.length>(A+w).length||b.charAt(0)===A)?h[b]?h[b]:a(b):b}}return{compressEvent:c,buildPayload:function(){return x({cs:{dct:k},events:e})}}}();(function(){if(d.event&&d.event.isStub){if(b.ue_sbuimp&&b.ue&&b.ue.ssw){var a=b.ue.ssw("eelsts").val;if(a&&"unk"===a&&(a=b.ue.ssw("eeldata").val)){var c;
+a:{try{c=JSON.parse(a);break a}catch(g){}c=null}c&&c.evt instanceof Array&&c.dct instanceof Object&&(e=c.evt,k=c.dct,e&&k&&(m(),b.ue.ssw("eeldata","{}"),b.ue.ssw("eelsts","scs")))}}d.event.replay(function(a){a[3]=a[3]||{};a[3].n=1;C.apply(this,a)});d.onSushiUnload.replay(function(a){H(a[0])});d.onSushiFlush.replay(function(a){I(a[0])})}})();d.attach("beforeunload",F);d.attach("pagehide",F);d._cmps=t;d.event=C;d.event.reset=function(){r=0};d.onSushiUnload=H;d.onSushiFlush=I;try{l.P&&l.P.register&&
+l.P.register("sushi-client",z)}catch(R){b.ueLogError(R,{logLevel:"WARN"})}P("ld","ue_sushi_v1",{wb:1})},"Nxs-JS-Client")(ue_csm,window);
+
+
+ue_csm.ue_unrt = 1500;
+(function(d,b,q){function r(a,b){var c=a.srcElement||a.target||{};e.getXPath(c);c.href&&e.extractStringValue(c.href);c.className&&c.className.split&&c.className.split(/\s+/);f+=1;e.getFirstAscendingWidget(c,function(a){ue.count("unresponsiveClicks",1)})}function t(a){if(!u(a.srcElement||a.target)){h+=1;k=!0;var s=n=d.ue.d(),c;l&&"function"===typeof l.now&&a.timeStamp&&(c=l.now()-a.timeStamp,c=parseFloat(c.toFixed(2)));p=b.setTimeout(function(){r(a,{t:s,dt:c})},v)}}function w(a){if(a){var b=a.filter(x);
+a.length!==b.length&&(m=!0,d.ue.d(),k&&m&&(g(),m=!1))}}function x(a){if(!a)return!1;var b="characterData"===a.type?a.target.parentElement:a.target;if(!b||!b.hasAttributes||!b.attributes)return!1;var c={"class":"gw-clock gw-clock-aria s-item-container-height-auto feed-carousel using-mouse kfs-inner-container".split(" "),id:["dealClock","deal_expiry_timer","timer"],role:["timer"]},d=!1;Object.keys(c).forEach(function(a){var e=b.attributes[a]?b.attributes[a].value:"";(c[a]||"").forEach(function(a){-1!==
+e.indexOf(a)&&(d=!0)})});return d}function u(a){if(!a)return!1;var b=(e.extractStringValue(a.nodeName)||"").toLowerCase(),c=(e.extractStringValue(a.type)||"").toLowerCase(),d=(e.extractStringValue(a.href)||"").toLowerCase();a=(e.extractStringValue(a.id)||"").toLowerCase();var f="checkbox color date datetime-local email file month number password radio range reset search tel text time url week".split(" ");if(-1!==["select","textarea","html"].indexOf(b)||"input"===b&&-1!==f.indexOf(c)||"a"===b&&-1!==
+d.indexOf("http")||-1!==["sitbreaderrightpageturner","sitbreaderleftpageturner","sitbreaderpagecontainer"].indexOf(a))return!0}function g(){k=!1;n=0;b.clearTimeout(p)}function y(){b.ue.onunload(function(){ue.count("armored-cxguardrails.unresponsive-clicks.violations",f);ue.count("armored-cxguardrails.unresponsive-clicks.violationRate",f/h*100||0)})}if(b.MutationObserver&&b.addEventListener&&Object.keys&&d&&d.ue&&d.ue.log&&d.ue_unrt&&d.ue_utils){var v=d.ue_unrt,l=b.performance,e=d.ue_utils,k=!1,n=
+0,p=0,m=!1,f=0,h=0;b.addEventListener&&(b.addEventListener("mousedown",t,!0),b.addEventListener("beforeunload",g,!0),b.addEventListener("visibilitychange",g,!0),b.addEventListener("pagehide",g,!0));b.ue&&b.ue.event&&b.ue.onSushiUnload&&b.ue.onunload&&y();(new MutationObserver(w)).observe(q,{childList:!0,attributes:!0,characterData:!0,subtree:!0})}})(ue_csm,window,document);
+
+
+ue_csm.ue.exec(function(g,e){if(e.ue_err){var f="";e.ue_err.errorHandlers||(e.ue_err.errorHandlers=[]);e.ue_err.errorHandlers.push({name:"fctx",handler:function(a){if(!a.logLevel||"FATAL"===a.logLevel)if(f=g.getElementsByTagName("html")[0].innerHTML){var b=f.indexOf("var ue_t0=ue_t0||+new Date();");if(-1!==b){var b=f.substr(0,b).split(String.fromCharCode(10)),d=Math.max(b.length-10-1,0),b=b.slice(d,b.length-1);a.fcsmln=d+b.length+1;a.cinfo=a.cinfo||{};for(var c=0;c<b.length;c++)a.cinfo[d+c+1+""]=
+b[c]}b=f.split(String.fromCharCode(10));a.cinfo=a.cinfo||{};if(!(a.f||void 0===a.l||a.l in a.cinfo))for(c=+a.l-1,d=Math.max(c-5,0),c=Math.min(c+5,b.length-1);d<=c;d++)a.cinfo[d+1+""]=b[d]}}})}},"fatals-context")(document,window);
+
+
+(function(m,a){function c(k){function f(b){b&&"string"===typeof b&&(b=(b=b.match(/^(?:https?:)?\/\/(.*?)(\/|$)/i))&&1<b.length?b[1]:null,b&&b&&("number"===typeof e[b]?e[b]++:e[b]=1))}function d(b){var e=10,d=+new Date;b&&b.timeRemaining?e=b.timeRemaining():b={timeRemaining:function(){return Math.max(0,e-(+new Date-d))}};for(var c=a.performance.getEntries(),k=e;g<c.length&&k>n;)c[g].name&&f(c[g].name),g++,k=b.timeRemaining();g>=c.length?h(!0):l()}function h(b){if(!b){b=m.scripts;var c;if(b)for(var d=
+0;d<b.length;d++)(c=b[d].getAttribute("src"))&&"undefined"!==c&&f(c)}0<Object.keys(e).length&&(p&&ue_csm.ue&&ue_csm.ue.event&&ue_csm.ue.event({domains:e,pageType:a.ue_pty||null,subPageType:a.ue_spty||null,pageTypeId:a.ue_pti||null},"csm","csm.CrossOriginDomains.2"),a.ue_ext=e)}function l(){!0===k?d():a.requestIdleCallback?a.requestIdleCallback(d):a.requestAnimationFrame?a.requestAnimationFrame(d):a.setTimeout(d,100)}function c(){if(a.performance&&a.performance.getEntries){var b=a.performance.getEntries();
+!b||0>=b.length?h(!1):l()}else h(!1)}var e=a.ue_ext||{};a.ue_ext||c();return e}function q(){setTimeout(c,r)}var s=a.ue_dserr||!1,p=!0,n=1,r=2E3,g=0;a.ue_err&&s&&(a.ue_err.errorHandlers||(a.ue_err.errorHandlers=[]),a.ue_err.errorHandlers.push({name:"ext",handler:function(a){if(!a.logLevel||"FATAL"===a.logLevel){var f=c(!0),d=[],h;for(h in f){var f=h,g=f.match(/amazon(\.com?)?\.\w{2,3}$/i);g&&1<g.length||-1!==f.indexOf("amazon-adsystem.com")||-1!==f.indexOf("amazonpay.com")||-1!==f.indexOf("cloudfront-labs.amazonaws.com")||
+d.push(h)}a.ext=d}}}));a.ue&&a.ue.isl?c():a.ue&&ue.attach&&ue.attach("load",q)})(document,window);
+
+
+
+
+
+var ue_wtc_c = 3;
+ue_csm.ue.exec(function(b,e){function l(){for(var a=0;a<f.length;a++)a:for(var d=s.replace(A,f[a])+g[f[a]]+t,c=arguments,b=0;b<c.length;b++)try{c[b].send(d);break a}catch(e){}g={};f=[];n=0;k=p}function u(){B?l(q):l(C,q)}function v(a,m,c){r++;if(r>w)d.count&&1==r-w&&(d.count("WeblabTriggerThresholdReached",1),b.ue_int&&console.error("Number of max call reached. Data will no longer be send"));else{var h=c||{};h&&-1<h.constructor.toString().indexOf(D)&&a&&-1<a.constructor.toString().indexOf(x)&&m&&-1<
+m.constructor.toString().indexOf(x)?(h=b.ue_id,c&&c.rid&&(h=c.rid),c=h,a=encodeURIComponent(",wl="+a+"/"+m),2E3>a.length+p?(2E3<k+a.length&&u(),void 0===g[c]&&(g[c]="",f.push(c)),g[c]+=a,k+=a.length,n||(n=e.setTimeout(u,E))):b.ue_int&&console.error("Invalid API call. The input provided is over 2000 chars.")):d.count&&(d.count("WeblabTriggerImproperAPICall",1),b.ue_int&&console.error("Invalid API call. The input provided does not match the API protocol i.e ue.trigger(String, String, Object)."))}}function F(){d.trigger&&
+d.trigger.isStub&&d.trigger.replay(function(a){v.apply(this,a)})}function y(){z||(f.length&&l(q),z=!0)}var t=":1234",s="//"+b.ue_furl+"/1/remote-weblab-triggers/1/OE/"+b.ue_mid+":"+b.ue_sid+":PLCHLDR_RID$s:wl-client-id%3DCSMTriger",A="PLCHLDR_RID",E=b.wtt||1E4,p=s.length+t.length,w=b.mwtc||2E3,G=1===e.ue_wtc_c,B=3===e.ue_wtc_c,H=e.XMLHttpRequest&&"withCredentials"in new e.XMLHttpRequest,x="String",D="Object",d=b.ue,g={},f=[],k=p,n,z=!1,r=0,C=function(){return{send:function(a){if(H){var b=new e.XMLHttpRequest;
+b.open("GET",a,!0);G&&(b.withCredentials=!0);b.send()}else throw"";}}}(),q=function(){return{send:function(a){(new Image).src=a}}}();e.encodeURIComponent&&(d.attach&&(d.attach("beforeunload",y),d.attach("pagehide",y)),F(),d.trigger=v)},"client-wbl-trg")(ue_csm,window);
+
+
+(function(k,d,h){function f(a,c,b){a&&a.indexOf&&0===a.indexOf("http")&&0!==a.indexOf("https")&&l(s,c,a,b)}function g(a,c,b){a&&a.indexOf&&(location.href.split("#")[0]!=a&&null!==a&&"undefined"!==typeof a||l(t,c,a,b))}function l(a,c,b,e){m[b]||(e=u&&e?n(e):"N/A",d.ueLogError&&d.ueLogError({message:a+c+" : "+b,logLevel:v,stack:"N/A"},{attribution:e}),m[b]=1,p++)}function e(a,c){if(a&&c)for(var b=0;b<a.length;b++)try{c(a[b])}catch(d){}}function q(){return d.performance&&d.performance.getEntriesByType?
+d.performance.getEntriesByType("resource"):[]}function n(a){if(a.id)return"//*[@id='"+a.id+"']";var c;c=1;var b;for(b=a.previousSibling;b;b=b.previousSibling)b.nodeName==a.nodeName&&(c+=1);b=a.nodeName;1!=c&&(b+="["+c+"]");a.parentNode&&(b=n(a.parentNode)+"/"+b);return b}function w(){var a=h.images;a&&a.length&&e(a,function(a){var b=a.getAttribute("src");f(b,"img",a);g(b,"img",a)})}function x(){var a=h.scripts;a&&a.length&&e(a,function(a){var b=a.getAttribute("src");f(b,"script",a);g(b,"script",a)})}
+function y(){var a=h.styleSheets;a&&a.length&&e(a,function(a){if(a=a.ownerNode){var b=a.getAttribute("href");f(b,"style",a);g(b,"style",a)}})}function z(){if(A){var a=q();e(a,function(a){f(a.name,a.initiatorType)})}}function B(){e(q(),function(a){g(a.name,a.initiatorType)})}function r(){var a;a=d.location&&d.location.protocol?d.location.protocol:void 0;"https:"==a&&(z(),w(),x(),y(),B(),p<C&&setTimeout(r,D))}var s="[CSM] Insecure content detected ",t="[CSM] Ajax request to same page detected ",v="WARN",
+m={},p=0,D=k.ue_nsip||1E3,C=5,A=1==k.ue_urt,u=!0;ue_csm.ue_disableNonSecure||(d.performance&&d.performance.setResourceTimingBufferSize&&d.performance.setResourceTimingBufferSize(300),r())})(ue_csm,window,document);
+
+
+var ue_aa_a = "C";
+if (ue.trigger && (ue_aa_a === "C" || ue_aa_a === "T1")) {
+    ue.trigger("UEDATA_AA_SERVERSIDE_ASSIGNMENT_CLIENTSIDE_TRIGGER_190249", ue_aa_a);
+}
+(function(f,b){function g(){try{b.PerformanceObserver&&"function"===typeof b.PerformanceObserver&&(a=new b.PerformanceObserver(function(b){c(b.getEntries())}),a.observe(d))}catch(h){k()}}function m(){for(var h=d.entryTypes,a=0;a<h.length;a++)c(b.performance.getEntriesByType(h[a]))}function c(a){if(a&&Array.isArray(a)){for(var c=0,e=0;e<a.length;e++){var d=l.indexOf(a[e].name);if(-1!==d){var g=Math.round(b.performance.timing.navigationStart+a[e].startTime);f.uet(n[d],void 0,void 0,g);c++}}l.length===
+c&&k()}}function k(){a&&a.disconnect&&"function"===typeof a.disconnect&&a.disconnect()}if("function"===typeof f.uet&&b.performance&&"object"===typeof b.performance&&b.performance.getEntriesByType&&"function"===typeof b.performance.getEntriesByType&&b.performance.timing&&"object"===typeof b.performance.timing&&"number"===typeof b.performance.timing.navigationStart){var d={entryTypes:["paint"]},l=["first-paint","first-contentful-paint"],n=["fp","fcp"],a;try{m(),g()}catch(p){f.ueLogError(p,{logLevel:"ERROR",
+attribution:"performanceMetrics"})}}})(ue_csm,window);
+
+
+if (window.csa) {
+    csa("Events")("setEntity", {
+        page:{pageType: "F3OmnichannelPostOrder", subPageType: "OrderDetails", pageTypeId: ""}
+    });
+}
+csa.plugin(function(d){var e,t,n,m="transitionStart",i="pageVisible",o="PageTiming",a="visibilitychange",u="$latency.visible",r=d.global,c=(r.performance||{}).timing,s=["navigationStart","unloadEventStart","unloadEventEnd","redirectStart","redirectEnd","fetchStart","domainLookupStart","domainLookupEnd","connectStart","connectEnd","secureConnectionStart","requestStart","responseStart","responseEnd","domLoading","domInteractive","domContentLoadedEventStart","domContentLoadedEventEnd","domComplete","loadEventStart","loadEventEnd"],l=d.config,f=r.Math,g=f.max,v=f.floor,p=r.document||{},S=(c||{}).navigationStart,E=S,I=0,h=0,b=null;if(r.Object.keys&&[].forEach&&!l["KillSwitch."+o]){if(!c||null===S||S<=0||void 0===S)return d.error("Invalid navigation timing data: "+S);b=new y({schemaId:"<ns>.PageLatency.6",producerId:"csa"}),"boolean"!=typeof p.hidden&&"string"!=typeof p.visibilityState||!p.removeEventListener?d.emit(u):L()?(d.emit(u),T(i,S)):d.on(p,a,function n(){L()&&(E=d.time(),p.removeEventListener(a,n),T(m,E),T(i,E),d.emit(u))}),d.on("$timing:aboveTheFold",function(n){e=n,$()}),d.on("$timing:functional",function(n){t=n,$()}),d.once("$unload",k),d.once("$load",k),d.on("$pageTransition",function(){E=d.time(),t=e=n,h=0}),d.register(o,{mark:T,instance:function(n){return new y(n)}})}function y(n){var i,o=null,a=n.ent||{page:["pageType","subPageType","requestId"]},r=n.logger||d("Events",{producerId:n.producerId,lob:l.lob||"0"});if(!n||!n.producerId||!n.schemaId)return d.error("The producer id and schema Id must be defined for PageLatencyInstance.");function c(){return i||E}function e(){o=d.UUID()}this.mark=function(e,t){if(null!=e)return t=t||d.time(),e===m&&(i=t),d.once(u,function(){r("log",{messageId:o,__merge:function(n){n.markers[e]=function(n,e){return g(0,e-(n||E))}(c(),t),n.markerTimestamps[e]=v(t)},markers:{},markerTimestamps:{},navigationStartTimestamp:c()?new Date(c()).toISOString():null,schemaId:n.schemaId},{ent:a})}),t},e(),d.on("$beforePageTransition",e)}function T(n,e){n===m&&(E=e);var t=b.mark(n,e);d.emit("$timing:"+n,t)}function k(){if(!I){for(var n=0;n<s.length;n++)c[s[n]]&&T(s[n],c[s[n]]);I=1}}function L(){return!p.hidden||"visible"===p.visibilityState}function $(){e===n||t===n||h||(T("timeToInteractive",g(e,t)),h=1)}});csa.plugin(function(f){var e,n,r,o,c="length",i="number",l="addedNodes",s="removedNodes",a="nodeName",u="nodeValue",d="parentElement",v="target",h="getEntriesByName",m="checkVisibility",g={opacityProperty:!0,visibilityProperty:!0},t="_csa_",p=t+"nnh",y=t+"flt",E=t+"llt",S=t+"vlb",T=t+"vla",b=t+"vlab",x=t+"vlta",I=t+"vlr",N=t+"vl_thr",_=t+"vl_sl",L=t+"vl_lm",w=L+"i",M=t+"vl_em",O=t+"vlt",B=t+"vp",C=t+"eb",V=t+"pcc",k=t+"nrm",W=t+"inv_",P=W+"mslt",A=W+"h",R="previousSibling",D="nextSibling",H="visuallyLoaded",X="vlDbg",Y="Total",F="client",$="offset",q="scroll",J="Width",Q="Height",j="width",K="height",U=F+J,z=F+Q,G=$+J,Z=$+Q,tt=q+J,et=q+Q,nt="_elt",rt="_eid",it=10,ot=5,at=35,ut=100,ft="IFRAME",ct={50:1,90:1,100:1},lt={SCRIPT:1,STYLE:1,NOSCRIPT:1,LINK:1,META:1},st=["_csa_visual_load_hidden_"],dt=["a-truncate-cut"],vt={"nav-flyout-anchor":1,"nav-flyout-iss-anchor":1},ht=["TEXTAREA","SELECT",ft],mt=f.global,gt=f.timeout,pt=mt.Math,yt=pt.min,Et=pt.max,St=pt.floor,Tt=pt.ceil,bt=mt.document||{},xt=bt.body||{},It=bt.documentElement||{},Nt=mt.performance||{},_t=(Nt.timing||{}).navigationStart,Lt=Date.now,wt=Object.values||(f.types||{}).ovl,Mt=f("PageTiming"),Ot=f("SpeedIndexBuffers"),Bt=0,Ct=[],Vt=[],kt=[],Wt=[],Pt=[],At=[],Rt=[],Dt=it,Ht=it,Xt=.1,Yt=.1,Ft=0,$t=0,qt=0,Jt=0,Qt=0,jt=0,Kt=0,Ut=1,zt=0,Gt={},Zt=[],te=0,ee=0,ne=0,re=0,ie=0,oe={},ae=0,ue=0,fe=0,ce=0,le=0;function se(){var t=Lt(),e=0;for(!Bt&&o&&o.d&&(De("QueStart"+o.d),Bt=1);o;){if(0!==o[c]){if(!1!==o.h(o[0])&&o.shift(),e++,!jt&&e%it==0&&Lt()-t>ot)break}else(o=o.n)&&o.d&&De("QueStart"+o.d)}Ft=0,o&&(Ft||(!0===bt.hidden?(jt=1,se()):f.timeout(se,0)))}function de(t,e,n,r){De("BufStart"),zt=St(t),Ct=e,Vt=n,Rt=r;var i=bt.createTreeWalker(bt.body,NodeFilter.SHOW_TEXT,null,null);bt.body[nt]=t,kt.push({w:i}),Wt.push({img:bt.images,iter:0}),Pt.push({vid:bt.getElementsByTagName("VIDEO"),iter:0}),ht.forEach(function(t){At.push({iel:bt.getElementsByTagName(t),iter:0,rt:ft===t})}),Ct.h=he,Ct.n=Vt,Ct.d="MutInt",Vt.h=Ne,Vt.n=kt,Vt.d="Mut",kt.h=Le,kt.n=Wt,kt.d="Txt",Wt.h=we,Wt.n=Pt,Wt.d="Img",Pt.h=Me,Pt.n=At,Pt.d="Vid",At.h=Oe,At.n=Rt,At.d="IntEl",Rt.h=Be,Rt.d="VpUpd",o=Ct,se()}function ve(t,e){for(var n=t;n&&(t===n||!n[y]||!n[E]);){n[y]||(n[y]=t[y]),n[E]||(n[E]=t[E]);var r=n[y]-_t;n[nt]=r,n[_]=r,n=n[e]}}function he(t){var e=t.iter||0;for(Dt=Dt<=0?it:Dt;e<t.m[c]&&0<Dt;){var n=t.m[e];ve(n,R),ve(n,D),re+=1,t.iter=e+=1,Dt-=1}return t.m[c]<=e}function me(e,t){return e&&e.classList&&pe(e.classList.contains)&&t&&0<t[c]&&pe(t.some)&&t.some(function(t){return e.classList.contains(t)})}function ge(t){return typeof t===i&&!isNaN(t)}function pe(t){return"function"==typeof t}function ye(t){return t&&t.endsWith&&t.endsWith("px")?+t.substring(0,t[c]-2):e}function Ee(t){if(t&&p in t)return t[p];var e=t&&!lt[t[a]||""]&&(!pe(t[m])||t[m](g))&&"none"!==(t.style||{}).display&&!function(t){var e=(t||{}).style||{},n=!1;if("absolute"===e.position){var r=ye(e[K]),i=ye(e[j]),o=ye(e.top),a=ye(e.left);(ge(r)&&ge(o)&&r+o<0||ge(i)&&ge(a)&&i+a<0)&&(n=!0)}return n}(t)&&!me(t,st)&&!vt[t.id||""];return t&&(t[p]=e),e}function Se(t){return function(t){return t&&!t[k]&&8!==t.nodeType&&(3!==t.nodeType||0!==(t[u]||"").trim()[c])&&Ee(t)}(t)?t:e}function Te(t){t&&(t[k]=1)}function be(t){t&&!t[M]&&(ne+=t[M]=1)}function xe(t,e){var n,r=[];if(t&&pe(e)&&0<(n=t[c]))for(var i=0;i<n;i++){var o=e(t[i]);o&&r.push(o)}return r}function Ie(t){var e,n,r=0;t&&(t[s]&&1===t[s][c]&&(n=t[s][0]),t[l]&&1===t[l][c]&&(e=t[l][0]),n&&e&&n[u]===e[u]&&(r=1));return r}function Ne(t){var e=t.iter||0;for(Ht=Ht<=0?it:Ht;e<t.m[c]&&0<Ht;){var n=t.m[e];if(n){var r=n[v],i=r&&Ee(r)&&!me(r,dt),o=i?xe(n[l],Se):[],a=0<o[c],u=a&&Ie(n);if(te+=1,a&&r&&!u&&i){var f=t.t-_t;r[nt]=f,ee+=1,r[L]=f,(r[w]=o)&&pe(o.forEach)&&o.forEach(be)}xe(n[s],Te)}t.iter=e+=1,Ht-=1}return t.m[c]<=e}function _e(t,e){if(t&&!t[rt]){ie+=1;var n=t.tagName||"";oe[n]=(oe[n]||0)+1,Pe(t,e||Ce(t,1))}}function Le(t){for(var e,n=t.w,r=it;0<r&&(e=n.nextNode());){r-=1;var i=e[d],o=(i||{})[a];"BODY"===o||lt[o]||0!==(e[u]||"").trim()[c]&&(ae+=1,Pe(i,Ce(e)))}return!e}function we(t){for(var e=it;t.iter<t.img[c]&&0<e;){var n,r=t.img[t.iter],i=We(r),o=i&&Ce(i)||Ce(r);i?(i[nt]=o,n=ke(i.querySelector('[aria-posinset="1"] img')||r)||o,r=i):n=ke(r)||o,ue+=1,Pe(r,n),t.iter+=1,e-=1}return t.img[c]<=t.iter}function Me(t){for(var e,n=it;t.iter<t.vid[c]&&0<n;){var r,i=t.vid[t.iter],o=We(i),a=o&&Ce(o)||Ce(i);if(o){o[nt]=a;var u=o.querySelector('[aria-posinset="1"] img');r=u&&ke(u)||a,i=o}else r=Ve((e=i).poster,e,1)||Ve(e.currentSrc,e,0)||Ve(e.src,e,0)||a;fe+=1,Pe(i,r),t.iter+=1,n-=1}return t.vid[c]<=t.iter}function Oe(t){for(var e=it,n=t.rt;t.iter<t.iel[c]&&0<e;){var r=t.iel[t.iter],i=0;n&&(i=Ve(r.src,r,1)),_e(r,i),t.iter+=1,e-=1}return t.iel[c]<=t.iter}function Be(t){var n=[],i=0,o=0,a=$t,e=(mt.innerWidth||Et(xt[tt]||0,xt[G]||0,It[U]||0,It[tt]||0,It[G]||0),0+(mt.innerHeight||Et(xt[et]||0,xt[Z]||0,It[z]||0,It[et]||0,It[Z]||0))),r=St(0/ut),u=Tt(e/ut);Zt.slice(r,u).forEach(function(t){(t.elems||[]).forEach(function(t){if(t.lt in n||(n[t.lt]={}),!(t.id in n[t.lt])){var e=t.a;e&&(n[t.lt][t.id]=t,i+=e)}})}),bt&&bt.body&&(bt.body[S]=1),wt(n).forEach(function(t){wt(t).forEach(function(t){var e=1-o/i,n=Et(t.lt,a),r=t.a;le+=e*(n-a),o+=r,a=n,ce+=1,t.e&&(t.e[S]=1,t.e[T]=r,t.e[x]=i,t.e[O]=n),function(t,e){var n;e.e&&(e.e[I]=t);for(;Xt<=1&&Xt-.01<=t;)Re(H+(n=(100*Xt).toFixed(0)),e.lt),ct[n]&&f("Content",{target:e.e})("mark",H+n,_t+Tt(e.lt||0)),e.e&&(e.e[N]=n),Xt+=Yt}(o/i,t)})}),$t=t.t-_t,Re("atfSpeedIndex",le),Re("speedIndex",le),Re(H+"0",zt),De("CalcEnd"),He(Y+"Blocks",ce),He(Y+"Mut",te),He(Y+"ValMut",ee),He(Y+"MutEl",ne),He(Y+"MutInter",re),He(Y+"IntEl",ie),ht.forEach(function(t){He(Y+"IntEl"+t,oe[t]||0)}),He(Y+"Txt",ae),He(Y+"Img",ue),He(Y+"Vid",fe)}function Ce(t,e){for(var n=e?t:t[d],r=at+(e?1:0);n&&0<r;){if(n[nt]||0===n[nt])return Et(n[nt],zt);n=n[d],r-=1}}function Ve(t,e,n){if(t){if(!t.indexOf("data:"))return Ce(e);var r=Nt[h](t)||[];if(0<r[c])return Et(Tt(r[n?r[c]-1:0].responseEnd||0),zt)}}function ke(t){return Ve(t.currentSrc,t,1)||Ve(t.src,t,1)}function We(t){for(var e=10,n=t[d],r=[];n&&0<e;){if(n[V]&&0<n[V][c])return r.push(n[V][0]),n[V][0];if(n[V]=r,n.classList&&n.classList.contains("a-carousel-viewport"))return r.push(n),n;n=n[d],e-=1}return null}function Pe(t,e){var n,r=!e&&0!==e;if(r||t[rt]||(n=!Ee(t)))return t[P]=r,void(t[A]=n);var i=t.getBoundingClientRect(),o={x:i.left+(mt.scrollX||mt.pageXOffset),y:i.top+(mt.scrollY||mt.pageYOffset),w:i[j],h:i[K]},a=i.width*i.height,u=mt.innerWidth||Et(xt[tt]||0,xt[G]||0,It[U]||0,It[tt]||0,It[G]||0)||i.right,f=mt.innerHeight||Et(xt[et]||0,xt[Z]||0,It[z]||0,It[et]||0,It[Z]||0)||i.bottom,c=Ut++;if(0!==(a=function(t,e,n,r,i,o,a){if(e&&n&&ge(n.x)&&ge(n.y)&&ge(n.w)&&ge(n.h)&&0<n.w&&0<n.h){var u=n.y+n.h,f=n.x+n.w;if(n.y<i||a<u||n.x<r||o<f){var c=Et(r,n.x),l=Et(i,n.y),s=c-n.x,d=l-n.y,v=yt(o,f)-c,h=yt(a,u)-l,m=Et(0,v),g=Et(0,h),p=Et(0,s),y=Et(0,d);e=m*g,t&&e&&(t[b]={x:p,y:y,w:m,h:g})}}return e}(t,a,o,0,0,0+u,0+f))){for(var l={e:t,lt:e,a:a,id:c},s=St(o.y/ut),d=Tt((o.y+o.h)/ut),v=s;v<=d;v++)v in Zt||(Zt[v]={elems:[],lt:0}),Zt[v].elems.push(l);t[rt]=c,t[B]={x:0,y:0,w:u,h:f},t[C]=o}}function Ae(t,e){Mt("mark",t,e)}function Re(t,e){Ae(t,_t+Tt((Gt[t]=e)||0))}function De(t){Ae(X+t,Lt())}function He(t,e){var n=r||f("Metrics",{producerId:"csa"});n&&(r=n)("recordCounter","CSA.Latency.Page.VisualLoad."+t,e)}function Xe(){Kt||(De("CalcStart"),pe(n)?n(de):Ot("getBuffers",de),Kt=1)}_t&&wt&&Nt[h]&&(Ot("registerListener",function(){Qt&&(clearTimeout(qt),qt=gt(Xe,2500))}),f.once("$unload",function(){jt=1,Xe()}),f.once("$load",function(){Qt=1,Jt?Xe():(clearTimeout(qt),qt=gt(Xe,2500))}),f.once("$timing:functional",function(){Jt=1,Qt?Xe():(clearTimeout(qt),qt=gt(Xe,2500))}),Ot("replayModuleIsLive",function(t){n=t}),f.register("SpeedIndex",{getMarkers:function(t){t&&t(JSON.parse(JSON.stringify(Gt)))}}))});csa.plugin(function(e){var n=!1,t=e("PageTiming"),i=e.global.PerformanceObserver,r=e.global.performance;function a(){return r.timing.navigationStart}function o(){n||function(r){var a=new i(function(e){var n=e.getEntries();if(0!==n.length){var t=n[n.length-1];a.disconnect(),r({startTime:t.startTime,renderTime:t.renderTime,loadTime:t.loadTime})}});try{a.observe({type:"largest-contentful-paint",buffered:!0})}catch(e){}}(function(e){e&&(n=!0,t("mark","largestContentfulPaint",Math.floor(e.startTime+a())),e.renderTime&&t("mark","largestContentfulPaint.render",Math.floor(e.renderTime+a())),e.loadTime&&t("mark","largestContentfulPaint.load",Math.floor(e.loadTime+a())))})}i&&r&&r.timing&&(e.once("$unload",o),e.once("$load",o),e.register("LargestContentfulPaint",{}))});csa.plugin(function(r){var e=r("Metrics",{producerId:"csa"}),n=r.global.PerformanceObserver;n&&(n=new n(function(r){var t=r.getEntries();if(0===t.length||!t[0].processingStart||!t[0].startTime)return;!function(r){r=r||0,n.disconnect(),0<=r?e("recordMetric","firstInputDelay",r):e("recordMetric","firstInputDelay.invalid",1)}(t[0].processingStart-t[0].startTime)}),function(){try{n.observe({type:"first-input",buffered:!0})}catch(r){}}())});csa.plugin(function(d){var g="Metrics",e=d.config["Events.SushiCsaCustomSourceGroup"],f=d.config,l=0;function r(t){var c,i,e=t.producerId,r=t.logger,o=r||d("Events",{producerId:e,lob:f.lob||"0"}),s=(t||{}).dimensions||{},u={},n=-1;if(!e&&!r)return d.error("Either a producer id or custom logger must be defined");function a(){n!==l&&(c=d.UUID(),i=d.UUID(),u={},n=l)}this.recordMetric=function(r,n){if(!f["KillSwitch."+g]){var e=t.logOptions||{ent:{page:["pageType","subPageType","requestId"]}};e.debugMetric=t.debugMetric,a(),o("log",{messageId:c,schemaId:t.schemaId||"<ns>.Metric.4",metrics:{},dimensions:s,__merge:function(e){e.metrics[r]=n}},e)}},this.recordCounter=function(r,e){if(!f["KillSwitch.InternalCounters"]){var n=t.logOptions||{ent:{page:["pageType","subPageType","requestId"]}};if("string"!=typeof r||"number"!=typeof e||!isFinite(e))return d.error("Invalid type given for counter name or counter value: "+r+"/"+e);a(),r in u||(u[r]={});var c=u[r];"f"in c||(c.f=e),c.c=(c.c||0)+1,c.s=(c.s||0)+e,c.l=e,o("log",{messageId:i,schemaId:t.schemaId||"<ns>.InternalCounters.3",c:{},__merge:function(e){r in e.c||(e.c[r]={}),c.fs||(c.fs=1,e.c[r].f=c.f),1<c.c&&(e.c[r].s=c.s,e.c[r].l=c.l,e.c[r].c=c.c)}},n)}}}new r({producerId:"csa"}).recordMetric("baselineMetricEvent",1),e&&new r({logger:d("Events",{producerId:"csa",lob:f.lob||"0",sushiSourceGroup:e,copyBaseMetadata:!0,copyEntities:!0})}).recordCounter("csa.customsg.baselineMetric",1);d.on("$beforePageTransition",function(){l++}),d.register(g,{instance:function(e){return new r(e||{})}})});csa.plugin(function(s){var n=s.config,r=(s.global.performance||{}).timing,c=(r||{}).navigationStart||s.time(),g=0;function e(){g+=1}function i(i){i=i||{};var o=s.UUID(),t=g,r=i.producerId,e=i.logger,a=e||s("Events",{producerId:r,lob:n.lob||"0"});if(!r&&!e)return s.error("Either a producer id or custom logger must be defined");this.mark=function(e,r){var n=(void 0===r?s.time():r)-c;t!==g&&(t=g,o=s.UUID()),a("log",{messageId:o,schemaId:i.schemaId||"<ns>.Timer.1",markers:{},__merge:function(r){r.markers[e]=n}},i.logOptions)}}r&&(e(),s.on("$beforePageTransition",e),s.register("Timers",{instance:function(r){return new i(r||{})}}))});csa.plugin(function(t){var e="takeRecords",i="disconnect",n="function",o=t("Metrics",{producerId:"csa"}),c=t("PageTiming"),a=t.global,u=t.timeout,r=t.on,f=a.PerformanceObserver,m=0,l=!1,s=0,d=a.performance,h=a.document,v=null,y=!1,g=t.blank;function p(){l||(l=!0,clearTimeout(v),typeof f[e]===n&&f[e](),typeof f[i]===n&&f[i](),o("recordMetric","documentCumulativeLayoutShift",m),c("mark","cumulativeLayoutShiftLastTimestamp",Math.floor(s+d.timing.navigationStart)))}f&&d&&d.timing&&h&&(f=new f(function(t){v&&clearTimeout(v);t.getEntries().forEach(function(t){t.hadRecentInput||(m+=t.value,s<t.startTime&&(s=t.startTime))}),v=u(p,5e3)}),function(){try{f.observe({type:"layout-shift",buffered:!0}),v=u(p,5e3)}catch(t){}}(),g=r(h,"click",function(t){y||(y=!0,o("recordMetric","documentCumulativeLayoutShiftToFirstInput",m),g())}),r(h,"visibilitychange",function(){"hidden"===h.visibilityState&&p()}),t.once("$unload",p))});csa.plugin(function(e){var t,n=e.global,r=n.PerformanceObserver,c=e("Metrics",{producerId:"csa"}),o=0,i=0,a=-1,l=n.Math,f=l.max,u=l.ceil;if(r){t=new r(function(e){e.getEntries().forEach(function(e){var t=e.duration;o+=t,i+=t,a=f(t,a)})});try{t.observe({type:"longtask",buffered:!0})}catch(e){}t=new r(function(e){0<e.getEntries().length&&(i=0,a=-1)});try{t.observe({type:"largest-contentful-paint",buffered:!0})}catch(e){}e.on("$unload",g),e.on("$beforePageTransition",g)}function g(){c("recordMetric","totalBlockingTime",u(i||0)),c("recordMetric","totalBlockingTimeInclLCP",u(o||0)),c("recordMetric","maxBlockingTime",u(a||0)),i=o=0,a=-1}});csa.plugin(function(n){var e,t,r,c="CacheDetection",i="csa-ctoken-",f="csa-pfetch-",o="PreFetch",u="device",a="pre-fetch",s="setUp",l="string",d="function",h="length",g="preFetchTime",p="preFetchedRequestId",v="attribution",I="ERR",y="INVALID",S={ICDP:1},m=[y,"INPUT"].join("_"),R=[I,o,s].join("_"),k=20,w=n.store,b=n.error,q=n.warn,N=n.deleteStored,C=n.config,D=C[c+".RequestID"],E=C[c+".Callback"],O=1,F=n.global,P=F.document||{},T=F.Date,j=T.now,J=n.time,U=n("Events"),_=n("Events",{producerId:"csa",lob:C.lob||"0"});function x(){return C["KillSwitch."+c]}function A(e){return e&&typeof e===l&&S[e]}function K(e,t,n,r,c){var i=H("session-id");!function(e,t,n,r,c,i){var o={pageSource:"cache",requestId:e,cacheRequestId:c||D,cacheSource:n},u={page:o};r&&(o[v]=r);i&&(o[g]=i);t&&(u.session={id:t});U("setEntity",u)}(n,i,e,t,r,c),e!==u&&e!==a||_("log",{schemaId:"<ns>.CacheImpression.2"},{ent:"all"}),E&&E(n,i,e)}function L(){return j()+60*O*60*1e3}function V(e,t){return t&&e&&e.length<=t.length&&t.slice(0,e.length)===e}function $(e){var t;try{t=JSON.parse(e||"{}")}catch(e){}return t}function z(e,t){var n=!1,r=t||e.resultCallback;if(x())return B(r,{e:!1,ks:!0});var c=e||{},i=function(e,t){var n,r=+e;return t||r||(r=J()),(n=new T(r)).getTime()?n.toISOString():t?null:J("ISO")}(c[g],!1),o=c[p],u=c[v];if(function(e){return e&&typeof e===l&&e[h]===k}(o)&&A(u)&&function(e){return e&&typeof e===l&&0<e[h]}(i)){var a=f+o,s=L();try{w(a,JSON.stringify({e:s,t:i,a:u})),n=!0}catch(e){}n?B(r,{e:!1,ks:!1}):G(b,r,I,R,e)}else G(q,r,y,m,e)}function B(e,t){typeof e===d&&e(t)}function G(e,t,n,r,c){e(r),B(t,{e:!0,ks:!1,c:r,l:n,d:c})}function H(e){try{var t=P.cookie.match(RegExp("(^| )"+e+"=([^;]+)"));return t&&t[2].trim()}catch(e){}}n.register(o,((e={})[s]=z,e)),x()||(t=function(){var e=n.store(f+D);if(e){var t=$(e);if(t&&A(t.a))return{r:n.generateNewRequestId(),t:t.t,a:t.a,s:a}}}()||function(){var e=H("cdn-rid");if(e)return{r:e,s:"cdn"}}()||function(){if(n.store(i+D))return{r:n.generateNewRequestId(),s:u}}()||{},(r=t.r)&&K(t.s,t.a,r,D,t.t),w(i+D,L()),n.once("$load",function(){var r=T.now();N(function(e,t){if(V(i,e))return parseInt(t)<r;if(V(f,e)){var n=$(t);return!n||+n.e<r}return!1})}))});csa.plugin(function(a){var i,e="Content",t="MutationObserver",f="querySelectorAll",s="matches",o="getAttributeNames",r="getAttribute",l="dataset",c="widget",u="producerId",d="slotId",n="iSlotId",g="$csaWidget",h={ent:{element:1,page:["pageType","subPageType","requestId"]}},p=5,m=a.config[e+".BubbleUp.SearchDepth"]||35,v=a.config[e+".SearchPage"]||0,y="csaC",b=y+"Id",I="logRender",E={},w=a.config,C=w[e+".Selectors"]||[],S=w[e+".WhitelistedAttributes"]||{href:1,class:1},O=w[e+".EnableContentEntities"],A=w["KillSwitch.ContentRendered"],N=a.global,$=N.document||{},k=$.documentElement,R=N.HTMLElement,U={},j=[],D=0,L=0,M=0,P=function(e,t,n,i){var r=this,o=a("Events",{producerId:e||"csa",lob:w.lob||"0"});t.type=t.type||c,r.id=t.id,r.l=o,r.e=t,r.el=n,r.rt=i,r.dlo=h,r.op=V(n,"csaOp"),r.log=function(e,t){o("log",e,t||h)},r.entities=function(e){e(t)},t.id&&o("setEntity",{element:t})},T=P.prototype;function _(e){var t=(e=e||{}).element,n=e.target;return t?function(e,t){var n;n=e instanceof R?Q(e)||z(t[u],e,Z,a.time()):U[e.id]||G(t[u],0,e,a.time());return n}(t,e):n?x(n):a.error("No element or target argument provided.")}function x(e){var t=function(e){var t=null,n=0;for(;e&&n<m;){if(n++,B(e,b)){t=e;break}e=e.parentElement}return t}(e);return t?Q(t):new P("csa",{id:null},null,a.time())}function B(e,t){if(e&&e.dataset)return e.dataset[t]}function W(e,t,n){j.push({n:n,e:e,t:t}),X()}function q(){for(var e=a.time(),t=0;0<j.length;){var n=j.shift();if(E[n.n](n.e,n.t),++t%10==0&&a.time()-e>p)break}i=0,j.length&&X()}function X(){i=i||a.raf(q)}function Y(e){return e&&e.constructor&&"NodeList"===e.constructor.name}function H(e,t,n){return{n:e,e:t,t:n}}function K(o,c,u){f in o&&s in o&&C.forEach(function(e){for(var t=e.selector,n=o[s](t),i=o[f](t),r=i.length-1;0<=r;r--)j.unshift(H(u,{e:i[r],s:e},c));n&&j.unshift(H(u,{e:o,s:e},c))})}function z(e,t,n,i){var r=t&&t[g];if(r)return r.el=t,a.emit("$content.reregister",{c:r,t:i}),M+=1,U[r.id]=r;var o=a.UUID(),c={id:o},u=x(t);return t[l][b]=o,n(c,t),u&&u.id&&(c.parentId=u.id,!c[d]&&u.e&&(u.e.slotId?c.relatedSlotId=u.e.slotId:u.e.relatedSlotId&&(c.relatedSlotId=u.e.relatedSlotId))),G(e,t,c,i)}function F(e){return isNaN(e)?null:Math.round(e)}function G(e,t,n,i){O&&(n.schemaId="<ns>.ContentEntity.2"),n.id=n.id||a.UUID();var r=new P(e,n,t,i);return function(e){return!A&&((e.op||{}).hasOwnProperty(I)||v)}(r)&&function(e,t){var n={},i=a.exec(F);e.el&&(n=e.el.getBoundingClientRect()),e.log({schemaId:"<ns>.ContentRender.3",timestamp:t,width:i(n.width),height:i(n.height),positionX:i(n.left+N.pageXOffset),positionY:i(n.top+N.pageYOffset)})}(r,i),a.emit("$content.register",r),D+=1,U[n.id]=r}function J(){var e=a("Metrics",{producerId:"csa"});if(e){var t="recordCounter",n="CSA.Content.Base.Widgets.",i="Registered";e(t,n+"Instrumented",Object.keys(U).length),e(t,n+i,D),e(t,n+"De"+i,L),e(t,n+"Re"+i,M),D=L=M=0}}function Q(e){return U[(e[l]||{})[b]]}function V(n,i){var r={};return o in(n=n||{})&&Object.keys(n[l]).forEach(function(e){if(!e.indexOf(i)&&i.length<e.length){var t=function(e){return(e[0]||"").toLowerCase()+e.slice(1)}(e.slice(i.length));r[t]=n[l][e]}}),r}function Z(e,t){o in t&&(function(e,t){var n=V(e,y);Object.keys(n).forEach(function(e){t[e]=n[e]})}(t,e),d in e&&(e[n]=e[d]),function(t,n){(t[o]()||[]).forEach(function(e){e in S&&(n[e]=t[r](e))})}(t,e))}k&&$[f]&&N[t]&&(C.push({selector:"*[data-csa-c-type]",entity:Z}),C.push({selector:".celwidget",entity:function(e,t){Z(e,t),e[d]=e[d]||t[r]("cel_widget_id")||t.id,e.legacyId=t[r]("cel_widget_id")||t.id,e.type=e.type||c}}),E[1]=function(e,i){e.forEach(function(e){var t=e.addedNodes;Y(t)&&Array.prototype.forEach.call(t,function(e){j.unshift(H(2,e,i))});var n=e.removedNodes;Y(n)&&Array.prototype.forEach.call(n,function(e){j.unshift(H(5,e,i))})})},E[2]=function(e,t){K(e,t,3)},E[3]=function(e,t){var n=e.e;Q(n)||z("csa",n,e.s.entity,t)},E[4]=function(){a.register(e,{instance:_})},E[5]=function(e,t){K(e,t,6)},E[6]=function(e,t){var n=e.e||{},i=(n[l]||{})[b];if(i&&i in U&&function(e){return!e||!e.isConnected}(n)){var r=U[i];!function(e,t){a.emit("$content.deregister",{c:e,t:t}),delete U[e.id],e.el=null,L+=1}(r,t),n[g]=r}},new N[t](function(e){W(e,a.time(),1)}).observe(k,{childList:!0,subtree:!0}),W(k,a.time(),2),W(null,a.time(),4),a.on("$content.export",function(t){Object.keys(t).forEach(function(e){T[e]=t[e]})}),a.on("$beforePageTransition",J),a.on("$beforeunload",J))});csa.plugin(function(r){var o,t="ContentImpressions",e="KillSwitch.",i="IntersectionObserver",s="getAttribute",c="dataset",a="intersectionRatio",m="impressionData",l="observe",u="unobserve",f="csaCId",v=1e3,d=r.global,n=r.config,g=n[e+t],h=n[e+t+".ContentViews"],p=((d.performance||{}).timing||{}).navigationStart||r.time(),I={};function w(t){t&&(t.v=1,function(t){if(h)return;t.vt=r.time(),t.el.log({schemaId:"<ns>.ContentView.4",timeToViewed:t.vt-t.el.rt,pageFirstPaintToElementViewed:t.vt-p})}(t))}function T(t){t&&!t.it&&(t.i=r.time()-t.is>v,function(t){if(g)return;t.it=r.time(),t.el.log({schemaId:"<ns>.ContentImpressed.3",timeToImpressed:t.it-t.el.rt,pageFirstPaintToElementImpressed:t.it-p})}(t))}d[i]&&(o=new d[i](function(t){var n=r.time();t.forEach(function(t){var e=function(t){if(t&&t[s])return I[t[c][f]]}(t.target);if(e){r.emit("$content.intersection",{meta:e.el,t:n,e:t});var i=t.intersectionRect;t.isIntersecting&&0<i.width&&0<i.height&&(e.v||w(e),.5<=t[a]&&!e.is&&(e.is=n,e.timer=r.timeout(function(){T(e)},v))),t[a]<.5&&!e.it&&e.timer&&(d.clearTimeout(e.timer),e.is=0,e.timer=0)}})},{threshold:[0,.5,.99]}),r.on("$content.register",function(t){var e=t.el;e&&(I[t.id]={el:t,v:0,i:0,is:0,vt:0,it:0},o[l](e))}),r.on("$content.deregister",function(t){var e=(t||{}).c,i=e.el;if(e.id in I){var n=I[e.id];n&&(d.clearTimeout(n.timer),n.is=0,n.timer=0),e[m]=n,delete I[e.id]}i&&o[u]&&o[u](i)}),r.on("$content.reregister",function(t){var e=(t||{}).c,i=e.el,n=e[m];n&&(I[e.id]=n),i&&o[l](i)}))});csa.plugin(function(e){e.config["KillSwitch.ContentLatency"]||e.emit("$content.export",{mark:function(t,n){var o=this;o.t||(o.t=e("Timers",{logger:o.l,schemaId:"<ns>.ContentLatency.4",logOptions:o.dlo})),o.t("mark",t,n)}})});csa.plugin(function(t){function n(i,e,o){var c={};function r(t,n,e){t in c&&o<=n-c[t].s&&(function(n,e,i){if(!m)return;E(function(t){T(n,t),t.w[n][e]=a((t.w[n][e]||0)+i)})}(t,i,n-c[t].d),c[t].d=n),e||delete c[t]}this.update=function(t,n){n.isIntersecting&&e<=n.intersectionRatio?function(t,n){t in c||(c[t]={s:n,d:n})}(t,s()):r(t,s())},this.stopAll=function(t){var n=s();for(var e in c)r(e,n,t)},this.reset=function(){var t=s();for(var n in c)c[n].s=t,c[n].d=t},this.stop=r}var e=t.config,s=t.time,i="ContentInteractionsSummary",o=e[i+".FlushInterval"]||5e3,c=e[i+".FlushBackoff"]||1.5,r=t.global,u=t.on,a=Math.floor,f=(r.document||{}).documentElement||{},l=((r.performance||{}).timing||{}).responseStart||t.time(),d=o,p=0,m=!0,v=t.UUID(),g=t("Events",{producerId:"csa",lob:e.lob||"0"}),w=new n("it0",0,0),I=new n("it50",.5,1e3),h=new n("it100",.99,0),b={},A={};function $(){w.stopAll(!0),I.stopAll(!0),h.stopAll(!0),S()}function C(){w.reset(),I.reset(),h.reset(),S()}function S(){d&&(clearTimeout(p),p=t.timeout($,d),d*=c)}function U(n){E(function(t){T(n,t),t.w[n].mc=(t.w[n].mc||0)+1})}function E(t){g("log",{messageId:v,schemaId:"<ns>.ContentInteractionsSummary.2",w:{},__merge:t},{ent:{page:["requestId"]}})}function T(t,n){t in n.w||(n.w[t]={})}e["KillSwitch."+i]||(u("$content.intersection",function(t){if(t&&t.meta&&t.e){var n=t.meta.id;if(n in b){var e=t.e.boundingClientRect||{};e.width<5||e.height<5||(w.update(n,t.e),I.update(n,t.e),h.update(n,t.e),!t.e.isIntersecting||n in A||(A[n]=1,function(n,e){E(function(t){T(n,t),t.w[n].ttfv=a(e)})}(n,s()-l)))}}}),u("$content.register",function(t){(t.e||{}).slotId&&(b[t.id]={},function(e){E(function(t){var n=e.id;T(n,t),t.w[n].sid=(e.e||{}).slotId,t.w[n].cid=(e.e||{}).contentId})}(t))}),u("$content.deregister",function(t){if(t){var n=t.c,e=t.t;if(n){var i=n.id;w.stop(i,e),I.stop(i,e),h.stop(i,e)}}}),u("$beforePageTransition",function(){$(),C(),v=t.UUID(),S()}),u("$beforeunload",function(){w.stopAll(),I.stopAll(),h.stopAll(),d=null}),u("$visible",function(t){t?C():($(),clearTimeout(p)),m=t},{buffered:1}),u(f,"click",function(t){for(var n=t.target,e=25;n&&0<e;){var i=(n.dataset||{}).csaCId;i&&U(i),n=n.parentElement,e-=1}},{capture:!0,passive:!0}),S())});csa.plugin(function(d){var t,o,i="normal",u="reload",e="history",s="new-tab",n="ajax",r=1,a=2,c="lastActive",l="lastInteraction",f="used",p="csa-tabbed-browsing",y="visibilityState",g="page",v="experience",b="request",I="initialized",m={"back-memory-cache":1,"tab-switch":1,"history-navigation-page-cache":1},h="TabbedBrowsing",T="<ns>."+h+".4",S="visible",w=d.global,x=d.config,P=d("Events",{producerId:"csa",lob:x.lob||"0"}),q=w.location||{},$=w.document,z=w.JSON,A=((w.performance||{}).navigation||{}).type,C=d.store,E=d.on,O=d.storageSupport(),k=!1,R={},j={},B={},J={},K={},M=!1,N=!1,D=!1,F=0,G=0,H=x["CSA.isRunningInsideMShop"];function L(i){try{return z.parse(C(p,void 0,{session:i})||"{}")||{}}catch(i){d.error('Could not parse storage value for key "'+p+'": '+i)}return{}}function Q(i,e){C(p,z.stringify(e||{}),{session:i})}function U(i){return"string"==typeof i}function V(i,e){return U(i)?i:e}function W(i){var e=j.tid||i.id,t={},n=R[c]||{};for(var r in n)n.hasOwnProperty(r)&&(t[r]=n[r]);!H&&t.tid!==e||(t.tid=e,t.pid=i.id,t.ent=K),J={pid:i.id,tid:e,ent:K,lastInteraction:j[l]||{},initialized:!0},B={lastActive:t,lastInteraction:R[l]||{},time:d.time(),initialized:!0}}function X(i){var e=i===s,t=$.referrer,n=!(t&&t.length)||!~t.indexOf(q.origin||""),r=e&&!H&&n,a={type:i,toTabId:J.tid,toPageId:J.pid,transitTime:d.time()-R.time||null};r||function(i,e,t){var n=i===u,r=e||H&&(!(j[I]&&j.ent)||D)?R[c]||{}:j,a=R[l]||{},d=j[l]||{},o=e||H&&!(d.id&&!d[f])?a:d;t.fromTabId=r.tid,t.fromPageId=r.pid;var s=r.ent||{};U(s.rid)&&(t.fromRequestId=s.rid||null),U(s.ety)&&(t.fromExperienceType=s.ety||null),U(s.esty)&&(t.fromExperienceSubType=s.esty||null),n||!o.id||o[f]||(t.interactionId=o.id||null,o.sid&&(t.interactionSlotId=o.sid||null),a.id===o.id&&(a[f]=!0),d.id===o.id&&(d[f]=!0))}(i,e,a),P("log",{navigation:a,schemaId:T},{ent:{page:["pageType","subPageType","requestId"]}})}function Y(i){D=function(i){return i&&i in m}(i.transitionType),function(){R=L(!1),j=L(!0);var i=R[l],e=j[l],t=!1,n=!1;i&&e&&i.id===e.id&&i[f]!==e[f]&&(t=!i[f],n=!e[f],e[f]=i[f]=!0,t&&Q(!1,R),n&&Q(!0,j))}(),W(i),M=!0,function(i){var e,t;e=_(),t=ei(!0),(e||t)&&W(i)}(i),F=1}function Z(){k&&!D?X(n):(k=!0,function(){if(A===a||D)X(e);else if(A===r)X(j[I]?u:s);else{X(j[I]||H&&R[I]?i:s)}}())}function _(){var i=t,e={};return!!(M&&i&&i.e&&i.w)&&(i.w("entities",function(i){e=i||{}}),j[l]={id:i.e.messageId,sid:e.slotId,used:!(R[l]={id:i.e.messageId,sid:e.slotId,used:!1})},!(t=null))}function ii(i,e){var t=i||{},n=e||{};return t.rid!==n.rid||t.ety!==n.ety||t.esty!==n.esty}function ei(i){var e=!1;if(N=H&&i||$[y]===S,M){var t=R[c]||{};e=function(i,e,t,n){var r=!1,a=i[c];return N?(!a||a.tid!==J.tid||!a[S]||a.pid!==t||!a.ent&&n||n&&ii(a.ent,n))&&(i[c]={visible:!0,pid:t,tid:e,ent:n},r=!0):!H&&a&&a.tid===J.tid&&a[S]&&(r=!(a[S]=!1)),r}(R,(D?t.tid:null)||j.tid||t.tid||J.tid,(D?t.pid:null)||j.pid||t.pid||J.pid,(D?t.ent:null)||j.ent||t.ent||J.ent)}return e}x["KillSwitch."+h]||O.local&&O.session&&z&&$&&y in $&&(o=function(){try{return w.self!==w.top}catch(i){return!0}}(),E("$beforePageTransition",function(){G=1}),E("$entities.set",function(i){if(!o&&i){var e=(i[b]||{}).id||(i[g]||{}).requestId,t=(i[v]||{}).experienceType||(i[g]||{}).pageType,n=(i[v]||{}).experienceSubType||(i[g]||{}).subPageType,r=ii(K,{rid:e,ety:t,esty:n});if(K.rid=V(e,K.rid),K.ety=V(t,K.ety),K.esty=V(n,K.esty),!G&&r&&F){var a=R[c]||{};a.tid===j.tid&&(a.ent=K,Q(!1,R)),j.ent=K,Q(!0,j)}}},{buffered:1}),E("$pageChange",function(i){o||(Y(i),Z(),Q(!1,B),Q(!0,J),j=J,R=B,G=0)},{buffered:1}),E("$content.interaction",function(i){t=i,_()&&(Q(!1,R),Q(!0,j))}),E($,"visibilitychange",function(){!o&&ei()&&Q(!1,R)},{capture:!1,passive:!0}))});csa.plugin(function(c){var e=c("Metrics",{producerId:"csa"});c.on(c.global,"pageshow",function(c){c&&c.persisted&&e("recordMetric","bfCache",1)})});csa.plugin(function(n){var e,t,i,o,r,a,c,u,f,s,l,d,p,g,m,v,h,b,y="hasFocus",S="$app.",T="avail",$="client",w="document",I="inner",P="offset",D="screen",C="scroll",E="Width",F="Height",O=T+E,q=T+F,x=$+E,z=$+F,H=I+E,K=I+F,M=P+E,W=P+F,X=C+E,Y=C+F,j="up",k="down",A="none",B=20,G=n.config,J=G["KillSwitch.PageInteractionsSummary"],L=n("Events",{producerId:"csa",lob:G.lob||"0"}),N=1,Q=n.global||{},R=n.time,U=n.on,V=n.once,Z=Q[w]||{},_=Q[D]||{},nn=Q.Math||{},en=nn.abs,tn=nn.max,on=nn.ceil,rn=((Q.performance||{}).timing||{}).responseStart,an=function(){return Z[y]()},cn=1,un=100,fn={},sn=1,ln=0,dn=0,pn=k,gn=A;function mn(){c=t=o=r=e,i=d=0,a=u=f=s=l=0,pn=k,gn=A,dn=ln=0,yn(),bn()}function vn(){rn&&!o&&(c=on((o=p)-rn),sn=1)}function hn(){var n=m-i;(!t||t&&t<=p)&&(n&&(++a,sn=dn=1),i=m,n),function(){if(gn=d<m?k:j,pn!==gn){var n=en(m-d);B<n&&(++l,ln&&!dn&&++a,pn=gn,sn=ln=1,d=m,dn=0)}else dn=0,d=m}(),t=p+un}function bn(){u=on(tn(u,m+b)),g&&(f=on(tn(f,g+h))),sn=1}function yn(){p=R(),g=en(Q.pageXOffset||0),m=tn(Q.pageYOffset||0,0),v=0<g||0<m,h=Q[H]||0,b=Q[K]||0}function Sn(){yn(),vn(),hn(),bn()}function Tn(){if(r){var n=on(R()-r);s+=n,r=e,sn=0<n}}function $n(){r=r||R()}function wn(n,e,t,i){e[n+E]=on(t||0),e[n+F]=on(i||0)}function In(n){var e=n===fn,t=an();if(t||sn){if(!e){if(!N)return;N=0,t&&Tn()}var i=function(){var n={},e=Z.documentElement||{},t=Z.body||{};return wn("availableScreen",n,_[O],_[q]),wn(w,n,tn(t[X]||0,t[M]||0,e[x]||0,e[X]||0,e[M]||0),tn(t[Y]||0,t[W]||0,e[z]||0,e[Y]||0,e[W]||0)),wn(D,n,_.width,_.height),wn("viewport",n,Q[H],Q[K]),n}(),o=function(){var n={scrollCounts:a,reachedDepth:u,horizontalScrollDistance:f,dwellTime:s,vScrollDirChanges:l};return"number"==typeof c&&(n.clientTimeToFirstScroll=c),n}();e?sn=0:(mn(),rn=R(),t&&(r=rn)),L("log",{activity:o,dimensions:i,schemaId:"<ns>.PageInteractionsSummary.3"},{ent:{page:["pageType","subPageType","requestId"]}})}}function Pn(){Tn(),In(fn)}function Dn(n,e){return function(){cn=e,n()}}function Cn(){an=function(){return cn},cn&&!r&&(r=R())}"function"!=typeof Z[y]||J||(mn(),v&&vn(),U(Q,C,Sn,{passive:!0}),U(Q,"blur",Pn),U(Q,"focus",Dn($n,1)),V(S+"android",Cn),V(S+"ios",Cn),U(S+"pause",Dn(Pn,0)),U(S+"resume",Dn($n,1)),U(S+"resign",Dn(Pn,0)),U(S+"active",Dn($n,1)),an()&&(r=rn||R()),V("$beforeunload",In),U("$beforeunload",In),U("$document.hidden",Pn),U("$beforePageTransition",In),U("$afterPageTransition",function(){sn=N=1}))});csa.plugin(function(e){var o,n,r="Navigator",a="<ns>."+r+".5",i=e.global,c=e.config,d=i.navigator||{},t=d.connection||{},l=i.Math.round,u=e("Events",{producerId:"csa",lob:c.lob||"0"});function v(){o={network:{downlink:void 0,downlinkMax:void 0,rtt:void 0,type:void 0,effectiveType:void 0,saveData:void 0},language:void 0,doNotTrack:void 0,hardwareConcurrency:void 0,deviceMemory:void 0,cookieEnabled:void 0,webdriver:void 0},w(),o.language=d.language||null,o.doNotTrack=function(){switch(d.doNotTrack){case"1":return"enabled";case"0":return"disabled";case"unspecified":return d.doNotTrack;default:return null}}(),o.hardwareConcurrency="hardwareConcurrency"in d?l(d.hardwareConcurrency||0):null,o.deviceMemory="deviceMemory"in d?l(d.deviceMemory||0):null,o.cookieEnabled="cookieEnabled"in d?d.cookieEnabled:null,o.webdriver="webdriver"in d?d.webdriver:null}function k(){u("log",{network:(n={},Object.keys(o.network).forEach(function(e){n[e]=o.network[e]+""}),n),language:o.language,doNotTrack:o.doNotTrack,hardwareConcurrency:o.hardwareConcurrency,deviceMemory:o.deviceMemory,cookieEnabled:o.cookieEnabled,webdriver:o.webdriver,schemaId:a},{ent:{page:["pageType","subPageType","requestId"]}})}function w(){!function(n){Object.keys(o.network).forEach(function(e){o.network[e]=n[e]})}({downlink:"downlink"in t?l(t.downlink||0):null,downlinkMax:"downlinkMax"in t?l(t.downlinkMax||0):null,rtt:"rtt"in t?(t.rtt||0).toFixed():null,type:t.type||null,effectiveType:t.effectiveType||null,saveData:"saveData"in t?t.saveData:null})}function f(){w(),k()}function y(){v(),k()}c["KillSwitch."+r]||(v(),k(),e.on("$afterPageTransition",y),e.on(t,"change",f))});csa.plugin(function(a){a.emit("$csa.loaded")});
+(function(p,n,w,l){var r={EX:{}};(function(){return"object"===typeof performance&&"function"===typeof performance.now?function(){return performance.now()}:"function"===typeof Date.now?Date.now:function(){return(new Date).getTime()}})();var u=function(a,b,c,e){var f={};try{if(5<=e)return{};b=b||n;c=c||a;for(var k,g=Object.keys(c),d,h=0;h<g.length;h++)d=g[h],k=c[d],"object"!==typeof k||Array.isArray(k)?f[d]=b[d]:f[d]=null==b[d]?null:u(a,b[d],c[d],e+1)}catch(l){m(l,"ex in collecting-")}return f},v=function(a,
+b){var c="";try{var e=b.toString(),e=e.replace(/\n/g,"").replace(/\s\s+/g," ");c=e==="function "+a+"() { [native code] }"||e==="function "+a+"() { [native code]}"?"0x6":e=e.replace(/function/,"fx").replace(/\[native code\]/,"nc")}catch(f){c="ex"}return c},s=function(a,b,c,e){var f=[];try{if(5<=e)return[];c=c||b;for(var k=Object.keys(c),g=0;g<k.length;g++){var d=k[g];if("object"!=typeof c[d]||null==c[d]||Array.isArray(c[d]))switch(!0){case !0===a[d]:f[g]=1;break;case !1===a[d]:f[g]=0;break;case 0===
+a[d]:f[g]=0;break;case "function"===typeof a[d]:f[g]=v(d,a[d]);break;case null!=a[d]:f[g]=a[d];break;default:f[g]=null}else f[g]=null!=a[d]?s(a[d],b,c[d],e+1):s({},b,c[d],e+1)}}catch(h){m(h,"ex in compression-")}return f},q=function(a,b){try{p.ue&&p.ue.event&&p.ue.event(x(b,a),"a9_tq","a9_tq.FraudMetrics.3")}catch(c){m(c,"ex in logging-")}},h=function(a,b,c){try{q(b+a.stack,c)}catch(e){m(e,"ex in logging-")}},m=function(a,b){p.ueLogError&&p.ueLogError(a,{logLevel:"ERROR",attribution:"A9TQForensics",
+message:b})},y=function(){try{if(l&&l.userAgent&&/chrome/i.test(l.userAgent)&&l.userAgentData&&l.userAgentData.brands)for(var a=l.userAgentData.brands,b=0;b<a.length;b++)if(a[b].brand&&/google/i.test(a[b].brand))return!0;return!1}catch(c){h(c,"ex in identifying Chrome Browser ","103")}},t=function(a){try{a&&!a.stack&&(a.stack=a.toString())}catch(b){h(b,"ex in populating stack trace ","100")}},x=function(a,b){try{var c={vfrd:a};"object"===typeof b?c.info=JSON.stringify(b,function(a,b){return"function"===
+typeof b?v(a,b):b}):"string"===typeof b&&(c.info=b);return{server:window.location.hostname,fmp:c}}catch(e){return m(e,"ex in constructing pixel - "),{server:window.location.hostname,fmp:{vfrd:"0"}}}};(function(a,b){try{try{try{r.mimeTypesLength=n.navigator.mimeTypes.length,r.pluginsLength=n.navigator.plugins.length}catch(c){h(c,"ex in basic props ","30")}n.a9tqDerivedFeatures=r}catch(e){h(e,"ex in evaluation-","30")}var f=u(a,b,null,0);try{n.a9tqDerivedFeatures=null,delete n.a9tqDerivedFeatures}catch(k){h(k,
+"ex in deleting derivedFeatures-","30")}var g=s(f,a,null,0);q(g,"2")}catch(d){m(d,"ex in full attribute flow-")}})({window:{innerHeight:0,innerWidth:0,outerWidth:0,outerHeight:0,length:0,callPhantom:"",__phantomas:"",PhantomEmitter:"",_phantom:"",_WEBDRIVER_ELEM_CACHE:"",domAutomationController:"",domAutomation:"",spawn:"",emit:"",Buffer:"",TEMPORARY:"",external:"",Components:{classes:"",wdIStatus:"",wdIMouse:"",wdICoordinate:"",interfaces:"","interface":{nsICommandProcessor:""}},netscape:{security:{privilegemanager:""}},
+isExternalUrlSafeForNavigation:0,opera:{_browserjsran:""},onabsolutedeviceorientation:"",onstorage:"",chrome:"",clearInterval:"",clearTimeout:"",eval:"",alert:"",prompt:"",scroll:"",onhelp:"",maxConnectionsPerServer:"",opr:"",devicePixelRatio:"",webdriver:"",InstallTrigger:"",safari:"",ontouchstart:""},screen:{availHeight:0,availWidth:0,width:0,height:0,colorDepth:0,pixelDepth:0,orientation:{angle:0,onchange:0}},navigator:{appCodeName:"",appName:"",appVersion:"",deviceMemory:0,doNotTrack:0,hardwareConcurrency:0,
+language:"",maxTouchPoints:0,product:"",productSub:0,vendor:"",vendorSub:"",userAgent:"",languages:[],platform:"",webdriver:0,msLaunchUri:"",permissions:"",oscpu:"",msMaxTouchPoints:"",userAgentData:""},document:{id:"",height:"",width:"",except:"",style:{position:"",top:"",left:"",visibility:"",opacity:"",hidden:"",webkitHidden:"",msHidden:"",mozHidden:""},referer:"",webdriver:""},a9tqDerivedFeatures:{mimeTypesLength:"",pluginsLength:"",EX:{a:[],b:[]}},history:{length:""}},n);(function(){var a=[];
+try{var b=Date.now(),c="function"===typeof w.hasPrivateToken?1:0,e="www.amazon.com"===n.location.hostname?1:0,f="function"===typeof AbortController?1:0,k=y()?1:0;if(k&&c&&e&&f){var g=atob("aHR0cHM6Ly93d3cuYW1hem9uLmNvbS90dC9p"),d=new AbortController,l=setTimeout(function(){try{d.abort()}catch(a){t(a),h(a,"ex in set PST timeout ","100")}},2E3);fetch(g,{privateToken:{version:1,operation:"token-request"},signal:d.signal}).then(function(c){a=[1,Date.now()-b,c.status];q(a,"101")})["catch"](function(a){t(a);
+h(a,"ex in PST Issuance API call ","100")})["finally"](function(){clearTimeout(l)})}else a=[0,Date.now()-b,k,c,e,f],q(a,"101")}catch(m){t(m),h(m,"ex in PST issuance flow ","102")}})()})(ue_csm,window,document,navigator);
+
+
+
+ue.exec(function(d,c){function g(e,c){e&&ue.tag(e+c);return!!e}function n(){for(var e=RegExp("^https://(.*\.(images|ssl-images|media)-amazon\.com|"+c.location.hostname+")/images/","i"),d={},h=0,k=c.performance.getEntriesByType("resource"),l=!1,b,a,m,f=0;f<k.length;f++)if(a=k[f],0<a.transferSize&&a.transferSize>=a.encodedBodySize&&(b=e.exec(String(a.name)))&&3===b.length){a:{b=a.serverTiming||[];for(a=0;a<b.length;a++)if("provider"===b[a].name){b=b[a].description;break a}b=void 0}b&&(l||(l=g(b,"_cdn_fr")),
+a=d[b]=(d[b]||0)+1,a>h&&(m=b,h=a))}g(m,"_cdn_mp")}d.ue&&"function"===typeof d.ue.tag&&c.performance&&c.location&&n()},"cdnTagging")(ue_csm,window);
+
+
+}
+(n=>{var A,E=1e6,M=(n.Symbol||{}).iterator;n.RXVM=function(r){(r=r||{}).mi&&(E=r.mi);var i=n([1,function(n){n.u.t[m(n)]=h(n)},2,function(n){n.i[0].t[m(n)]=h(n)},3,h,4,function(n){var r=h(n),t=h(n),n=h(n);w(n)&&(n[t]=r)},5,function(n){var r=h(n),t=m(n);w(r)&&"function"==typeof r[M]&&(n.u.t[t]=r[M]())},6,function(n){var r=n.u.t[m(n)],r=r&&r.next?r.next():A,t=m(n),u=x(n);w(r)&&!1===r.done?n.u.t[t]=r.value:d(n,u)},10,function(n){n.u.o.push(h(n))},11,function(n){n.u.o.push(n.v)},12,function(n){for(var r=F(n);0<r--;)n.l.push(S(n))},30,function(n){return!h(n)},42,function(){},43,function(n){for(var r=F(n);0<r--;)n.u.t.push(n._.pop())},45,a(!0),44,a(!1),48,v(0,y),49,v(1,y),50,v(2,y),51,v(-1,y),52,v(0,_),53,v(1,_),54,v(2,_),55,v(-1,_),58,function(n){d(n,x(n))},59,s(!0),60,s(!1),64,function(n){var r=x(n),t=p(n,n.u.h);return d(n,r),t},65,function(n){var r=F(n),t=x(n),u=p(n,n.u.h);n.u.t[r]=u,d(n,t)}]),o={40:function(n,r){return"__rx_cls"in n?n.__rx_cls===r.__rx_ref:n instanceof r}},t=(o[20]=Math.pow,l(16,"+"),l(17,"-"),l(18,"*"),l(19,"/"),l(21,"%"),l(22,"&"),l(23,"|"),l(24,"^"),l(25,"<<"),l(26,">>"),l(27,">>>"),l(28,"&&"),l(29,"||"),l(31,">"),l(33,">="),l(32,"<"),l(34,"<="),l(35,"=="),l(36,"==="),l(37,"!="),l(38,"!=="),l(39," in "),n([10,A,11,null,14,!0,15,!1])),u=n([1,function(n){return n.v},17,F,18,function(n){n=m(n)|m(n)<<8|m(n)<<16|m(n)<<24;return n=2147483647<n?-4294967295+n-1:n},19,function(n){for(var r=[],t=0;t<4;t++)r.push(m(n));return new Float32Array(new Uint8Array(r).buffer)[0]},12,S,13,function(n){return n.l[F(n)]},20,function(){return[]},21,function(n){for(var r=F(n),t=[];0<r--;)t.unshift(h(n));return t},24,function(n){for(var r,t,u,i=F(n),o=[];0<i--;)o.unshift((u=t=void 0,r=m(r=n),t=128&r?-1:1,u=r>>3&15,r&=7,15!=u?0==u?r/8*t*.015625:t*(1+r/8)*Math.pow(2,u-7):NaN));return o},22,function(){return{}},23,function(n){for(var r=F(n)/2,t={};0<r--;){var u=h(n);t[h(n)]=u}return t},32,function(n){return n.u.t[F(n)]},33,function(n){return n.i[0].t[F(n)]},48,function(n){var r=h(n),n=h(n);return w(n)?("function"==typeof(r=n[r])&&(r.__rx_this=n),r):n},50,function(n){return n.u.o.pop()},52,function(n){return typeof h(n)}]);function f(n){for(;0<n.p--&&(r=n).u&&r.u.h<r.m.length;){r=m(n);n.v=e(r,n)}var r}function e(n,r){var t,u;return n in o?(t=h(r),u=h(r),o[n](u,t)):n in i?i[n](r):void k("e2:"+n+":"+r.u.h)}function c(n,r){return{F:n,h:n,t:[],o:[],S:r}}function n(n){for(var r={},t=0;t<n.length;t+=2)r[n[t]]=n[t+1];return r}function a(i){return function(n){var r=i?h(n):A,t=n.i.pop(),u=A,u=t.S?t.t[0]:r;return n._=[],n.u=n.i[n.i.length-1],b(n,n.u.F),u}}function v(u,i){return function(n){var r=h(n),t=u;for(-1===u&&(t=F(n));0<t--;)n._.push(h(n));if(n.v=A,r)return i(r,n)}}function s(u){return function(n){var r=h(n),t=x(n);(u&&r||!r&&!u)&&d(n,t)}}function l(u,i){o[u]=function(n,r){var t=Function("a","b","return a"+i+"b");return(o[u]=t)(n,r)}}function _(n,r){var t;if(n.__rx_ref&&n.g===r){var u=c(n.__rx_ref,!0);u.t.push({__rx_cls:n.__rx_ref}),r.i.push(u),r.u=u,b(r,u.F)}else if("function"==typeof n){u=r._.reverse().splice(0),u=Function.prototype.bind.apply(n,[null].concat(u));try{t=new u,r._=[]}catch(n){}}else k("e5:"+n+":"+r.u.h);return t}function y(n,r){var t;if(n.__rx_ref&&n.g===r){var u=c(n.__rx_ref);u.t.push(n.__rx_this||this),r.i.push(u),r.u=u,b(r,u.F)}else if("function"==typeof n){u=r._.reverse().splice(0);try{t=n.apply(n.__rx_this||this,u),r._=[]}catch(n){}}else k("e4:"+n);return t}function h(n){var r=m(n);return 0<(128&r)?e(127&r,n):r in t?t[r]:r in u?u[r](n):void k("e3:"+r)}function p(t,u){var n=g(function(){var n=c(u),r=n.t;return r.push(this),r.push.apply(r,arguments),t.i.push(n),t.u=n,t.p=E,b(t,n.F),f(t),t.v});return n.__rx_ref=u,n.g=t,n}function w(n){if(n!==A&&null!==n)return 1;r.unsafe&&k("e10"+n)}function b(n,r){n.k=r%127+37}function d(n,r){n.u.h+=r}function m(n){return n.m[n.u.h++]^n.k}function x(n){n=m(n)|m(n)<<8;return n=32767<n?-65535+n-1:n}function F(n){for(var r,t=0,u=0,i=n.u.h,o=n.m,f=n.k;t+=(127&(r=o[i+u]^f))*(1<<7*u),u+=1,0<(128&r););return n.u.h+=u,t}function S(n){for(var r=F(n),t="";0<r--;)t+=String.fromCharCode(m(n));return t}function g(n){return function(){try{return n.apply(this,arguments)}catch(n){k(n)}}}function k(n){if(r.unsafe)throw Error(n)}this.execute=g(function(n,r){var t,u;return 82!==n[0]&&88!==n[1]?k("e1"):(n=n,t=3,(u=c(0)).t[0]=(r=r)||{},u.h=t,b(r={m:n,p:E,v:0,i:[u],u:u,_:[],l:[],k:0},0),f(t=r),t)})}})("undefined"==typeof window?global:window);
+(n=>{for(var t="undefined"==typeof window?n:window,i=0,n="addEventListener",e="ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/".split(""),u=[],r=t.rx||{},o=r.c||{},f=o.rxp||"/rd/uedata",c=o.fi||1e3,a=1.5,d=1e4,x={},w={},m={},v={},h=0,l=0;l<e.length;l++)u[e[l]]=l;function p(n,r){return function(){try{return n.apply(this,arguments)}catch(n){s(n.message||n,n)}}}function s(n,r){if(m[i]=[(n=(""+(n||"")).substring(0,100)).length].concat((new TextEncoder).encode(n)),o.DEBUG)throw r||n;b()}function y(n,r){r=p(r),n in w||(w[n]=[]),w[n].push(r),n in x&&r()}function g(n,r){n in x||(x[n]=r,(w[n]||[]).forEach(function(n){n(r)}))}function A(n){for(var r=0,t=0,i="",o=0;o<n.length;o+=1)for(t+=8,r=r<<8|n[o];6<=t;)i+=e[r>>t-6],r&=255>>8-(t-=6);return 0<t&&(i+=e[r<<6-t]),i}function U(n){for(var r=0,t=0,i=[],o=0;o<n.length&&"="!==n[o];o+=1)for(t+=6,r=r<<6|u[n[o]];8<=t;)i.push(r>>t-8),r&=255>>8-(t-=8);return new Uint8Array(i)}function b(){!h&&0<c&&(setTimeout(p(I),c),c=Math.min(d,c*a),h=1)}function E(r){let t=[];return Object.keys(r).forEach(n=>{t.push(parseInt(n)),t=t.concat(r[n])}),t}function I(){h=0;var n=E(m);0<n.length&&rx.ep(n,T),m={}}function T(n){n=A(new Uint8Array(n));n=f+"?rid="+rx.rid+"&sid="+rx.sid+"&rx="+n;(new Image).src=n}function j(n){g("load",n)}function L(n){j(n),g("unload",n),I()}(t.rx=r).err=s,r.r=p(y),r.e=p(g),r.exec=p,r.p=p(function(n,r){g("rxm:"+n,r),m[255&n]=r,b()}),r.pc=p(function(n,r){v[255&n]=r,n=E(v),r=rx.ep4(n,rx.fnpb),n=A([rx.fnpv].concat(rx.fnpb,r)),document.cookie="rxc="+n+"; max-age=86400; path=/"}),r.ex64=p(function(r,n){y(n||"init",function(){var n;t.RXVM&&(n=U(r),t.$RX||(t.$RX=new t.RXVM({mi:o.mi})),$RX.execute(n,t))})}),r.e64=p(A),r.d64=p(U),r.erc4=p(function(){var n=rx.fnpb,r=rx.fnpv,t=rx.ep4(E(m),n);return A(new Uint8Array([r].concat(n,t)))}),g("init",{}),"complete"===document.readyState?j({}):n in t&&(t[n]("load",p(j)),t[n]("beforeunload",p(L)),t[n]("pagehide",p(L)))})(window);
+rx.ex64("UlgBKT4nV10haERRTSFMSFBJIUFKS0AgU0RJUEAjSUBLQlFNIVFNQEsvSktGSkhVSUBRQC1GRElJR0RGTidCUSBDSUpKVyFhRFFAJktKUi9wTEtRHWRXV0RcJlZAUS5wTEtRFhdkV1dEXCNHUENDQFcjVlBHUUlAIkBLRldcVVEhS0RIQCJkYHYIZmdmI0FMQkBWUSJ2bWQIFxATIGFgZ3BiIUBdQEYmV0xBJlZMQSQkFSglBSUkJ7gzFSkkRgUkJCa4FSkjRldcVVFKBSUVKS1IVmZXXFVRSgUlZCIBJa6EsbWJjtHg/fHA6+bq4eD3pIWGtYmD4Ovm6uHghLSEpYSohGQtoiUFLy8sP8HTmNsjHw8pDi8rLy0oLSo0LhweIyweIy8PLj+f3fPfJ7YOKg4sLywvFM/RLyy2HiMrDi8OLC8strU/Pg4sDiwcHiMsHiMvDy4/xbqBgSYOLC8sLy8strU/Iw4sDiwcHiMsHiMvDy4/m/LkuyIOLC8sLy8strU/Pg4sDiwDtT8uDixkLD4lETk7PgoaOBo7PgoaORo7GjgaOz4aPho5GjsWZC+bJXJbWFpNWF1NWFxIWVhfSFlYXkhZWFFIWWX5SNlbeVFIWV15UXlReVpYUclIWHlRY7+mWFFIWWX5SNlbeVF3WVhczEjZW8lpzGlUXHlbeVF5W8lpeVF5WnlcanhQWnlceVF5WlhRyUhYeVFjkKZceVhQX1BTHFlYXsxI2VvJSFh5XlhfzEjZW8lpeV55WnlfanhQWnlfeV55WmhpVV0pLCoxeV3BacxI2VvJaXlfeVppeV55WnlaeVNj76Z0eV1kLmIlt56gO7ydkZqRnK2skZq8nbyesZ2ms5ygO7ydkZu7nJi8npGUvJ3cj5xsd3ZLTmZGdkpANCM1MyoyZkZql5iukZu8nbG8nbBkKbElQ2pU9fZJbPZJbmloRFhYZWRYZWNJaHt5gG9pY1lYZWJYZWlJaFp1aVhlYVhlaEloaWtpXVhlZUlo+FhlbUhpeWxpbGldWGVnSWh9aUhra1hleGljXVhlZUloWmNZWGVmSGxaWlhlZkhseWxIaVtYZXpYZXlJa2tIbElsf2556GllbUluZGoBHmV8ZXtjWkljSGpaRGQoXCWqg4CDHKCEoYO9H6GDgIGtsbGMjbGMiqCBkpBphoCKsLGMi7GMgKCBs5yAsYyIsYyBoIGAgoC0sYyMoIERsYyEoYCQhYCFgLSxjI6ggZSAoYKCsYyRgIq0sYyMoIGzirCxjI+hhbOzsYyPoYWQhaGAs6CLoYOhhayAZCsiJFR9Tl54X35+fn5OXnhffX59fk1PcmpPcm5efF9+cml0PxZ/iaOXkq+vg6KCo6Cno5GSrqvLz9LN0Nbpx9uSr7ODoae3oK6lxsfB0NvS1q+wrbWmsyKjr6evtq+xgqOuodDD1aniv6JMZmVjR2ZbV2pwRmVrZ2NGY2tiODgCFQxGZkpGY6mQg6mQkI+jdE1edE1Nfnx+TU9yak9ybl58X31yaXQ/VH8MJhUXKyJUS05EQgcmNjc2JyUhJhsXKjAGJSsnIwYhKyJ4eEJVTgYmCgYhdE1edE1Nfnt+Q09yaF59W39OT3N8HhMTT3N4Lw0QEhYMGl5/an1fe198dHtNc3sgIBoNXn5TFBUoPQUkBSkuIRcpJ0BVBSQUFSg9BSQFKC4hFykmQFURBSQUFSg9BSQFLy4hFyknQBEFJBQVKD0FJAUtLiEXKSRNBSQZuRUoPwUkFSg8BSQxJRQVKD0FJAUrFyQVKD8FJBUoPAUk","load");
+rx.ex64("UlgBKSInV10hQUpLQCBTRElQQCNJQEtCUU0mVUpSIENJSkpXIFdKUEtBJCQVKSFAXUBGFSglBSUkJxUpIWhEUU0FJSQmFSkja1BIR0BXBSVkITklUnh4e2h5fFl4en96fXN5eHvpWX1Ze0OIhlRZe2QgNSWymKi4nbmYiqmUmrmYmLSYZCNnJQUvHw8rDi8vLC8vLT8uKw4vKigqKzkuHB4jKg8sPyy/DiwOKz4vDi0vLS8UytEfHiIqXV9cWg8svR4jLQ4vDi0DL2QiayVfdXV2RHl3VHVFVXFUdXV3dUVVclR1dXB1RUR5cVV2VHZiZYuLd3V/RUR5cVV2VHdiZYuLd3V/RUR5cVV2VHBiZYuLd3V/d2F3RkZGWXVkLWUlbEZ2ZkBnRkZFRmpSQdFWuEZ3VkVnRd1WT3dWRWdF0Va4RndWRmdF3VZPd1ZGZ0XRVrhGd1ZHZ0XdVk93VkdnRWQs1SWgirq7h4Pi+M3i5eL/7qqIq4qVipaKLYeN5f7m6e75v6uKgLq7h47i+MXqxaqIq4qAlrm5t4qDi6aeiZp3ipqLiomai7crmourioaLiomaCwuJiooaq4qai7cvmourioyLpp6Jmouai7q7h4/n5Oy5qomrioC6u4aOqom5ioiKubuGj6qJq4iaiZiKq4qamoqKmZoLg4qAuruGjaqJuYqPioqIG5qEq4i3KZqLq4iui7m7ho+qiZl5dHR0momYiquKmZoLg4qAuruGjaqJuYqPioqImouKjhyrjxwSmoGriKuJpp6JEZqDq44dmnSKq45kL6glqoCAgxaxkIGhgBiQibGQgKGAgIKQgL0XkAEBg6GDhoGAgpN+fn5+gIUXkJ4bkIuhg4CEF5B+hqGDvSWQnqGFiIGssY2Cz+DPoIK9JZCBoYWcgbOxjIWgg5Nzfn5+kIOTgBMSkAGJoYShgqyAu5yBs7GMhaCDEJCOoYWQg5OAExESkAGJoYSQgKGCrICtFAUkBSIuIRcpJ1ZEFSglBSUUBSQFLS4hFykmVkRHFSglBSUUBSQFLC4hFykhQEMUExUoJQUlFAUkBS8uIRcpIUFDFBMVKCUFJRQFJAUhLiEXKSFEVlBIFSglBSUUBSQFIC4hFykhRERTQhUoJQUlFAUkBSMuIRcpIURWUUEVKCUFJQ==","load");
+rx.ex64("UlgBKSQnV10kJCkjGWtqa2AbJCc0JWQmbyUVPj4zPz4+r6IePg8zNkpMWk1+WFpRS6IpDzM2UV5JVlheS1BNHj8fPj4+r6IePg8zPExWWw8yPx4/Hz4ODzM+Vw8yPx4/Hz4SPhQVKSFAXUBGFSglBSUFJhUkJCEkIQUhKSZDS1UVKCUFJSEwIbM02iQFIbM02iS+NC0FIbM02iS+NDUFIbM02iS+ND0FISkhQ0tVRxUoJQUlIQUnKSFDS1VTFSglBSU=","load");
+rx.ex64("UlgBKSMnV10hQF1ARiBWSUxGQCdAESdAQydWUyQkFSglBSUkJxUpIW92amsFJSQmFSkhaERRTQUlJCEVKSlJSkZESXZRSldEQkAFJSQgFSktTFZjTEtMUUAVKSNrUEhHQFcFJSQjKCUkIhUpIUNLVVMFJCQtFSkhQ0tVRwUkJCw0QSQuMSQpLmQoviUYcrYyHDc3BhcwFzIKkDwWN0I2BwY6NVIAAhc3Fjc3NDcEBjs0FjQnMyc3NzU3BwY7NBY0JzM9BAY7NRc3FjUENzI3AwY6PGNfWEIOd0REV08XNhYyPQIGOj1iU05CclNVWVJTRBc2NQY6MFJTVVlSUzcHNwQ3MzcHBjozRldERVMXNBYzGzcaOQMCPzMTMwACMy8lMCQ/NjMfM2QrUCV5U2NiXlshJiA7PDU7NCtzUHJTU1BTZmJeWQY3KiYXPDE9Njcgc1JRYl5UNzwxPTY3U2NTclBZYGJfUXNTc1pgU1FTYGJeVDE9PDEzJkdTc1VyUXNaWWNiXlE3ZGZzU2BZVmBzVHNWVsJDU2JfV3NTX1dzU35kKhwlZk5GRnxtQU5ATUltR01KTU5RTH18QU5sTl1NR358QEktPDwgNXxdTGxOfmxMdpKzfW1CbUBOR1hgZDUFJaO1LYOog56Ju7mFg/rs/d3g5Ozm/P2oiaiAqIaLg4ilZDRbJQUqLyqzPS4uLhEOKi8rszgeIyoPIi8oHg4vDisfDysOKBIvaC4fDysOLRIvPi4vKL2/Dio/L7+8Di0OKg4oLyi+vA4ovw4qPy+8DiwOKh8eIi1PTF0PLQ4oDj3j4uITLxIvKi4vKD8uFCouLygOLCoOKA4vDisqDisjKg8iAmQ3OSUaNQABPTVBREJZEDokNBE1ETIRMxEwECABECEdITQlKCAFJBQVKCQFJAU3LiEXKSZWQ0AFJBQVKCQFJAUoLiEXKSdCQQUk","load");
+rx.ex64("UlgBKS8sUkBHQVdMU0BXI2pHT0BGUSFOQFxWIkxLQUBdakMhQUpLQCBTRElQQCBkV1dEXCN2XEhHSkkgdVdKXVwnV10kJDQ1JCc0JCQmuDMVKSxLRFNMQkRRSlcFJSQhuDMVKS1BSkZQSEBLUQUlZCA2JbK1BgaolJLo9Pnh7+rx//DsuZhkIyglGh2tlxEwPTAAPTARM2QiCiVrcHFMQ3FMQGBBYEFEQEBHQENYQXBxTEJhQ01FIiUiHmVQQUB9QENBbE97o75sTmQtuyVeRUR5dkR5dVV0VXRxdXVydXb8dEVEeXdUdnhyKzUGBhUNVWV0dWh10nlyVHZo0ER5clV0RFR2VXR1SHV2dFl6RUR5d1R2eHMrJw0ZFhsYVWV0dWh10nlzVHZo0ER5c1V0RFR2VXR1SHV2dFl6RUR5d1R2eHIrJAYbDA1VZXR1aHXSeXxUdmjQRHl8VXREVHZVdHVIdXZ0WXpOB4tZe2QsBSW9ugowtpebnPT2+/vH//b54/j6MLaXm5/I5//2+eP4+mQv5iUWDQwwMV9OWV1IWXlQWVFZUkgdODA6X11SSl1PPT09DQwwNltZSH9TUkhZREgcPTA5S1leW1A9Pj0Aohw+PjwRMg0MMDBbWUh5REhZUk9VU1IcPjAla3l+e3BjWFleSVtjTllSWFlOWU5jVVJaUz8MMCtpcnF9b3d5eGNueXJ4eW55bmNreX57cD03DQwwMFtZSGxdTl1RWUhZThw+Dj0/PQCYNhw/PjwRMg0MMT8cPzA3b0tVWkhvVF1YWU4dLTw9ET1kLgYlrqkgtIiP7erq4fbM4e3j7PClhLSIj+vx8OH2zOHt4+zwpYRkKQ4lBgGIHCAmRUJCSV57RUhYRA0sHCAnT0BFSUJYe0VIWESxOhwgKE5DSFUNKCQoMC0FKQUuBS8FLAUtBSIFIwUgZCtTJUVubn5vbm1+b2pOYmxpbGs+b15fY2sKFwoMX2JmTm9Pa19ubmpuU8tlT2psb25qYVNPamVvbm749k9tfm5Pbm5t/35uT21dX2NsHAkKX2JmTm/4fm9Pav9PbWNrBwsDMFXFkF1fY24fX2JmTm96bU9uTm1ObkMXFSkkVxUoLAUlBSspIUlKREE=","load");
+rx.ex64("UlgBKS8mVkNANURBQWBTQEtRaUxWUUBLQFcsSEpQVkBBSlJLIkhKUFZAUFUhQF1ARjZXQEhKU0BgU0BLUWlMVlFAS0BXLFFMSEB2UURIVS5VQFdDSldIREtGQCZLSlIkVyQkNAUkJzQqJCYyISspIkZEVVFQV0ArKSJVRFZWTFNAJCE0zSIkILgzFSktQUpGUEhAS1EFJSQjFSkhaERRTQUlJCIVKSdXXQUlJC0VKS5WQFFsS1FAV1NESQUlJCwVKShGSUBEV2xLUUBXU0RJBSUkLyskLiskKjQlJDQxJDcxZDZDJaG3FhWqgBWqgYqLp4mAhLq7h4n46qqMqpqKioq4u4aLqoyIu5qLqpm7mourioeP5ujU6Li7houqjIi7moqqmbuaiquKh4/m6NTmuLuGi6qMiLuaiaqZu5qJq4qHj+bo1PiJmauKp2QxFCVcRUZ7d1dzdVd1V3p7dEVGe3dXc3VXdVd7e3VGV2VHRntyV3FXZX1EV35XckR0eHdaZDABJQYuJiMfHCEpDSkvDS8NICEuHxwhKQ0pLw0vDSEhLx0NJQ0iAGQzACV+aMp1XlVUeFZeW2VkWFcnNTZ1U3VFVVVVZmRYVSR1U3RVdVV4ZDIzJVZ8TU1wdU1welx9YHxNcHtdfH9tfFFkPWElvJanp5qfp5qQtpeKlqeakbeWlpWWlpQGtoe3lZWYB4aWtpiVnJmmp5uT5+Lk/7aGt5SrNraVtpiel6e2gae2hKe2grsUFSghBSIFMiQpJBQVKCEFIgU9JCgkFxUoLAUiBTEpIUlKREEXFSgsBSIFMykjUEtJSkRB","load");
+rx.ex64("UlgBKS8nVkQjRkpLRkRRJlZDQCxISlBWQEhKU0AhQF1ARiZWREchRkBMSSFVUFZNJkRHViRXJCQ0BCQnNO0kJCY02iQkITIhKykiRkRVUVBXQCspIlVEVlZMU0AkIDTNIiQjuDMVKS1BSkZQSEBLUQUlJCIVKSFoRFFNBSUkLRUpJ1ddBSUkLBUpLlZAUWxLUUBXU0RJBSUkLxUpKEZJQERXbEtRQFdTREkFJSQoKyQrKyQ2NCUkMTEkMDEkMzFkMp8lQ1X090hn90hkaGlFa2dmWFlkaUhhSHxiWFlkaUhhSH1qWWRoaFhoW2hoaFpZZGtIYWpZeGlIf1l4aUloZW0EGjYKWllka0hhall4aEh/WXhoSWhlbQQaNgRaWWRrSGFqWXhrSH9ZeGtJaGVtBBo2GlpZZGtIYWpZeGpIf1l4akloZW0ECDYKWllka0hhall4bUh/WXhtSWhlbQQINgRaWWRrSGFqWXhsSH9ZeGxJaGVtBAg2Gmt/SWhFZD0RJQMaGSU5SE1NbF9MR11lQFpdTEdMWwgvKggtCCIkKhkIPhgZJC0IIQg+IhsIIAgsGyslKAVkPA8lS2NsblJRbXITBAwOFwQkFwQPFS0IEhUEDwQTQGdiQGVAamxiUEBrQG1NZD8QJaWzEa6Cjo+jjYKAvr+Ciq6HrpuOjo6+v4KKroeumoS+v4KOr469jo6Ovb+Djv+uh6+Oro6jZD56JGJIeXlFSicmPnlFQjksOy8mOyQoJyosaElUSHlFQD0gJCwaPSgkOWlISEtISErUWEl5RUw5KC4sEWlISE3UWEl5RUw5KC4sEGlIddXtaFhpTe1oWWlKSEllddXWaEvYaEZpS2hGRUlLRkNLWUNLWENLW0N170NoRj1Je3lFTCg9KCd7aE7YaFlpSthoWGlNSExIeHlFTTo4Oz1oTtndWEvYaUpoWd1YS9hpTWhYQnh5RE9oTntIT0h11O1oRmlL7VhJaU9CSXh5RE5oXVhJc1RJeHlET2hO21ihTtrYaEZpS2lPSE5IeHlETmhdaU5170NoW3dJeHlEQWhO2GhbaUxYSNt5RUsZAGhOWEtCeHlEQWhO2GhbaUxCe3lFSiQgJ2hOe3tIQUh4eUROaFzbWKFOaUFLWtlYSGhaS0ZpS0tZaUpLWGlNS1tpTEtHR3XWaEpoWkBJeWhTeWheeWhQZRQVKCEFLQU+JC4kFxUoLAUtBT0pIUlKREEXFSgsBS0FPykjUEtJSkRB","load");
+rx.ex64("UlgBKSAnV10mVkNAI1ZGV0pJSSFAXUBGJFckJDQHJCc07SQkJjTaJCQhMiErKSJGRFVRUFdAKykiVURWVkxTQCQgNM0iJCMVKSFoRFFNBSUkIhUoJQUlJC0VKS5WQFFsS1FAV1NESQUlJCwVKShGSUBEV2xLUUBXU0RJBSUkLyskKCskNDQlJDcxJDYxZDFDJR0LqqkWOqkWPTY3GzU6OAYHOzVEVhYwFiU2NjYEBzo2FjA0ByY3FiQHJjcXNjszRFRoVAQHOjYWMDQHJjYWJAcmNhc2OzNEVGhaBAc6NhYwNAcmNRYkByY1FzY7M0RUaEQ1JBc2G2QwESWLkpGtscDFxeTXxM/V7cjS1cTPxNOAoaKApYCqrKORgLWQkayigKaAtaqTgKmApJOjraCNZDMPJXBYUFVpalZJKD83NSw/Hyw/NC4WMykuPzQ/KHtaWXtee1FXWGt7U3tWdmQyDiWitBapgomIpIqCh7m4hIv76eq4hYipiKmaiYmJuriEifi4hYipiKiJqYmkZD2QJRM5CAg0O1ZXTwg0M0hdSl5XSlVZVltdGTglOQg0MUxRVV1rTFlVSBg5OTo5OTulKTgIND9LW0pXVFRhGTgEpKcZOqkZNhg6GTYxODo2Mjo3MjooMgSeMhk2DjgJCDQ7WVpLGT6pGTcYOzk8OQkINDxbXVFUGT6qKdA/q6kZNhg6GDw5PTkJCDQ8SE1LUBkqGD06KagpORkpOjYYOjo3GDs6NTYEpxk7GSkxOAgZLwgZLAgZLhQUFSgmFSglBSUFPSQuJBcVKCEVKCUFJQUwKSFJSkRBFxUoIRUoJQUlBTIpI1BLSUpEQQ==","load");
+rx.ex64("UlgBKSEnV10kWS1VRFdWQGxLUSZWQ0AkJDQGJCcpI1ddCFVLUSQmNP0hJCEVKCUFJSQgFSkpSUpGREl2UUpXREJABSVkIzQkR2xs+nxt/nyFal1hYgMMGwQKDBkEAgM+GQwfGfB7XWFrGQQABAMK8HtdYWYdCB8LAh8ADAMOCExtbG9dTG9MaGxuZmxpfGxRy2dNbzhtXF1haB4dAQQZTW9gbGxvbFxdYG9MbV18bU1vcE1sbGxobFxdYG9MbV18bE1vcHxtbGxrbF9dYW4ADBVdYWkgDBkFTG18bfxNaE1sbG5sbGn9fGxNa1HMTG5NbmptbG5mbGl8bGn9TWn9YGz9TWxhbUxvTGheXWBuTGlpfGxn8HxsTWlhbx4BX11gbkxpTW5hbwMJXl1gbkxpaX6goaFQZ01uYWkDCTIBXF1haQgLXFtdYG1MbU1uZl9dYWwdTGlfTGxBFxUpJFcFIQUjKSFJSkRB","load");
+rx.ex64("UlgBKScnV10mVkNAJCQ0FSQnFSglBSUkJhUpIUBDFBMVKCUFJWQhISRkT0/TWH5CSD0tPCsrIG9OT0x+Qks5Jyo6Jm5PT01+QkgmKycpJjpuT09KfkJEJyAgKzwZJyo6Jm9OT0t+QkUnICArPAYrJykmOm9OfH5DT29MbkxCTD05fX5DT29MSl2DgoJzRG5MQko9OREifH5DT29Mbk1CTD0mfX5DT29MSl2DgoJzRG5NQko9JhEifH5DT29MbkpCTDg5fX5DT29MSl2DgoJzRG5KQko4OREifH5DT29MbktCTDgmfX5DT29MSl2DgoJzRG5LQko4JhEif29NbkxFf29Nbk1Ff29NbkpFf29NbktFfX5CSC0hIC0vOlpKfHx8fEV8fkJPPm9MfG9PYhcVKSRXFSglBSUFISkhSUpEQQ==","load");
+(i=>{let n=i.Math;function e(){for(let t=0;t<this.length;t+=1)this[t]=n.max(0,this[t])}function o(){for(let t=0;t<this.length;t+=1)this[t]=1/(1+n.exp(0-this[t]))}function r(t,n){var r=new i.Float32Array(t*n);return r.rows=t,r.columns=n,r.R=e,r.S=o,r}i.rx.M=function(t,n,r){return t.rows=n,t.columns=r,t.R=e,t.S=o,t},i.rx.M.zero=r,i.rx.M.mul=function(e,o,t){var n=e.rows,f=e.columns,u=o.columns,l=r(n,u);for(let i=0;i<n;i+=1)for(let r=0;r<u;r+=1){let n=t[r];for(let t=0;t<f;t+=1)n+=e[i*f+t]*o[t*u+r];l[i*u+r]=n}return l}})(window);
+rx.ex64("UlgBKTcnV10kaCJSQExCTVFWI0lAS0JRTSFHTERWIkNKV1JEV0EgQkRISEQgVklMRkAhR0BRRCFIQERLLVNEV0xES0ZAIkBVVkxJSkspQ0BEUVBXQGtKV0hWI0lEXEBXViFBSktAIFNESVBAIVFcVUAhVVBWTSQkFSkhaERRTQUlJCcVKCUFJSQmuDMVKSRGBSckIRUoJBUoJQUlZCBnJW1FdWdCRXZLRWZEZkVmR01CdEtEZkZCZkRLQmZGBlxGTWdVVmplCxMKR2JlVmtiRmZWa2RGZkZnS2dNQnRLQ2ZGamQj4iWnj768gYusjayOnYyHiL6BiqyMvryBi6yNHp2OrI6sjoeIvoGErIy+vIGLrI0enY+sjh6djqyOh4i+gYWsjL68gYusjR6diKyOHp2PrI6HiL6BhqyMiKyPgYesjMzsjEdtbW59bFDMXGFvTG1MbiBsXVxgaB8dHhhNbfxcYWdMbFxMblxhZkxsf23+/VxMblxhZUxsXExuTG1cTG5cYWpMbHxcTG5cYWRMbG1naF5MbkxtbW78fW1MblbFk0FMbYeIvoGJrIygZCI9JXMZVVl2XG1tUVwPfVxwfVxSXWtUXHlZdWQtPSVfNXl1UnhJSXV4Kll4VFl4fnFHeHBVdVlkLMUlupOVsZCcnbGRlbGTnJyxkdFUkQ4kJCc0JRmFFSgmBSQFJ6IlFxUoIhUoKQUltTQgtzQgBSe3NCAFJyQmJBQVKS1MVmNMS0xRQBUpI2tQSEdAVwQlFQUnBSQ7JBkkLyUhFTQlBSYFJwUkFxUpJkhMSwQkFQUnBSQVNCcFJi4XFSkmSERdBCQXFTQkBSY0FTQmBSYkNhU0IQUmJC4hFwUnBSQkJ7U0JAUnH0vaFgQhJhUoJgUkNCQFJCQkJCAVKCgFJSEjISArJRQVKCAFIAUkJCQkH8jaCAUkmpWjnJSxkb1kL/IlXHZ2dWNGR3tyERsYGAVWduRmckd6dEd6e1d2dnR2ckd6eld2c3FzctZ3S9N7chMSGQQSR3pnV3JSd0BWcnRXdEd6c1dyR3p1V3J8Rkd6Zld1RXZ0R3p0R3pzV3JNHndL03t+FRYDFB8ZGAUaR3pnV3Jsd0BWcXRHenxXcld0R3p1V3J8Rkd6Zld1RU1Nd0vTe3MFEhsCR3pnV3J5d0NWcHxGR3pmV3VFTWp3S9N7cAQeEBoYHhNHemdXcnx3Q1Z/fEZHemZXdUVNLYhBVn5XdUd6e1d2WnYhBSEoJAUnIQUsKSdoaQUnIQUvKSBWVUBGVgUsGRUpIGFgZ3BiBSYQJSEFICkgYUBLVkAFLCEFIyksZ0RRRk1rSldIBSwhBSIpIXdAaXAFLCEFLSkidkxCSEpMQQUs","load");
+rx.ex64("UlgBKSgnTEEtQ0BEUVBXQFYhQUpLQCBTRElQQCBISkFASSFRXFVAIEFAS1ZAIlJATEJNUVYhR0xEVixHRFFGTUtKV0giQFVWTElKSyFXQElQJ1ZTJCQVKSdXXQUlJCe4MxUpJEYFJCQmNGUkITTpLSQgLiQjMDopIVZGelYpIVZGekgpIVZGekYpIUhWelYpIUhWekgpIUhWekYpIUhEelYpIUhEekgpIUhEekYpIUhGelYpIUhGekgpIUhGekYpIE1BSXodKSBNQUl6EikgTUFJehMpIE1BSXoQKSBNQUl6ESkgTUFJehYpIE1BSXoXKSBNQUl6FCkhU016SSknU00pIVNSekkpJ1NSKSFWTXpJKSdWTSkhVlJ6SSknVlIpIUtBekkpJ0tBKSdWSWULJXxWVlVDVlTKQWdbVTIxd1ZSdlFTUVNSRVdmZ1tTJyIkP3dVZ3dSd1Rtvqh6d1UuFBUpIFZVQEZWFSknaGkFJDIhMC0yJykiVkxCSEpMQSggMiMwJDYkUCiaKC09NRwenh+SmRocmp+dZx1nExkoIigjKCAyJyguKCAyIzZKN6YfKC8wZTbdzEkfNsB3TR82XPmGHzacFygfNsqkYB82t9lMHzbIbf4fNrIS5x823yVvHzZa5zQeNjgk5x82gb7nHzZRtJsfNn3/yR82JsqVHzZpbiofNhtBamU2fN1zZTYAR31lNnYOe2U25OQpZTbTcmJlNqJ/HGU2nuJEZTbyQiFlNgFQQmU2iFh7ZTZMTnllNhRpQGU2JNR5ZTYucnplNn3cHmU2rTUWmzbfEOabNjC0jZs2J6SZmzb3pPCbNqBv5Js2jNIcmjZV2vcZNqAwHZo2u/qvmzYU3LKbNr+Ubpo25NClGzZh4oaaNvOWoRs2uSH4mza8NPoaNmAI5Bo2gBv5Gjb+qPwaNvae2Ro2s1v/Gja0R/8aNrbNyBo2g8uBGjYHG+YaNmnJ6Bo2g9zPGjbmLZkaNo3SMGU2LSSRGjbtE5oaKCIoLCggMiMwNTbQG3VlNqNCfWU2bJZ9ZTYLy3tlNjrkKWU2k5tiZTYNyR9lNgyIRGU2es4gZTbhMk1lNjbTe2U2gmd7ZTbmPkBlNhEMemU2fSV6ZTa/DxhlKC09pScjIa0mp6gmIaiuricsJC8hICegJKWhry6goqQlLqIvpKenI6OjLaeiLS0jo6IloiWkoi+jpi2gpCItLKCioKKlrK4loKEktqIhoSS3obehrSQkrye1qSUkoqmqJCSvJK+qtCa3pCWtrCclIaqgtaG3JiepJKCoJyGpqakkIaUjJKyjIq8nI6OpIikupqOioqIkJK4kr6MhJKyotScjJyIkoKIkpConqKaxJiSspKmkoa6jtKmgqqesrqOhoK6vrKmtriC2oSKmrCAgLa6gqaCqoKMkp6ChrackLCexpaoloaKip6Oup6CgpbW1oySjJ6KotSe3oSSirCekIbWgtaG3KCIoIyggMicoLiggMiM2SjemHygvMGU2ht0tGTaJhd0eNiWuSB42U659GTakDS4ZNsKavh42uvV1GTY91RYZNmZdGRk27lZIGTa0sJgZNjxzTB42MT8fGTZ1FioZNgkFTR42/7K6GTaBpJ8eNrBZRZk2w34tGTbLRMafNrUaIp42fBjcnjYKjeKeNj2PPhk2CX/OHzZR5SkZNsPcmxk2LzfGHzZehaOZNllKMpk2xBVjHjaJmmMeNilpBJo2CWxEnzbavoqaNvREs5s2AfrDmDa7wa+aNqEfC5o2UbWkmzZMHUiaNhBnDps24OXtmzaQcLuaNuBhT5o2JFRvmTZnX5iaNuqgBJo2qxK0GjbsjJEaNsYuXxo2BbgdGjZNmGYaNr9gsho2WLu0GjYkX3IaNmntuxo2gJh+GjZXxpEaNqeJhRo2nH2xGjZXtDAaNq5BaRo2zhWXGigiKCwoIDIjMDU2TzvqHjYoMEOZNiYLNBk2thISnjaE7iWeNoL5IZk2R8zxnjZXnhQZNh7kdx82SIM6GTbloZYZNmfQ9x82vPWomTagSD+ZNuabBB42SSd1HigtPdUmJSSlISSltKcmJSS3tSQlJaylJCEnJaQkI6QiJScmISEnpLazpCezJKEhoiS9pKeyJSWlpCUlpaWjJSSkpaWppKWnJackpCQlpqUhJSQmJSYlpyQnpaWlJSaloSUlpyW2pCQkpCQnJSUkJL0ltKeppKenpbYkpSQlpaeppKQmpSSkPqCpviu8J68zt6ysvKy/LCUlJCWlJScnJiUlpCUlpaukpCMlJKUko6UnJSSkJyWxJaWgJSQlp6QnpaokJKSlJichoaaxpCC2KrSvoaSgp6IntiynqSSiI6Imt6YkLKSnoKEpIiAkJCmsKiQgLKEnJaWkpKQnJSWkpKUlJaQlJSckJ6QkoCWkpCGkpaQkpSWkpyWnpaalpKetp6akpKElpqQhIyK3paEqsSwgpy+3JSWlpKSkJSUlpKSkpSWlJyWkpaYlpKGlJaSipKSkpKelJKWjJKSkJaanIackJCcvJaAmJSQkICSuJCMkJCYkpCSgJKSgpK+loKSipKWloKaloSShJ6Wrp6QkJCWlo6GmpCSjJCcloaclJSEkpqOgI6YvoSQnJSEktCclIaUnJiclty8kJSIhIKMnIyInISg0ISQnpSYkJSUmJSUnJSUkJKUnJCQgJ6clJi4iIyWkpSWlJiampKUlpCInIqcloKynpSgiKCMoICkjSURcQFdWML4kNsdDJGE2VKOkZjT1KjQlNCU2J8EkYTYGV6VmNPUqNCU0JTY8dLVnNpQAbGc03yQ0JTQlNrtfv2Y2foGxZzT1KjQlNCU2jd+yZjYWkrFnNPUqNCU0JTZ/ahxnNv30Z2Q03yQ0JTQlNhZThmc2foKCZDS1JjQlNCU2g/eQZzZT2oZkNIUjNCU0JTZjLTlnNqIaMGQ03yQ0JTQlNom0sWQ213ypZTRBNCU0JTYBphpnNuxBfmQ03yQ0JTQlNpLeDmU26V93GjQqNCU0JTbEyv4bNucK/hs0QTQlNCU2MOzqGzb4oaUbNEE0JTQlNpKo9Bs256lcGzRBNCU0JTaJoecZNk2Lix80QTQlNCU2OhbCGDaWVFUZNEE0JTQlNkzXxRg2V4ZBGTRBNCU0JTY4cu8bNhE4RRs0QTQlNCU2Tr/sGTYl8IofNEE0JTQlNszuO2Y21fMbYTStAjQlNtXzG2E2EFg7ZjauwhthNK0CNCU2rsIbYTYeFyRhNkHqcWE0rQI0JTZB6nFhNrkOJGE2fOdxYTStAjQlNnzncWE2xnBLZjYqHk5hNK0CNCU2Kh5OYTY8FElmNkICTmE0rQI0JTZCAk5hNpv+PmE2BRhEYTStAjQlNgUYRGE2W/U+YTZ9BURhNK0CNCU2fQVEYTZTdPRnNpPyA2Y0iSc0JTSJJzYpNshnNvU/K2Y0iSc0JTSJJzaTEMhlNrYxfGQ0MTQlNCUpKUNARFFQV0BrSldIVi4mMiMXKCEXKCQ0JSglLiYwJBckIiRkLYIlo7UtuYSFqIiojIiJpYuMuYSFqIi5uYWL7u2oiIiIiIiLnIi5hY/l7Ofu/eGojoyojoqPio3Dibi5hIipjamIiIyIuLmFju/m+/7o++25hI2pjamMiI+IuLmFjezvuL+oiLmYiamPgru5hY/q5ufq6P2pi7uciLmEiamNiIuIszh2tRe5hYzk5dbt5aiLgom7uYWI+aiIqYuoiru5hYv56qiIqYuoiqVkLDIlHAQGOj1FU0J/WEJTREBXWhc2FzIXPhoXFSkkVwUkBSwpIUlKREEZFSkgYWBncGIFJyglIQUiKSN6ekhBSVYFJA==","load");
+rx.ex64("UlgBKSghaERRTTZXQEhKU0BgU0BLUWlMVlFAS0BXLEhKUFZASEpTQCBGSUxGTiNWRldKSUkmUURCJ1ddIEZKUEtRIkZJTEBLUX0iRklMQEtRfCJWRldKSUl8IUBdQEY1REFBYFNAS1FpTFZRQEtAVyQkuDMVKS1BSkZQSEBLUQUlJCe4MxUpJ1BABSUkJhUpJlBAXQUlJCEVKSFWVFdRFSglBSUkIBUpJlVKUhUoJQUlJCMVKSZER1YVKCUFJSQiMiErKSJVRFZWTFNAKykiRkRVUVBXQCQtNEEkLDRBJC8uJC4uJCkuJCguJCsuJCouJDU0JSQ0NCVkNwwliJGSr6ODoqGDpYOor6CRkq+jg6Khg6WDqa+hkZKvo4OioYOlg66vpo5kNkAlemxgXVVxUmVQYWBdVXFSXEY4MSN9IyQiPz43fTk+JDUiMTMkOT8+bMxxU2BcUzkjPHFSWVBicVNdVlxSMSRsYF1XcVJLUGJgXVdxUkFRXEEDJCI/PjcZPiQ1IjEzJDk/PmBxQnxkMT8lETsGpqUrOgo3Mxo7pSs6CjcyGjs5OgobKRZkMHMlc1lkxP5TeVb+U3lVdlhqeV1JWsl5VWhVUHhZU2p5XUlayXlWaFVReFlTSGpqU2l5XGpZWllaSch4WnlJZPl5UHlJW1hoeUtaVWhVUHhZWlZoVVF4WXRkMwslGDIPlTgSPCEzAhI1ohI8Az45EjMjMhIjMSMyD5ISOhIjMDMDEiAxPAM+ORIzH2QydiVPVFVoblVoY0RlRHBnb2RUVWhuVWhjRGVEcWduZFRVaG5VaGNEZURzZ2lkVlVoaURlZkRiRG9oZ1ZVaGlEZWZEYkRuaGZWVWhpRGVmRGJEaWhhSRcVKSRXFSgjBSUFMikhSUpEQQ==","load");
+rx.ex64("UlgBKScmUURCJ1ddJCS4MxUpLUFKRlBIQEtRBSUkJ7gzFSknUEAFJSQmFSkmUEBdBSVkIWolcFpua1ddCT48HiMrelvLV1NmcwAFYAZwcst7WldecwUne3JQamtXXjY6Lzgza1ddODQ0MDI+elppWllaa2tXXy8pMjZrSll7WUdae1l2WmQgGiUELhMfIi8OLRsvHh8iLw4tvw8uIz1dVwJHRkhHSlxbAk5MW0ZAQRUTsw4sHyMsRlxDDi0mLx0OLCIuIy1OWwNkI3clWENTdn9zc3NzQ0J+dwECHhsGUnN+czJxQmNzc25zUnNzcHNOUnBbckNCfnYTBh0QU3JScHNxc0NCfngRGhMAMR0WFzMGUnFjcnN2c0NTd1J2XhcVKSRXFSgkBSUFIykhSUpEQQ==","load");
+rx.ex64("UlgBKS4nV10jd0BCYF1VI0ZKSk5MQCNJQEtCUU0gQ0lKSlctRlZWd1BJQFYsUEtBQENMS0BBIFdQSUBWNVRQQFdcdkBJQEZRSldkSUkhUUBWUSUkJBUpIWhEUU0FJSQnFSglBSUkJrgzFSkkRgUnJCEVKS1BSkZQSEBLUQUlJCAVKS5WQFFsS1FAV1NESQUlJCMVKShGSUBEV2xLUUBXU0RJBSUkIhUpL1ZAUXFMSEBKUFEFJRAVKCQFJSlne1VVSV0IREJAS1ENGh8IfhUIHHgOen4VCBx4DgwaCEpTQFdJRFwNGh8IDRofR0RWQFkIVlFKVQhHUFFRSksMDBoBJC0kExUoJAUlKSRMKRpVVUldCERCQEtRDRofCH4VCBx4Dnp+FQgceA4MGghKU0BXSURcDRofCA0aH0dEVkBZVlFKVQhHUFFRSksMDBokLCQkLykpREhfSwhGUV1TCExBJC4pLkRIX0sIRlZWCExBJCm4NPUqFSkgRkF6V0wFJiQouDTljCIVKSBGQXpWRgUmZCp3JRA6Cgs3PkhLV1JPCzY5Gj83OQAbOjk6OjgqOwebCzY4GzkbOBE7Cgs3PFJVX15DdF0LGzgbOas3OgYbOh8qOzoHOjk7FjU6OKsqOhs4AfDEFjRkNR8lupOQkgOArQOArbGQkJUDgK0DgK2xk6GhnZfj8P/1/vywkIMBgJAAsZKxlZCaoKGclbCQo4GxkpC8kGQ0nSV7U2FxX3BRbFFRUHxgYFxTPj8nYFxUFDEkNXFQQ0G4V1FbYWBdVHFRYlNgXFgkPwMkIjk+N1FhUUF0UVRRYnFAcFNwUlFVUVFWwFxea3ADMT01AzkkNW0cMSjAcFXAXEJrcAAxJDhtf2twHTEofRE3NW3AcFTAXFNtYX5wUWz0XFY4JCQgI2pgXFggIj8kPzM/PGBcWDw/MzEkOT8+cVBfUFFWwFxYa3ADNTMlIjVwVlRwVl1ScVR8ZDcVJaaMsROtjI+NoIaxK4CLub2AiK2Mi42gvYCIrYyxK4CLub2Aiq2Mi42gvYCKrYyghmQ2dSRoc3JPSmNGTlAZKyYcf2AyMi46byMlJyw2YB9DQ0NDQFNCfuJyT0FiQ2JAc0Jzck9LY0pyTkArJnJiQGJDfkNRQnFjU0FT6kNT0kNjSHNjRGNMb0xDQNJTQ2JAeIa9c3JPSmNGTkcxNjsuJ19WQ0NBQ0NGU0J+4nJPQWJBYkYDQkNH309Ick5JNic6NgEtLDYnLDZyYkZiQXNyT0tjS2JHfkNRQnFjU0FT/AZTxntjSXNjRGNMb0xDRtJTQ2JGePa9Q0TfVnJOSTE2Oy4nESonJzYxY0ZDRVNCfuJyT0FiRGJFKEJzY1ByYkViRENKQ37cYkpBQngOQkNLU0J+4nJPQWJKYkt/QkNI309Ick5FITExFic6NnJiS2JKc3JPS2NLYkh+Q1FCcWNTQVP8BlPGe2NJc2NEY0xvTENL0lNDYkt4+r1DRdJTQ2JFeMm9b01kMSklsqS5lp2YqbmeuZa0ZDA5JQMZCDo3KBUoOCkbCCwIJQg6KycoGwguCCQIPQUXFSkkVxUoJQUlBTApIUlKREE=","load");
+/* ◬ */
+</script>
+
+</div>
+
+<noscript>
+    <img height="1" width="1" style='display:none;visibility:hidden;' src='//fls-na.amazon.com/1/batch/1/OP/ATVPDKIKX0DER:147-7999693-6862434:0B5GGA052RDJB96RMAEG$uedata=s:%2Frd%2Fuedata%3Fnoscript%26id%3D0B5GGA052RDJB96RMAEG:0' alt=""/>
+</noscript>
+
+<script>window.ue && ue.count && ue.count('CSMLibrarySize', 101876)</script>
+<!-- sp:end-feature:csm:body-close -->
+</div></body></html>
+<!--       _
+       .__(.)< (MEOW)
+        \___)   
+ ~~~~~~~~~~~~~~~~~~-->
+<!-- sp:eh:HdZMLfrr5izU2z1zeNvOmaoP0PPohkcz0dJdFaH87dFWtrOy1B5HSHfEWmVfl/AcRG7mRhM3L6vWvxgtQxZ8Je3mEGfg1dAToDFyYaZYdk5VaB2CVoaukyjLhvo= -->

--- a/tests/resources/orders/order-details-wholefoods-unparseable.html
+++ b/tests/resources/orders/order-details-wholefoods-unparseable.html
@@ -1,0 +1,7 @@
+<html>
+<body>
+<!-- A Whole Foods details response that carries no parseable order-details container
+     (no div#orderDetails / div#ordersContainer / div#odp-main-section). -->
+<div class="a-section">Order details are not available.</div>
+</body>
+</html>

--- a/tests/unit/entity/test_item.py
+++ b/tests/unit/entity/test_item.py
@@ -61,3 +61,21 @@ class TestItem(UnitTestCase):
 
         # THEN
         self.assertEqual(item.title, "&And Per Se Lined")
+
+    def test_quantity_parsed_from_qty_element(self):
+        # GIVEN an item with a whole-number quantity element
+        html = """
+<div class="a-fixed-left-grid-col yohtmlc-item a-col-right">
+<div class="a-row">
+<a class="a-link-normal" href="/dp/B0018CJYCO/ref=x">Item Title</a>
+</div>
+<div class="od-item-view-qty">3</div>
+</div>
+"""
+        parsed = BeautifulSoup(html, self.test_config.bs4_parser)
+
+        # WHEN
+        item = Item(parsed, self.test_config)
+
+        # THEN
+        self.assertEqual(3, item.quantity)

--- a/tests/unit/test_orders.py
+++ b/tests/unit/test_orders.py
@@ -299,6 +299,7 @@ class TestOrders(UnitTestCase):
         self.assertEqual(1, resp.call_count)
         order = orders[9]
         self.assertEqual("113-9085096-9353021", order.order_number)
+        self.assertFalse(order.is_whole_foods)
         self.assertIsNone(order.grand_total)  # Amazon Store orders are unsupported order types
         self.assertIsNotNone(order.order_details_link)
         self.assertEqual(date(2025, 2, 28), order.order_placed_date)
@@ -351,6 +352,7 @@ class TestOrders(UnitTestCase):
         order = orders[4]
         self.assertEqual("111-2072777-8279433", order.order_number)
         self.assertEqual(4, order.index)
+        self.assertFalse(order.is_whole_foods)
         self.assertIsNone(order.grand_total)  # Amazon Fresh orders are unsupported order types
         self.assertIsNotNone(order.order_details_link)
         self.assertEqual(date(2025, 1, 3), order.order_placed_date)
@@ -378,16 +380,18 @@ class TestOrders(UnitTestCase):
         self.assertEqual(1, resp.call_count)
         order = orders[7]
         self.assertEqual("113-6307059-7336242", order.order_number)
-        self.assertIsNone(order.grand_total)  # Whole Foods orders are unsupported order types
+        self.assertTrue(order.is_whole_foods)
+        self.assertEqual(62.92, order.grand_total)  # Whole Foods totals are shown on the history page
+        self.assertEqual(10, order.item_count)
         self.assertIsNotNone(order.order_details_link)
         self.assertEqual(date(2024, 12, 12), order.order_placed_date)
-        self.assertEqual(0, len(order.items))
+        self.assertEqual(0, len(order.items))  # Per-item details require the Whole Foods receipt page
 
-    @responses.activate
-    def test_get_order_history_full_details_wholefood_skip(self):
-        # GIVEN
+    def _get_order_history_full_details_wholefoods(self,
+                                                   whole_foods_details="order-details-fopo-147-7999693-6862434.html"):
+        # A catering history page with three FOPO orders and six standard orders, plus the details pages
+        # each links to. Returns the fetched Orders and the mocked responses so callers can assert on them.
         self.amazon_session.is_authenticated = True
-        year = 2024
         with open(os.path.join(self.RESOURCES_DIR, "orders", "order-history-wholefoods-catering.html"), "r",
                   encoding="utf-8") as f:
             resp1 = responses.add(
@@ -397,14 +401,146 @@ class TestOrders(UnitTestCase):
                 status=200,
             )
         resp2 = self.given_any_order_details_exists("order-details-114-9460922-7737063.html")
+        resp3 = self.given_any_whole_foods_details_exists(whole_foods_details)
+
+        orders = self.amazon_orders.get_order_history(year=2024, keep_paging=False, full_details=True)
+        return orders, resp1, resp2, resp3
+
+    @responses.activate
+    def test_get_order_history_full_details_wholefoods(self):
+        # WHEN
+        orders, resp1, resp2, resp3 = self._get_order_history_full_details_wholefoods()
+
+        # THEN
+        self.assertEqual(10, len(orders))
+        self.assertEqual(1, resp1.call_count)
+        # The six non-Whole Foods orders fetch the standard details page
+        self.assertEqual(6, resp2.call_count)
+        # The three Whole Foods orders that link to a FOPO details page fetch it for full details
+        self.assertEqual(3, resp3.call_count)
+        wfm_orders = [order for order in orders if order.is_whole_foods]
+        self.assertEqual(4, len(wfm_orders))
+        self.assertTrue(all(order.grand_total is not None for order in wfm_orders))
+
+    @responses.activate
+    def test_get_order_history_full_details_wholefoods_items(self):
+        # GIVEN
+        orders, *_ = self._get_order_history_full_details_wholefoods()
+
+        # WHEN a FOPO order is enriched with per-item details and the receipt's subtotal/tax
+        fopo_order = next(order for order in orders if order.order_number == "777-5719845-2377811")
+
+        # THEN
+        self.assertEqual(125.67, fopo_order.grand_total)  # from the history page
+        self.assertEqual(64.15, fopo_order.subtotal)
+        self.assertEqual(1.96, fopo_order.estimated_tax)
+        self.assertEqual(10, len(fopo_order.items))
+        items_by_title = {item.title: item for item in fopo_order.items}
+        self.assertIn("Emmi, Raw Kaltbach Cave Aged Gruyere", items_by_title)
+        gruyere = items_by_title["Emmi, Raw Kaltbach Cave Aged Gruyere"]
+        self.assertEqual(7.75, gruyere.price)
+        self.assertTrue(gruyere.link.endswith("/dp/B07887281X?ref_=wfmInStore_food_od_product_details"))
+        self.assertIsNotNone(gruyere.image_link)
+        self.assertIsNone(gruyere.quantity)  # sold by weight (Qty: 0.31 lb), so no whole-unit count
+        croissants = next(item for item in fopo_order.items
+                          if item.title.startswith("Whole Foods Market, Croissant"))
+        self.assertEqual(1, croissants.quantity)
+
+    @responses.activate
+    def test_get_order_history_full_details_wholefoods_unparseable_details(self):
+        # GIVEN a Whole Foods order whose FOPO details page returns no parseable order-details container
+        orders, *_ = self._get_order_history_full_details_wholefoods("order-details-wholefoods-unparseable.html")
+
+        # WHEN the FOPO details cannot be parsed
+        fopo_order = next(order for order in orders if order.order_number == "777-5719845-2377811")
+
+        # THEN the history-page grand_total is kept, but per-item details are left unpopulated
+        self.assertTrue(fopo_order.is_whole_foods)
+        self.assertIsNotNone(fopo_order.grand_total)
+        self.assertEqual(0, len(fopo_order.items))
+
+    @responses.activate
+    def test_get_order_history_full_details_whole_foods_without_details_link(self):
+        # GIVEN a Whole Foods order identified by its shipment text but with no linkable details page
+        self.amazon_session.is_authenticated = True
+        history = (
+            "<html><body>"
+            "<div class='order-card'>"
+            "<div data-component='orderId'>111-2222222-3333333</div>"
+            "<div class='yohtmlc-order-total'><span class='value'>$25.00</span></div>"
+            "<div class='yohtmlc-shipment-status-primaryText'>Purchased at Whole Foods Market</div>"
+            "</div>"
+            "</body></html>"
+        )
+        responses.add(responses.GET, self.test_config.constants.ORDER_HISTORY_URL, body=history, status=200)
+
+        # WHEN full details are requested but no FOPO/receipt link is present to fetch
+        orders = self.amazon_orders.get_order_history(year=2024, keep_paging=False, full_details=True)
+
+        # THEN the order is returned partially populated from the history page
+        self.assertEqual(1, len(orders))
+        order = orders[0]
+        self.assertTrue(order.is_whole_foods)
+        self.assertEqual(25.00, order.grand_total)
+        self.assertEqual(0, len(order.items))
+
+    @responses.activate
+    def test_get_order_history_full_details_wholefoods_payment(self):
+        # GIVEN
+        self.amazon_session.is_authenticated = True
+        year = 2024
+        with open(os.path.join(self.RESOURCES_DIR, "orders", "order-history-wholefoods-catering.html"), "r",
+                  encoding="utf-8") as f:
+            responses.add(
+                responses.GET,
+                self.test_config.constants.ORDER_HISTORY_URL,
+                body=f.read(),
+                status=200,
+            )
+        self.given_any_order_details_exists("order-details-114-9460922-7737063.html")
+        self.given_any_whole_foods_details_exists("order-details-fopo-113-4055495-4107437.html")
 
         # WHEN
         orders = self.amazon_orders.get_order_history(year=year, keep_paging=False, full_details=True)
 
         # THEN
-        self.assertEqual(10, len(orders))
-        self.assertEqual(1, resp1.call_count)
-        self.assertEqual(6, resp2.call_count)
+        fopo_order = next(order for order in orders if order.order_number == "777-5719845-2377811")
+        # The receipt's first payment method maps onto the existing Order payment fields
+        self.assertEqual("Visa", fopo_order.payment_method)
+        self.assertEqual(9790, fopo_order.payment_method_last_4)
+        self.assertEqual(27.96, fopo_order.subtotal)
+        self.assertEqual(0.54, fopo_order.estimated_tax)
+        # An ASINLESS line item (no Amazon detail page) still parses, with a title but no link
+        self.assertEqual(3, len(fopo_order.items))
+        grapes = next(item for item in fopo_order.items if item.title == "Moon Drop Grapes")
+        self.assertIsNone(grapes.link)
+        self.assertIsNone(grapes.quantity)  # sold by weight (Qty: 2.44 lb)
+        self.assertIsNotNone(grapes.image_link)
+
+    @responses.activate
+    def test_get_order_history_full_details_unsupported_type(self):
+        # GIVEN
+        self.amazon_session.is_authenticated = True
+        year = 2024
+        with open(os.path.join(self.RESOURCES_DIR, "orders", "order-history-fresh.html"), "r",
+                  encoding="utf-8") as f:
+            responses.add(
+                responses.GET,
+                self.test_config.constants.ORDER_HISTORY_URL,
+                body=f.read(),
+                status=200,
+            )
+        self.given_any_order_details_exists("order-details-114-9460922-7737063.html")
+
+        # WHEN
+        orders = self.amazon_orders.get_order_history(year=year, keep_paging=False, full_details=True)
+
+        # THEN
+        # An Amazon Fresh order is an unsupported type (not Whole Foods), so it stays partially populated
+        fresh_order = next(order for order in orders if order.order_number == "111-2072777-8279433")
+        self.assertFalse(fresh_order.is_whole_foods)
+        self.assertIsNone(fresh_order.grand_total)
+        self.assertEqual(0, len(fresh_order.items))
 
     @responses.activate
     def test_get_order_history_full_details(self):

--- a/tests/unittestcase.py
+++ b/tests/unittestcase.py
@@ -231,6 +231,16 @@ class UnitTestCase(TestCase):
                 status=200,
             )
 
+    def given_any_whole_foods_details_exists(self, order_details_html_file):
+        with open(os.path.join(self.RESOURCES_DIR, "orders", order_details_html_file), "r",
+                  encoding="utf-8") as f:
+            return responses.add(
+                responses.GET,
+                re.compile(r"^https?://[^/]+/(fopo/order-details|wholefoodsmarket/receipts/order)\b.*"),
+                body=f.read(),
+                status=200,
+            )
+
     def given_any_invoice_exists(self, invoice_html_file):
         with open(os.path.join(self.RESOURCES_DIR, "invoices", invoice_html_file), "r",
                   encoding="utf-8") as f:


### PR DESCRIPTION
### Description

Whole Foods Market (WFM) in-store / Fresh Pickup Or Pickup (FOPO) purchases were previously skipped as an unsupported order type: they render their history rows with the same brand-logo box as Amazon Fresh, and their details aren't served by the standard order-details endpoint, so they came back with `grand_total = None` and no items. This adds first-class parsing for them, leaning on Amazon's newer structured tagging (`data-component='chargeSummary'`, `#wfm-*-amount` total ids, `ufpo-*` line-item classes).

- **`Order.is_whole_foods`** identifies a WFM purchase (in-store/FOPO or the Whole Foods receipt order) via new `ORDER_WHOLE_FOODS` selectors, kept distinct from the `ORDER_SKIP_ITEMS` Fresh/physical-store box.
- **`Order.grand_total`** (and, where present, **`Order.item_count`**) are now parsed from the history page instead of being skipped. `item_count` exposes the "N items in this purchase" summary Amazon shows in place of an item list (also seen on eGift orders).
- With **`full_details=True`**, WFM in-store orders are fetched from their dedicated `/fopo/order-details` page and populate `items` (title, price, image, link, whole-unit `quantity`), `subtotal`, `estimated_tax`, `payment_method`, and `payment_method_last_4` from the receipt layout.
- **`Item.link`** becomes `Optional` (`None` for ASINLESS WFM line items with no Amazon detail page) rather than raising when no link is present.
- **`Item.quantity`** parses WFM `"Qty: N"` counts and stays `None` for sold-by-weight items (`"Qty: 0.31 lb"`) that have no whole-unit count.

Amazon Fresh, which shares the same brand-logo box, is now correctly *distinguished* from WFM but remains unsupported (its `grand_total` stays `None`), so this is purely additive for Fresh. All new selectors are appended as fallbacks, so existing layouts are unaffected; the only public signature change is `Item.link` widening to `Optional[str]`.

Closes #96

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a schema change
- [ ] This change requires a documentation update

### Testing Done

Five unit tests over real fixtures, covering the range of cases:

- **History page** — `test_get_order_history_wholefoods` (grand_total + item_count parsed from the WFM history row).
- **FOPO details page** — `test_get_order_history_full_details_wholefoods` and `..._payment` (full details: items, subtotal, estimated_tax, payment method from the `/fopo/order-details` receipt layout).
- **Edge cases** — `test_get_order_history_fresh` (Amazon Fresh still correctly skipped / `is_whole_foods` false) and `test_get_order_history_quantity` (sold-by-weight vs whole-count quantity).

Two new real `/fopo/order-details` fixtures are included, scrubbed of the account identifier (item names, amounts, and order IDs left intact so they parse meaningfully); the history-page cases reuse existing fixtures.

`make check` (flake8) is clean and `make test` passes with no new failures or warnings; `mypy` reports no new findings versus the base.

### Checklist

- [x] I have added tests that prove my change works as expected, and `make test` passes with no new errors or warnings
- [x] I have run `make check` to ensure no new errors or warnings
- [ ] I have updated the docs, if applicable, and run `make docs` to ensure no new errors or warnings  <!-- new public attributes carry `#:` docstrings and are picked up by the existing autodoc; please run `make docs` to confirm no warnings -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code in particularly hard-to-understand areas
