### PR TITLE
Raise a clear error on CSD-encrypted Order history pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased](https://github.com/alexdlaird/amazon-orders/compare/4.5.0...HEAD)
 
+### Fixed
+
+- `parse_order_history()` now raises a clear `AmazonOrdersError` on a page Amazon served with its content encrypted, rather than an entity error about a missing Order ID.
+
 ## [4.5.0](https://github.com/alexdlaird/amazon-orders/compare/4.4.7...4.5.0) - 2026-09-02
 
 ### Added

--- a/amazonorders/orders.py
+++ b/amazonorders/orders.py
@@ -73,6 +73,8 @@ class AmazonOrders:
         A page with no Orders is returned as an empty list only when the page's own Order count
         confirms the window is empty at ``start_index``; otherwise it raises, since that is a page
         that failed to render.
+        A page Amazon served with its content encrypted (which can happen to fetches made outside the
+        library's session) raises rather than being parsed as empty cards.
 
         :param html: The Order history page HTML to parse.
         :param config: The config providing the selectors and entity classes used for parsing.
@@ -81,6 +83,11 @@ class AmazonOrders:
         :return: A list of the parsed Orders.
         """
         parsed = BeautifulSoup(html, config.bs4_parser)
+
+        if util.select_one(parsed, config.selectors.ORDER_HISTORY_CSD_ENCRYPTED_SELECTOR):
+            raise AmazonOrdersError("Could not parse Order history, Amazon served the page with its content "
+                                    "encrypted. Fetch it through an authenticated session instead.")
+
         order_tags = util.select(parsed, config.selectors.ORDER_HISTORY_ENTITY_SELECTOR)
 
         if not order_tags:

--- a/amazonorders/selectors.py
+++ b/amazonorders/selectors.py
@@ -87,6 +87,8 @@ class Selectors:
     # Digital Order history renders the count in the time filter label rather than in span.num-orders
     ORDER_HISTORY_COUNT_SELECTOR = [".js-yo-container span.num-orders",
                                     "form.js-time-filter-form label.time-filter__label b"]
+    # A page served with its card content encrypted carries this noscript fallback; readable pages never do
+    ORDER_HISTORY_CSD_ENCRYPTED_SELECTOR = "noscript meta[content*='disableCsd']"
     ORDER_DETAILS_ENTITY_SELECTOR = ["div#orderDetails",
                                      "div#ordersContainer",
                                      "div#odp-main-section"]

--- a/tests/resources/orders/order-history-csd-encrypted.html
+++ b/tests/resources/orders/order-history-csd-encrypted.html
@@ -1,0 +1,92 @@
+<div class="a-section js-yo-main">
+<form action="/your-orders/orders" class="js-time-filter-form a-spacing-none" method="get">
+<label class="a-form-label time-filter__label aok-inline-block a-text-normal" for="time-filter">
+<b>1 order</b> placed in
+</label>
+<span class="a-dropdown-container"><select autocomplete="off" class="a-native-dropdown" id="time-filter" name="timeFilter" tabindex="-1">
+<option data-ref="d30" value="last30">
+            last 30 days
+        </option>
+<option data-ref="m3" value="months-3">
+            past 3 months
+        </option>
+<option data-ref="y2026" selected="" value="year-2026">
+            2026
+        </option>
+<option data-ref="y2025" value="year-2025">
+            2025
+        </option>
+<option data-ref="y2024" value="year-2024">
+            2024
+        </option>
+<option data-ref="y2023" value="year-2023">
+            2023
+        </option>
+<option data-ref="y2022" value="year-2022">
+            2022
+        </option>
+<option data-ref="y2021" value="year-2021">
+            2021
+        </option>
+<option data-ref="y2020" value="year-2020">
+            2020
+        </option>
+<option data-ref="y2019" value="year-2019">
+            2019
+        </option>
+<option data-ref="y2018" value="year-2018">
+            2018
+        </option>
+<option data-ref="y2017" value="year-2017">
+            2017
+        </option>
+<option data-ref="y2016" value="year-2016">
+            2016
+        </option>
+<option data-ref="y2015" value="year-2015">
+            2015
+        </option>
+<option data-ref="y2014" value="year-2014">
+            2014
+        </option>
+<option data-ref="y2013" value="year-2013">
+            2013
+        </option>
+<option data-ref="y2012" value="year-2012">
+            2012
+        </option>
+<option data-ref="y2011" value="year-2011">
+            2011
+        </option>
+<option data-ref="y2010" value="year-2010">
+            2010
+        </option>
+<option data-ref="y2009" value="year-2009">
+            2009
+        </option>
+<option data-ref="y2008" value="year-2008">
+            2008
+        </option>
+<option data-ref="y2007" value="year-2007">
+            2007
+        </option>
+<option data-ref="y2006" value="year-2006">
+            2006
+        </option>
+<option data-ref="y2005" value="year-2005">
+            2005
+        </option>
+</select><span class="a-button a-button-dropdown" tabindex="-1"><span class="a-button-inner"><span aria-hidden="true" class="a-button-text a-declarative" data-action="a-dropdown-button" role="button" tabindex="0"><span class="a-dropdown-prompt">2026</span></span><i class="a-icon a-icon-dropdown"></i></span></span></span>
+<input name="ref_" type="hidden" value="ppx_yo2ov_dt_b_filter_digital"/>
+<input name="orderFilter" type="hidden" value="digital"/>
+</form>
+<div class="order-card js-order-card" data-csa-c-content-id="amzn1.yourorders.order-card" data-csa-c-slot-id="amzn1.yourorders.order-card.D01-3000555-4000666" data-csa-c-type="widget">
+<div class="a-box-group a-spacing-base">
+<script type="text/javascript">csdContent({"content":"SCRUBBED-ENCRYPTED-PAYLOAD","iv":"AAAAAAAAAAAAAAAA","kid":"000000"})</script>
+<div class="csd-encrypted-sensitive" id="e78e8f01-0335-4bb1-94ab-038a85ccf523">
+<script type="text/javascript">csdContent({"content":"SCRUBBED-ENCRYPTED-PAYLOAD","iv":"AAAAAAAAAAAAAAAA","kid":"000000"})</script>
+<noscript><meta content="0;url=?disableCsd=no-js&amp;orderFilter=digital&amp;startIndex=0&amp;timeFilter=year-2026" http-equiv="refresh"/></noscript>
+</div>
+</div>
+</div>
+</div>

--- a/tests/unit/test_orders.py
+++ b/tests/unit/test_orders.py
@@ -759,6 +759,19 @@ class TestOrders(UnitTestCase):
         # THEN
         self.assertIn("Could not parse Order history", str(cm.exception))
 
+    def test_parse_order_history_csd_encrypted(self):
+        # GIVEN
+        with open(os.path.join(self.RESOURCES_DIR, "orders", "order-history-csd-encrypted.html"), "r",
+                  encoding="utf-8") as f:
+            html = f.read()
+
+        # WHEN
+        with self.assertRaises(AmazonOrdersError) as cm:
+            AmazonOrders.parse_order_history(html, self.test_config)
+
+        # THEN
+        self.assertIn("encrypted", str(cm.exception))
+
     def test_parse_order_history_unparseable(self):
         # GIVEN
         with open(os.path.join(self.RESOURCES_DIR, "500.html"), "r", encoding="utf-8") as f:


### PR DESCRIPTION
Fixes #116.

When an Order history page is obtained outside the library's session, Amazon can serve it with the order cards' content replaced by an encrypted client-side-decryption payload. The card shells still match `ORDER_HISTORY_ENTITY_SELECTOR`, so `parse_order_history()` tried to build an `Order` from one and raised an entity error about a missing Order ID, pointing callers at markup drift that doesn't exist.

The shells carry a `noscript` fallback naming `disableCsd`, which readable pages never do. This checks for it before row parsing and raises a plain `AmazonOrdersError` saying the content is encrypted and the page should be fetched through a session.

Fixture: a captured encrypted page trimmed to the time filter form and one card shell, with the payload replaced by a dummy of the same shape and the order ID remapped. Without the check, the test reproduces the entity error from #116.

`make test`, flake8, and mypy pass.