### PR TITLE
Fix order count parse on empty digital Order history pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased](https://github.com/alexdlaird/amazon-orders/compare/4.4.7...HEAD)
 
+### Fixed
+
+- `get_order_history()` no longer raises `AmazonOrdersError` on an empty digital Order history window (for example `order_filter="digital"` with a year that has no digital orders), where the page renders its `0 orders` count in the time filter label instead of the `span.num-orders` element.
+
 ## [4.4.7](https://github.com/alexdlaird/amazon-orders/compare/4.4.6...4.4.7) - 2026-08-02
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Fixed
 
 - `get_order_history()` no longer raises `AmazonOrdersError` on empty Order history pages that render their count in the time filter label instead of the `span.num-orders` element — an empty digital window (for example `order_filter="digital"` with a year that has no digital orders), or a `start_index` past the end of the window.
+- `get_order_history()` order count parsing no longer raises an unhandled `ValueError` when the count contains a thousands separator (e.g. `1,213 orders`).
 
 ## [4.4.7](https://github.com/alexdlaird/amazon-orders/compare/4.4.6...4.4.7) - 2026-08-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
-- `get_order_history()` no longer raises `AmazonOrdersError` on an empty digital Order history window (for example `order_filter="digital"` with a year that has no digital orders), where the page renders its `0 orders` count in the time filter label instead of the `span.num-orders` element.
+- `get_order_history()` no longer raises `AmazonOrdersError` on empty Order history pages that render their count in the time filter label instead of the `span.num-orders` element — an empty digital window (for example `order_filter="digital"` with a year that has no digital orders), or a `start_index` past the end of the window.
 
 ## [4.4.7](https://github.com/alexdlaird/amazon-orders/compare/4.4.6...4.4.7) - 2026-08-02
 

--- a/amazonorders/orders.py
+++ b/amazonorders/orders.py
@@ -5,6 +5,7 @@ import asyncio
 import concurrent.futures
 import datetime
 import logging
+import re
 from typing import Any, Callable, List, Optional
 from urllib.parse import quote
 
@@ -187,9 +188,12 @@ class AmazonOrders:
             if not order_tags:
                 order_count_tag = util.select_one(page_response.parsed,
                                                   self.config.selectors.ORDER_HISTORY_COUNT_SELECTOR)
-                (order_count, _) = order_count_tag.text.split(" ", 2) if order_count_tag else ("0", None)
+                # Parse just the leading number so the count survives thousands separators
+                # (e.g. "1,213 orders") and any trailing copy; an unparsable count falls
+                # through to the raise below rather than escaping as a bare ValueError
+                count_match = re.match(r"\s*([\d,]+)", order_count_tag.text) if order_count_tag else None
 
-                if order_count_tag and int(order_count) <= current_index:
+                if count_match and int(count_match.group(1).replace(",", "")) <= current_index:
                     break
                 else:
                     raise AmazonOrdersError("Could not parse Order history. Check if Amazon changed the HTML.")

--- a/amazonorders/selectors.py
+++ b/amazonorders/selectors.py
@@ -84,8 +84,11 @@ class Selectors:
 
     ORDER_HISTORY_ENTITY_SELECTOR = ["div.order-card",
                                      "div.order"]
+    # The count confirms an empty page is a spent window rather than a page that failed to render, so
+    # it has to keep matching as Amazon reskins the filter form. The count moved out of its own
+    # ``span.num-orders`` and into a bare ``b``, inside the same label it has always been rendered in
+    # (digital Order history renders it this way as well).
     ORDER_HISTORY_COUNT_SELECTOR = [".js-yo-container span.num-orders",
-                                    # Digital order history renders the count in the time filter label instead
                                     "form.js-time-filter-form label.time-filter__label b"]
     ORDER_DETAILS_ENTITY_SELECTOR = ["div#orderDetails",
                                      "div#ordersContainer",

--- a/amazonorders/selectors.py
+++ b/amazonorders/selectors.py
@@ -84,7 +84,9 @@ class Selectors:
 
     ORDER_HISTORY_ENTITY_SELECTOR = ["div.order-card",
                                      "div.order"]
-    ORDER_HISTORY_COUNT_SELECTOR = ".js-yo-container span.num-orders"
+    ORDER_HISTORY_COUNT_SELECTOR = [".js-yo-container span.num-orders",
+                                    # Digital order history renders the count in the time filter label instead
+                                    "form.js-time-filter-form label b"]
     ORDER_DETAILS_ENTITY_SELECTOR = ["div#orderDetails",
                                      "div#ordersContainer",
                                      "div#odp-main-section"]

--- a/amazonorders/selectors.py
+++ b/amazonorders/selectors.py
@@ -86,7 +86,7 @@ class Selectors:
                                      "div.order"]
     ORDER_HISTORY_COUNT_SELECTOR = [".js-yo-container span.num-orders",
                                     # Digital order history renders the count in the time filter label instead
-                                    "form.js-time-filter-form label b"]
+                                    "form.js-time-filter-form label.time-filter__label b"]
     ORDER_DETAILS_ENTITY_SELECTOR = ["div#orderDetails",
                                      "div#ordersContainer",
                                      "div#odp-main-section"]

