### PR TITLE
feat: add order_filter param to get_order_history() for digital orders

### DIFF
--- a/amazonorders/constants.py
+++ b/amazonorders/constants.py
@@ -112,6 +112,7 @@ class Constants:
     ORDER_DETAILS_URL = f"{BASE_URL}/gp/your-account/order-details"
     ORDER_INVOICE_URL = f"{BASE_URL}/gp/css/summary/print.html"
     HISTORY_FILTER_QUERY_PARAM = "timeFilter"
+    ORDER_FILTER_QUERY_PARAM = "orderFilter"
 
     ##########################################################################
     # URLs for Transactions

--- a/amazonorders/orders.py
+++ b/amazonorders/orders.py
@@ -103,7 +103,8 @@ class AmazonOrders:
                           start_index: Optional[int] = None,
                           full_details: bool = False,
                           keep_paging: bool = True,
-                          time_filter: Optional[str] = None) -> List[Order]:
+                          time_filter: Optional[str] = None,
+                          order_filter: Optional[str] = None) -> List[Order]:
         """
         Get the Amazon Order history for a given time period.
 
@@ -119,6 +120,9 @@ class AmazonOrders:
         :param time_filter: The time filter to use. Supported values are ``"last30"`` (last 30 days),
             ``"months-3"`` (past 3 months), or ``"year-YYYY"`` (specific year). If provided, this takes
             precedence over the ``year`` parameter.
+        :param order_filter: The order type filter to use (Amazon's ``orderFilter`` query parameter). Useful
+            values include ``"digital-orders"`` to fetch Kindle and other digital purchases. When provided,
+            this is appended as an additional query parameter alongside the time filter.
         :return: A list of the requested Orders.
         """
         if not self.amazon_session.is_authenticated:
@@ -144,12 +148,20 @@ class AmazonOrders:
             filter_value = f"year-{year}"
 
         optional_start_index = f"&startIndex={start_index}" if start_index else ""
+        optional_order_filter = (
+            "&{param}={value}".format(
+                param=self.config.constants.ORDER_FILTER_QUERY_PARAM,
+                value=order_filter,
+            )
+            if order_filter else ""
+        )
         next_page: Optional[str] = (
-            "{url}?{query_param}={filter_value}{optional_start_index}"
+            "{url}?{query_param}={filter_value}{optional_order_filter}{optional_start_index}"
         ).format(
             url=self.config.constants.ORDER_HISTORY_URL,
             query_param=self.config.constants.HISTORY_FILTER_QUERY_PARAM,
             filter_value=filter_value,
+            optional_order_filter=optional_order_filter,
             optional_start_index=optional_start_index
         )
 

--- a/tests/unit/test_orders.py
+++ b/tests/unit/test_orders.py
@@ -894,3 +894,20 @@ class TestOrders(UnitTestCase):
 
         self.assertIn("Invalid time_filter 'last90'", str(cm.exception))
         self.assertIn("Valid values are 'last30', 'months-3', or 'year-YYYY'", str(cm.exception))
+
+    @responses.activate
+    def test_get_order_history_with_order_filter(self):
+        # GIVEN
+        self.amazon_session.is_authenticated = True
+        year = 2018
+        resp = self.given_any_order_history_exists("order-history-2018-0.html")
+
+        # WHEN
+        orders = self.amazon_orders.get_order_history(year=year, order_filter="digital-orders", keep_paging=False)
+
+        # THEN - URL must include both timeFilter and orderFilter
+        self.assertEqual(1, resp.call_count)
+        request_url = resp.calls[0].request.url
+        self.assertIn(f"timeFilter=year-{year}", request_url)
+        self.assertIn("orderFilter=digital-orders", request_url)
+        self.assertEqual(10, len(orders))


### PR DESCRIPTION
## Summary

Adds an optional `order_filter` parameter to `get_order_history()` that maps to Amazon's `orderFilter` query parameter. This enables fetching digital orders (Kindle books, digital software, etc.) which are not included in the default physical order history.

**Usage:**
```python
# Fetch digital/Kindle orders
digital_orders = amazon_orders.get_order_history(order_filter="digital-orders")

# Fetch digital orders for a specific year
digital_orders = amazon_orders.get_order_history(year=2026, order_filter="digital-orders")
```

## Changes

- `amazonorders/constants.py`: Add `ORDER_FILTER_QUERY_PARAM = "orderFilter"` constant
- `amazonorders/orders.py`: Add `order_filter: Optional[str] = None` parameter to `get_order_history()`, appended to the URL as `&orderFilter={value}` when provided

## Background

Amazon's order history page supports an `orderFilter` query parameter for filtering by order type. Passing `orderFilter=digital-orders` returns Kindle books, digital games, apps, and other digital purchases — none of which appear in the default order history view. This is useful for tools that reconcile Amazon charges against bank/card statements, since digital purchases appear as separate charges (e.g. "Amazon Kindle Services") and need their own order data to be categorized correctly.

The change is purely additive and fully backwards-compatible — existing calls to `get_order_history()` are unaffected.