### PR TITLE
feat: expose Item.asin parsed from the product link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - `Order.order_number` now uses the caller-supplied value as a fallback when the order number cannot be parsed from the details page; previously documented but unintuitive behavior.
 
+### Added
+
+- `Item.asin`, the product's ASIN parsed from `Item.link` (`None` for items whose link is not a product detail page, e.g. a "Buy it again" or offer-listing URL).
+
 ## [4.4.1](https://github.com/alexdlaird/amazon-orders/compare/4.4.0...4.4.1) - 2026-07-04
 
 ### Fixed

--- a/amazonorders/entity/item.py
+++ b/amazonorders/entity/item.py
@@ -2,6 +2,7 @@ __copyright__ = "Copyright (c) 2024-2025 Alex Laird"
 __license__ = "MIT"
 
 import logging
+import re
 from datetime import date
 from typing import Optional, TypeVar
 
@@ -35,6 +36,10 @@ class Item(Parsable):
         #: The Item link.
         self.link: str = self.safe_simple_parse(selector=self.config.selectors.FIELD_ITEM_LINK_SELECTOR,
                                                 attr_name="href", required=True)
+        #: The Item's ASIN (Amazon Standard Identification Number), a best-effort derivation from :attr:`link`.
+        #: ``None`` when the link does not point at a product page (e.g. a "Buy it again" or offer-listing
+        #: URL). Parsing never raises; a failure yields ``None``.
+        self.asin: Optional[str] = self.safe_parse(self._parse_asin)
         #: The Item price.
         self.price: Optional[float] = self.to_currency(
             self.safe_simple_parse(selector=self.config.selectors.FIELD_ITEM_PRICE_SELECTOR)
@@ -70,3 +75,11 @@ class Item(Parsable):
     def __lt__(self,
                other: ItemEntity) -> bool:
         return self.title < other.title
+
+    def _parse_asin(self) -> Optional[str]:
+        # Amazon's order pages don't expose the ASIN in a keyed element (no ``data-asin``); it lives in the
+        # item's product link, as the canonical ``/dp/<ASIN>`` or ``/gp/product/<ASIN>`` path segment -- a URL
+        # form Amazon has used for 20+ years. Encapsulated here so it can adopt a structured source if one ever
+        # appears on these pages. Any link that isn't a product page (or an empty one) simply yields no match.
+        match = re.search(r"/(?:dp|gp/product|product)/([A-Z0-9]{10})(?:[/?]|$)", self.link)
+        return match.group(1) if match else None

--- a/tests/unit/entity/test_item.py
+++ b/tests/unit/entity/test_item.py
@@ -39,6 +39,7 @@ class TestItem(UnitTestCase):
         # THEN
         self.assertEqual(item.title, "Item Title")
         self.assertEqual(item.price, 1234.99)
+        self.assertEqual(item.asin, "B0018CJYCO")
 
     def test_title_starts_with_ampersand_use_lxml(self):
         # GIVEN
@@ -61,3 +62,22 @@ class TestItem(UnitTestCase):
 
         # THEN
         self.assertEqual(item.title, "&And Per Se Lined")
+        self.assertEqual(item.asin, "B0CW5Y6PKG")
+
+    def test_asin_none_when_link_not_a_product_page(self):
+        # GIVEN an item whose link is not a product detail page (e.g. a "Buy it again" URL)
+        html = """
+<div class="a-fixed-left-grid-col yohtmlc-item a-col-right">
+<div class="a-row">
+<a class="a-link-normal" href="/gp/buyagain?ie=UTF8&amp;ref_=ppx_od_dt_b_buy_again">Item Title</a>
+</div>
+</div>
+"""
+        parsed = BeautifulSoup(html, self.test_config.bs4_parser)
+
+        # WHEN
+        item = Item(parsed, self.test_config)
+
+        # THEN
+        self.assertEqual(item.title, "Item Title")
+        self.assertIsNone(item.asin)


### PR DESCRIPTION
### Description

`Item` exposes `title`, `link`, `price`, `seller`, `condition`, `return_eligible_date`, `image_link`, and `quantity` -- but no stable product identifier. The ASIN is the natural key for correlating or de-duping the same product across orders, and callers otherwise have to regex it out of `Item.link` themselves.

This parses the ASIN from the link (`/dp/`, `/gp/product/`, or `/product/` + the 10-char id) and exposes it as `Item.asin: Optional[str]`:

- Pure derivation from the already-parsed `link` -- no extra request.
- Optional and failure-safe, per your guidance: it's derived through `safe_parse`, so a bad/unexpected link never blows anything up -- a miss just yields `None`. It never guesses.
- `None` when the link isn't a product page (e.g. a "Buy it again" or offer-listing URL).
- Handles both id formats found in real order pages: standard (`B0...`) and ISBN-style digits.

On the "why a URL, not a keyed element" question from the issue: Amazon's order pages don't carry the ASIN in a keyed attribute (no `data-asin` on the item block -- the only `[asin]`-keyed nodes on the page belong to the unrelated "Buy it again" recommendations carousel). It lives in the item's product link as the canonical `/dp/<ASIN>` / `/gp/product/<ASIN>` path segment, a URL form Amazon has used for 20+ years. The parse is isolated in `_parse_asin` with a comment to that effect, so it can adopt a structured source if one ever appears.

Fully additive; no change to existing fields.

Closes #101

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a schema change
- [ ] This change requires a documentation update

### Testing Done

Unit tests in `tests/unit/entity/test_item.py` covering the range:

- `/gp/product/<asin>` link -> `asin` parsed (folded into `test_price_stripped`).
- `/dp/<asin>` link -> `asin` parsed (folded into `test_title_starts_with_ampersand_use_lxml`).
- Non-product link (`/gp/buyagain?...`) -> `asin` is `None` (`test_asin_none_when_link_not_a_product_page`).

`item.py` is at 100% line coverage under the unit suite. If you'd like a simple integration assertion too (you mentioned just checking it's non-null), the natural home is an `assertIsNotNone(orders[0].items[0].asin)` alongside the existing item assertions in `test_integration_generic.py` -- I left that to you since it runs against your account's private resources, but happy to add it if you'd prefer it in the PR.

`make check` (flake8) is clean and `make test` passes with no new failures or warnings; `mypy` reports no new findings versus the base.

### Checklist

- [x] I have added tests that prove my change works as expected, and `make test` passes with no new errors or warnings
- [x] I have run `make check` to ensure no new errors or warnings
- [ ] I have updated the docs, if applicable, and run `make docs` to ensure no new errors or warnings  <!-- Item.asin carries a `#:` docstring picked up by the existing autodoc (api.rst autodocs amazonorders.entity.item); run `make docs` to confirm no warnings -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code in particularly hard-to-understand areas