--- a/tests/resources/orders/order-history-2026-220.html
+++ b/tests/resources/orders/order-history-2026-220.html
@@ -1,0 +1,108 @@
+<!DOCTYPE html>
+<html lang="en-us">
+<head><title>Your Orders</title></head>
+<body>
+<div id="a-page">
+<section class="your-orders-content-container aok-relative js-yo-container">
+<div class="your-orders-content-container__content js-yo-main-content">
+<div class="a-row a-spacing-base">
+<form action="/your-orders/orders" class="js-time-filter-form a-spacing-none" method="get">
+<label class="a-form-label time-filter__label aok-inline-block a-text-normal" for="time-filter">
+<b>213 orders</b> placed in
+</label>
+<span class="a-dropdown-container"><select autocomplete="off" class="a-native-dropdown" id="time-filter" name="timeFilter" tabindex="-1">
+<option data-ref="d30" value="last30">
+            last 30 days
+        </option>
+<option data-ref="m3" value="months-3">
+            past 3 months
+        </option>
+<option data-ref="y2026" selected="" value="year-2026">
+            2026
+        </option>
+<option data-ref="y2025" value="year-2025">
+            2025
+        </option>
+<option data-ref="y2024" value="year-2024">
+            2024
+        </option>
+<option data-ref="y2023" value="year-2023">
+            2023
+        </option>
+<option data-ref="y2022" value="year-2022">
+            2022
+        </option>
+<option data-ref="y2021" value="year-2021">
+            2021
+        </option>
+<option data-ref="y2020" value="year-2020">
+            2020
+        </option>
+<option data-ref="y2019" value="year-2019">
+            2019
+        </option>
+<option data-ref="y2018" value="year-2018">
+            2018
+        </option>
+<option data-ref="y2017" value="year-2017">
+            2017
+        </option>
+<option data-ref="y2016" value="year-2016">
+            2016
+        </option>
+<option data-ref="y2015" value="year-2015">
+            2015
+        </option>
+<option data-ref="y2014" value="year-2014">
+            2014
+        </option>
+<option data-ref="y2013" value="year-2013">
+            2013
+        </option>
+<option data-ref="y2012" value="year-2012">
+            2012
+        </option>
+<option data-ref="y2011" value="year-2011">
+            2011
+        </option>
+<option data-ref="y2010" value="year-2010">
+            2010
+        </option>
+<option data-ref="y2009" value="year-2009">
+            2009
+        </option>
+</select><span class="a-button a-button-dropdown" tabindex="-1"><span class="a-button-inner"><span aria-hidden="true" class="a-button-text a-declarative" data-action="a-dropdown-button" role="button" tabindex="0"><span class="a-dropdown-prompt">2026</span></span><i class="a-icon a-icon-dropdown"></i></span></span></span>
+<input name="ref_" type="hidden" value="ppx_yo2ov_dt_b_filter_all"/>
+</form>
+<script>
+        P.declare("time-filter-form-ready", {});
+    </script>
+</div>
+<div class="a-row a-spacing-extra-large a-spacing-top-large">
+<div class="a-section a-spacing-top-medium a-text-center">
+        Looks like you didn't place an order in 2026.
+        
+            <a class="a-link-normal" href="?timeFilter=year-2025">View orders in 2025</a>
+</div>
+<script type="text/javascript">if (typeof uet === "function") { uet('cf'); }</script>
+<script type="text/javascript">if (typeof uet === "function") { uet('af'); }</script>
+</div>
+<div class="a-row">
+<div class="a-text-center"><ul class="a-pagination"><li><a href="/your-orders/orders?timeFilter=year-2026&amp;page=21&amp;ref_=ppx_yo2ov_dt_b_pagination_23_22">←<span class="a-letter-space"></span><span class="a-letter-space"></span>Previous</a></li>
+<li class="a-normal"><a href="/your-orders/orders?timeFilter=year-2026&amp;page=0&amp;ref_=ppx_yo2ov_dt_b_pagination_23_1">1</a></li>
+<li class="a-disabled">...</li>
+<li class="a-normal"><a href="/your-orders/orders?timeFilter=year-2026&amp;page=14&amp;ref_=ppx_yo2ov_dt_b_pagination_23_15">15</a></li>
+<li class="a-normal"><a href="/your-orders/orders?timeFilter=year-2026&amp;page=15&amp;ref_=ppx_yo2ov_dt_b_pagination_23_16">16</a></li>
+<li class="a-normal"><a href="/your-orders/orders?timeFilter=year-2026&amp;page=16&amp;ref_=ppx_yo2ov_dt_b_pagination_23_17">17</a></li>
+<li class="a-normal"><a href="/your-orders/orders?timeFilter=year-2026&amp;page=17&amp;ref_=ppx_yo2ov_dt_b_pagination_23_18">18</a></li>
+<li class="a-normal"><a href="/your-orders/orders?timeFilter=year-2026&amp;page=18&amp;ref_=ppx_yo2ov_dt_b_pagination_23_19">19</a></li>
+<li class="a-normal"><a href="/your-orders/orders?timeFilter=year-2026&amp;page=19&amp;ref_=ppx_yo2ov_dt_b_pagination_23_20">20</a></li>
+<li class="a-normal"><a href="/your-orders/orders?timeFilter=year-2026&amp;page=20&amp;ref_=ppx_yo2ov_dt_b_pagination_23_21">21</a></li>
+<li class="a-normal"><a href="/your-orders/orders?timeFilter=year-2026&amp;page=21&amp;ref_=ppx_yo2ov_dt_b_pagination_23_22">22</a></li>
+<li class="a-disabled a-last">Next<span class="a-letter-space"></span><span class="a-letter-space"></span>→</li></ul></div>
+</div>
+</div>
+</section>
+</div>
+</body>
+</html>

--- a/tests/resources/orders/order-history-digital-2005-0.html
+++ b/tests/resources/orders/order-history-digital-2005-0.html
@@ -1,0 +1,328 @@
+<div class="your-orders-content-container__content js-yo-main-content">
+        
+        
+
+<div class="a-section a-spacing-medium a-spacing-top-small">
+    <ul class="breadcrumbs">
+        
+            
+                <li class="breadcrumbs__crumb">
+                    <a class="a-link-normal" href="/your-account/ref=ppx_yo2ov_dt_b_ya_link">Your Account</a>
+                </li>
+                <li class="breadcrumbs__crumb breadcrumbs__crumb--divider">&#8250;</li>
+            
+        
+            
+                <li class="breadcrumbs__crumb breadcrumbs__crumb--current">
+                    <span class="a-color-state">Your Orders</span>
+                </li>
+            
+        
+    </ul>
+</div>
+
+
+<div class="a-row a-spacing-medium">
+    <div class="a-column a-span6">
+        <h1>Your Orders</h1>
+    </div>
+    <div class="a-column a-span6 a-span-last">
+        <div class="search-bar">
+    <form method="get" action="/your-orders/search/ref=ppx_yo2ov_dt_b_search" class="a-spacing-none">
+        <input type="hidden" name="opt" value="ab">
+        
+        <div class="search-bar__input-container">
+            <label for="searchOrdersInput" class="a-form-label"></label>
+            <div class="a-search a-span12" aria-label="Search all orders"><i class="a-icon a-icon-search"></i><input type="search" id="searchOrdersInput" placeholder="Search all orders" name="search" spellcheck="false" class="a-input-text a-span12" aria-label="Search all orders"></div>
+        </div>
+        <div class="search-bar__button-container">
+            <span class="a-button a-button-search"><span class="a-button-inner"><input class="a-button-input" type="submit"><span class="a-button-text" aria-hidden="true">Search Orders</span></span></span>
+        </div>
+    </form>
+</div>
+
+    </div>
+</div>
+
+
+
+<div class="a-section a-spacing-medium page-tabs">
+    <ul>
+        
+            
+                <li class="page-tabs__tab">
+                    <a class="a-link-normal" href="/gp/your-account/order-history?ref_=ppx_yo2ov_dt_b_tb_all_m3">Orders</a>
+                </li>
+            
+        
+            
+                <li class="page-tabs__tab">
+                    <a class="a-link-normal" href="/gp/buyagain?ref_=ppx_yo2ov_dt_b_tb_buy_again">Buy Again</a>
+                </li>
+            
+        
+            
+                <li class="page-tabs__tab">
+                    <a class="a-link-normal" href="/your-orders/orders?ref_=ppx_yo2ov_dt_b_tb_open&orderFilter=open">Not Yet Shipped</a>
+                </li>
+            
+        
+            
+                <li class="page-tabs__tab page-tabs__tab--selected">
+                    Digital Orders
+                </li>
+            
+        
+            
+                <li class="page-tabs__tab">
+                    <a class="a-link-normal" href="https://pay.amazon.com/jr/your-account/orders?ref=ppx_yo2ov_dt_b_amazonPay">Amazon Pay</a>
+                </li>
+            
+        
+    </ul>
+</div>
+
+
+
+    
+<div class="a-row a-spacing-base">
+    <form method="get" action="/your-orders/orders" class="js-time-filter-form a-spacing-none">
+        
+            
+<label for="time-filter" class="a-form-label time-filter__label aok-inline-block a-text-normal">
+    <b>0 orders</b> placed in
+</label>
+
+
+            <span class="a-dropdown-container"><select name="timeFilter" autocomplete="off" id="time-filter" tabIndex="-1" class="a-native-dropdown">
+    
+        <option data-ref="d30" value="last30">
+            last 30 days
+        </option>
+    
+        <option data-ref="m3" value="months-3">
+            past 3 months
+        </option>
+    
+        <option data-ref="y2026" value="year-2026">
+            2026
+        </option>
+    
+        <option data-ref="y2025" value="year-2025">
+            2025
+        </option>
+    
+        <option data-ref="y2024" value="year-2024">
+            2024
+        </option>
+    
+        <option data-ref="y2023" value="year-2023">
+            2023
+        </option>
+    
+        <option data-ref="y2022" value="year-2022">
+            2022
+        </option>
+    
+        <option data-ref="y2021" value="year-2021">
+            2021
+        </option>
+    
+        <option data-ref="y2020" value="year-2020">
+            2020
+        </option>
+    
+        <option data-ref="y2019" value="year-2019">
+            2019
+        </option>
+    
+        <option data-ref="y2018" value="year-2018">
+            2018
+        </option>
+    
+        <option data-ref="y2017" value="year-2017">
+            2017
+        </option>
+    
+        <option data-ref="y2016" value="year-2016">
+            2016
+        </option>
+    
+        <option data-ref="y2015" value="year-2015">
+            2015
+        </option>
+    
+        <option data-ref="y2014" value="year-2014">
+            2014
+        </option>
+    
+        <option data-ref="y2013" value="year-2013">
+            2013
+        </option>
+    
+        <option data-ref="y2012" value="year-2012">
+            2012
+        </option>
+    
+        <option data-ref="y2011" value="year-2011">
+            2011
+        </option>
+    
+        <option data-ref="y2010" value="year-2010">
+            2010
+        </option>
+    
+        <option data-ref="y2009" value="year-2009">
+            2009
+        </option>
+    
+        <option data-ref="y2008" value="year-2008">
+            2008
+        </option>
+    
+        <option data-ref="y2007" value="year-2007">
+            2007
+        </option>
+    
+        <option data-ref="y2006" value="year-2006">
+            2006
+        </option>
+    
+        <option data-ref="y2005" value="year-2005" selected>
+            2005
+        </option>
+    
+</select><span tabIndex="-1" class="a-button a-button-dropdown"><span class="a-button-inner"><span class="a-button-text a-declarative" data-action="a-dropdown-button" role="button" tabIndex="0" aria-hidden="true"><span class="a-dropdown-prompt">2005</span></span><i class="a-icon a-icon-dropdown"></i></span></span></span>
+            
+
+        
+
+        
+
+        
+            <input type="hidden" name="ref_" value="ppx_yo2ov_dt_b_filter_digital">
+        
+            <input type="hidden" name="orderFilter" value="digital">
+        
+    </form>
+    <script></script>
+</div>
+
+
+
+
+        
+
+        
+    <div id="unread-safety-warning-banner" class="a-box a-alert a-alert-warning page-banner--hidden-by-default a-spacing-medium a-spacing-top-medium"><div class="a-box-inner a-alert-container"><h4 class="a-alert-heading">An item you have purchased has been recalled or has a safety alert</h4><i class="a-icon a-icon-alert"></i><div class="a-alert-content">
+    Review the details and next steps on your <a class="a-link-normal" href="/your-product-safety-alerts?ref_=yo_banner_orders_view_bsx_ypsa">recalls & safety alert page</a>.
+</div></div></div>
+
+<style>
+    .page-banner--hidden-by-default {
+        display: none;
+    }
+</style>
+
+
+    <div id="attn-required-alert" class="a-box a-alert a-alert-error page-banner--hidden-by-default a-spacing-medium a-spacing-top-medium" aria-live="assertive" role="alert"><div class="a-box-inner a-alert-container"><h4 class="a-alert-heading">Action is required on one or more of your orders. </h4><i class="a-icon a-icon-alert"></i><div class="a-alert-content">
+    Please <a class="a-link-normal" href="#attn-required-order">see below</a>.
+</div></div></div>
+
+<style>
+    .page-banner--hidden-by-default {
+        display: none;
+    }
+</style>
+
+
+    <div id="problem-displaying-orders-page-banner" class="a-box a-alert a-alert-warning page-banner--hidden-by-default a-spacing-medium a-spacing-top-medium"><div class="a-box-inner a-alert-container"><h4 class="a-alert-heading">There's a problem displaying your orders right now.</h4><i class="a-icon a-icon-alert"></i><div class="a-alert-content">
+    We are working to resolve this issue. Please try again later.
+</div></div></div>
+
+<style>
+    .page-banner--hidden-by-default {
+        display: none;
+    }
+</style>
+
+
+    <div id="digital-orders-experiment-banner" class="a-box a-alert a-alert-info page-banner--hidden-by-default a-spacing-medium a-spacing-top-medium"><div class="a-box-inner a-alert-container"><h4 class="a-alert-heading">Shape the future of Amazon Digital Subscriptions.</h4><i class="a-icon a-icon-alert"></i><div class="a-alert-content">
+    We have made updates to the Your Orders Page. <a class="a-link-normal" target="_blank" rel="noopener" href="https://tiny.amazon.com/17z9tp2l0/amazacti ">Click here to "Opt In"</a> to view the changes and/or provide your feedback. If you spot an issue, please <a class="a-link-normal" target="_blank" rel="noopener" href="https://sim.amazon.com/issues/create?template=f80a98d8-07ac-49e9-b57e-5b521abf38a3">report the bug here</a>. For critical issues (Sev2+), please use <a class="a-link-normal" target="_blank" rel="noopener" href="https://t.corp.amazon.com/create/templates/ce106fde-83ba-4a7a-b702-3ff7017fef2c">TT</a>.
+</div></div></div>
+
+<style>
+    .page-banner--hidden-by-default {
+        display: none;
+    }
+</style>
+
+
+
+
+
+
+
+
+        
+        
+    
+        <div class="top-banner-stack js-top-banner-stack">
+            <div class="celwidget" cel_widget_id="yo-desktop-top-banner-stack_pom" data-csa-op-log-render="" data-csa-c-content-id="DsUnknown" data-csa-c-slot-id="DsUnknown-1" data-csa-c-type="widget" data-csa-c-painter="capability-enforcement-banner-experience"><script></script>
+<!-- k-injected k+b64 eyJrLW9ic2VydmUiOiIiLCJrLWV4dGVybmFsLWNvbmZpZyI6eyJ3ZWJmbG93IjpbeyJzdGF0ZSI6ImFkNjgwMWViNjA2M2Y4MjdiYTQyNzkyMTFmMjY5OTY1OWNhN2Q4ZDEwNmQ4YzcxYjc0YmZmZjIwMjRkMzNlNzUiLCJ0eXBlIjoibm9kZS1zdGF0ZSIsImlkIjoiL2V4cGVyaWVuY2VzL21hcmtldHBsYWNlcy9BVFZQREtJS1gwREVSL3hhL2NhcGFiaWxpdHktZW5mb3JjZW1lbnQtYmFubmVyLWV4cGVyaWVuY2UvYmx1ZXByaW50L2xheW91dHMvY2FwYWJpbGl0eS1lbmZvcmNlbWVudC1iYW5uZXItbGF5b3V0L25vZGVzL24zLWNhcGFiaWxpdHktZW5mb3JjZW1lbnQtc2xvdC1iYW5uZXJfNjVjYTdhYzMyNjRhNDhiYWFlNmFmZGMyZGU0YWM5ZjIifV19fQ== --><!-- k-injected k-component-close --></div>
+        </div>
+    
+
+        
+
+        
+
+        
+            <div class="a-row a-spacing-extra-large a-spacing-top-large">
+    <div class="a-section a-spacing-top-medium a-text-center">
+        Looks like you didn&#x27;t place an order in 2005.
+        
+    </div>
+
+    
+    <script type="text/javascript"></script>
+
+
+
+
+
+    
+
+
+    
+    <script type="text/javascript"></script>
+
+
+
+
+
+    
+
+
+    
+</div>
+
+        
+
+        
+        
+
+        
+
+        <div>
+            <!-- adplacements:feature -->
+
+    
+    
+    
+
+
+
+
+        </div>
+    </div>

--- a/tests/unit/test_orders.py
+++ b/tests/unit/test_orders.py
@@ -1016,6 +1016,30 @@ class TestOrders(UnitTestCase):
         self.assertEqual(1, resp.call_count)
         self.assertIn("Could not parse Order history.", str(cm.exception))
 
+    @responses.activate
+    def test_get_order_history_count_with_thousands_separator(self):
+        # GIVEN - the same real past-the-end page, with the count rendered the way Amazon renders
+        # four-digit counts ("1,213 orders"); the previous split()/int() parse raised ValueError on it
+        self.amazon_session.is_authenticated = True
+        year = 2026
+        start_index = 1220
+        with open(os.path.join(self.RESOURCES_DIR, "orders", "order-history-2026-220.html"), "r",
+                  encoding="utf-8") as f:
+            body = f.read().replace("<b>213 orders</b>", "<b>1,213 orders</b>")
+        resp = responses.add(
+            responses.GET,
+            f"{self.test_config.constants.ORDER_HISTORY_URL}?timeFilter=year-{year}&startIndex={start_index}",
+            body=body,
+            status=200,
+        )
+
+        # WHEN
+        orders = self.amazon_orders.get_order_history(year=year, start_index=start_index)
+
+        # THEN
+        self.assertEqual(0, len(orders))
+        self.assertEqual(1, resp.call_count)
+
     @unittest.skipIf(not os.path.exists(temp_order_history_file_path),
                      reason="Skipped, to debug an order history page, "
                             "place it at tests/output/temp-order-history.html")

--- a/tests/unit/test_orders.py
+++ b/tests/unit/test_orders.py
@@ -1097,3 +1097,21 @@ class TestOrders(UnitTestCase):
         self.assertIn(f"timeFilter=year-{year}", request_url)
         self.assertIn("orderFilter=digital-orders", request_url)
         self.assertEqual(10, len(orders))
+
+    @responses.activate
+    def test_get_order_history_digital_empty_window(self):
+        # GIVEN - the digital Order history page renders its count (and no order cards) in the
+        # time filter label, without the span.num-orders element regular Order history pages have
+        self.amazon_session.is_authenticated = True
+        year = 2005
+        resp = self.given_any_order_history_exists("order-history-digital-2005-0.html")
+
+        # WHEN
+        orders = self.amazon_orders.get_order_history(year=year, order_filter="digital")
+
+        # THEN - an empty window returns an empty list rather than raising a parse error
+        self.assertEqual(0, len(orders))
+        self.assertEqual(1, resp.call_count)
+        request_url = resp.calls[0].request.url
+        self.assertIn(f"timeFilter=year-{year}", request_url)
+        self.assertIn("orderFilter=digital", request_url)

--- a/tests/unit/test_orders.py
+++ b/tests/unit/test_orders.py
@@ -968,6 +968,54 @@ class TestOrders(UnitTestCase):
                     self.assertEqual(0, len(orders))
                     self.assertEqual(1, resp.call_count)
 
+    @responses.activate
+    def test_get_order_history_start_index_past_end(self):
+        # GIVEN
+        self.amazon_session.is_authenticated = True
+        year = 2026
+        start_index = 220
+        with open(os.path.join(self.RESOURCES_DIR, "orders", "order-history-2026-220.html"), "r",
+                  encoding="utf-8") as f:
+            resp = responses.add(
+                responses.GET,
+                f"{self.test_config.constants.ORDER_HISTORY_URL}?timeFilter=year-{year}&startIndex={start_index}",
+                body=f.read(),
+                status=200,
+            )
+
+        # WHEN
+        orders = self.amazon_orders.get_order_history(year=year, start_index=start_index)
+
+        # THEN
+        self.assertEqual(0, len(orders))
+        self.assertEqual(1, resp.call_count)
+
+    @responses.activate
+    def test_get_order_history_empty_page_within_window(self):
+        """
+        The same page served for an index the count does not account for is a page that failed to render, not a
+        spent window, and must not be reported as no Orders.
+        """
+        # GIVEN
+        self.amazon_session.is_authenticated = True
+        year = 2026
+        with open(os.path.join(self.RESOURCES_DIR, "orders", "order-history-2026-220.html"), "r",
+                  encoding="utf-8") as f:
+            resp = responses.add(
+                responses.GET,
+                f"{self.test_config.constants.ORDER_HISTORY_URL}?timeFilter=year-{year}",
+                body=f.read(),
+                status=200,
+            )
+
+        # WHEN
+        with self.assertRaises(AmazonOrdersError) as cm:
+            self.amazon_orders.get_order_history(year=year)
+
+        # THEN
+        self.assertEqual(1, resp.call_count)
+        self.assertIn("Could not parse Order history.", str(cm.exception))
+
     @unittest.skipIf(not os.path.exists(temp_order_history_file_path),
                      reason="Skipped, to debug an order history page, "
                             "place it at tests/output/temp-order-history.html")


### PR DESCRIPTION
Fixes #107.

## What happens

The digital Order history page (`orderFilter=digital`) renders its order count inside the time filter form's `<label><b>0 orders</b></label>` rather than in the `span.num-orders` element regular Order history pages use. On a window with zero digital orders there are no order cards either, so `get_order_history()` finds neither cards nor a count tag and raises `AmazonOrdersError("Could not parse Order history...")` instead of returning an empty list.

Also reported for regular order history when paging past the end of a window — see @zackgomez's comment on #107.

## The fix

`ORDER_HISTORY_COUNT_SELECTOR` becomes a list with `form.js-time-filter-form label b` as a fallback — `util.select_one` already accepts selector lists, and the existing count parse in `orders.py` handles the label's `0 orders` text unchanged, so this is the only code change.

While here, the empty-page count check itself is hardened: the previous `split()`/`int()` parse raised an unhandled `ValueError` on counts with thousands separators (`1,213 orders`), which this change would otherwise make easier to hit since every empty page now flows through the count check. The parse now takes just the leading number, and an unparsable count falls through to the existing `AmazonOrdersError`.


## Test

Covers both ways this bug bites, with real captured pages as fixtures (sanitized):

- An empty **digital** history window (`order-history-digital-2005-0.html`) returns `[]` with both `timeFilter` and `orderFilter` sent.
- A `start_index` **past the end** of a regular window (`order-history-2026-220.html`, captured at startIndex 220 of a 213-order window — thanks @zackgomez, cherry-picked from zackgomez@e1c9c93 with authorship preserved) returns `[]`.
- The same empty page served at an index the count *does* cover still raises — an empty page is only a spent window when the page's own count says so.

Without the selector change the first two reproduce the exact error from #107.

`make test`, flake8, and mypy pass.
