### PR TITLE
Fix PlaywrightJSAuthForm always timing out when the JS challenge reloads the same URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased](https://github.com/alexdlaird/amazon-orders/compare/4.5.0...HEAD)
 
+### Fixed
+
+- `PlaywrightJSAuthForm` could never detect the JavaScript bot-detection challenge resolving — and always timed out — when Amazon served the challenge at the destination URL, since it resolves by reloading that same URL. Resolution is now detected by waiting for the challenge text to disappear from the page content instead of waiting for the URL to change.
+
 ## [4.5.0](https://github.com/alexdlaird/amazon-orders/compare/4.4.7...4.5.0) - 2026-09-02
 
 ### Added

--- a/amazonorders/contrib/browser/playwright.py
+++ b/amazonorders/contrib/browser/playwright.py
@@ -514,8 +514,37 @@ class PlaywrightJSAuthForm(PlaywrightAuthForm):
         self.amazon_session = amazon_session
         return bool(re.search(self.regex, parsed.text))
 
+    def _on_challenge_page(self, page: Any, context: Any, output_dir: Optional[str]) -> None:
+        # Wait until the challenge resolves, which it does by reloading the original URL with
+        # different content: the robot-challenge text is gone and a real page has rendered. The
+        # text length guard avoids false positives while the reload leaves the DOM briefly empty.
+        from playwright.sync_api import TimeoutError as PlaywrightTimeoutError  # type: ignore[import-not-found]
+
+        try:
+            page.wait_for_function(
+                "(pattern) => {"
+                "  const el = document.body;"
+                "  if (!el) return false;"
+                "  const text = el.innerText || '';"
+                "  return !new RegExp(pattern, 'i').test(text) && text.length > 500;"
+                "}",
+                arg=self.regex,
+                timeout=self.config.browser_timeout * 1000,
+            )
+        except PlaywrightTimeoutError as e:
+            logger.debug(f"Browser timed out at URL: {page.url}")
+            self._save_debug_snapshot(page, output_dir, "browser-timeout")
+            if page.context.browser:
+                page.context.browser.close()
+            raise AmazonOrdersError(
+                "Browser timed out waiting for the JavaScript challenge to resolve."
+            ) from e
+
     def _is_challenge_url(self, url: str, original_url: str) -> bool:
-        return url.split("?")[0] == original_url.split("?")[0]
+        # Resolution is detected by page content in _on_challenge_page. The challenge is served
+        # at the destination URL and reloads that same URL when solved, so a URL comparison
+        # would report "still challenged" forever.
+        return False
 
 
 class PlaywrightManualWafForm(PlaywrightAuthForm):

--- a/tests/unit/contrib/test_playwright.py
+++ b/tests/unit/contrib/test_playwright.py
@@ -536,18 +536,65 @@ class TestPlaywrightJSAuthForm(UnitTestCase):
         # THEN
         self.assertEqual(self.test_config.constants.JS_ROBOT_TEXT_REGEX, form.regex)
 
-    def test_is_challenge_url_matches_original_path(self):
+    def test_is_challenge_url_always_false(self):
         # GIVEN
         form = PlaywrightJSAuthForm(self.test_config)
+
+        # The challenge is served at the destination URL and resolves by reloading that same
+        # URL, so resolution is detected by page content, not by URL change -- even an identical
+        # URL must therefore be reported as resolved.
         original = "https://www.amazon.com/ap/signin?openid.return_to=abc"
-
-        # same path, different query → still on challenge
-        self.assertTrue(form._is_challenge_url(
-            "https://www.amazon.com/ap/signin?other_param=123", original))
-
-        # different path → challenge resolved
+        self.assertFalse(form._is_challenge_url(original, original))
         self.assertFalse(form._is_challenge_url(
             "https://www.amazon.com/gp/yourorders", original))
+
+    def test_submit_waits_for_challenge_text_to_disappear(self):
+        # GIVEN
+        form = PlaywrightJSAuthForm(self.test_config)
+        parsed = BeautifulSoup(self.js_html, self.test_config.bs4_parser)
+        form.select_form(self.amazon_session, parsed)
+
+        original_url = "https://www.amazon.com/"
+        last_response = MagicMock()
+        last_response.url = original_url
+        self.amazon_session.get = MagicMock(return_value="refetched")
+
+        # the challenge resolves by reloading the SAME url
+        mock_sync_playwright, mock_page, _, _ = _make_mock_playwright(final_url=original_url)
+        fake_module = _playwright_module(mock_sync_playwright)
+
+        # WHEN
+        with patch.dict(sys.modules, {"playwright": MagicMock(), "playwright.sync_api": fake_module}):
+            result = form.submit(last_response)
+
+        # THEN
+        mock_page.wait_for_function.assert_called_once()
+        _, kwargs = mock_page.wait_for_function.call_args
+        self.assertEqual(form.regex, kwargs["arg"])
+        self.assertEqual(self.test_config.browser_timeout * 1000, kwargs["timeout"])
+        self.assertEqual("refetched", result)
+        self.amazon_session.get.assert_called_once_with(original_url, persist_cookies=True)
+
+    def test_submit_timeout_when_challenge_text_persists(self):
+        # GIVEN
+        form = PlaywrightJSAuthForm(self.test_config)
+        parsed = BeautifulSoup(self.js_html, self.test_config.bs4_parser)
+        form.select_form(self.amazon_session, parsed)
+
+        last_response = MagicMock()
+        last_response.url = "https://www.amazon.com/"
+
+        mock_sync_playwright, mock_page, _, mock_browser = _make_mock_playwright(
+            final_url="https://www.amazon.com/")
+        mock_page.wait_for_function.side_effect = _FakeTimeoutError("timed out")
+        mock_page.context.browser = mock_browser
+        fake_module = _playwright_module(mock_sync_playwright, timeout_error_cls=_FakeTimeoutError)
+
+        # WHEN / THEN
+        with patch.dict(sys.modules, {"playwright": MagicMock(), "playwright.sync_api": fake_module}):
+            with self.assertRaises(AmazonOrdersError):
+                form.submit(last_response)
+        mock_browser.close.assert_called_once()
 
     def test_submit_refetches_final_url(self):
         # GIVEN


### PR DESCRIPTION
Fixes #121.

## Problem

`PlaywrightJSAuthForm` detected challenge resolution via a URL change (`_is_challenge_url`: `url.split("?")[0] == original_url.split("?")[0]`). But Amazon serves this bot-detection challenge **at the destination URL** and resolves it by reloading that same URL (solve → set cookie → reload), so `wait_for_url()` never fired and login always failed with `AmazonOrdersError: Browser timed out waiting for the JavaScript challenge to resolve.` — even when the challenge was solved correctly, and regardless of how large `browser_timeout` was set. Reproduced against live Amazon in a headless-Chromium Docker environment; the Playwright log shows `navigated to "https://www.amazon.com/"` immediately before the timeout.

## Fix

Resolution is now detected by page **content**, which is the actual signal for this challenge type:

- New `_on_challenge_page()` override waits (via `page.wait_for_function`, bounded by `browser_timeout`) for the `JS_ROBOT_TEXT_REGEX` match to disappear from the rendered page AND for real content (`> 500` chars of `innerText`) to appear — the length guard avoids false positives while the reload leaves `document.body` briefly empty.
- `_is_challenge_url()` now always returns `False` for this form, with a comment explaining why a URL comparison can never work here; the base class's subsequent `wait_for_url()` then passes instantly after the content wait.
- Timeout behavior (debug log, `browser-timeout` snapshot, browser cleanup, `AmazonOrdersError`) mirrors the base class's handling.

No changes to the base class or to `PlaywrightAcicForm`/`PlaywrightManualWafForm`, whose challenge pages navigate to a genuinely different URL on resolution.

## Tests

- Replaced `test_is_challenge_url_matches_original_path` (which asserted the broken semantics) with `test_is_challenge_url_always_false`.
- Added `test_submit_waits_for_challenge_text_to_disappear` — resolution at the *same* URL now succeeds, and the content wait receives the regex and `browser_timeout`.
- Added `test_submit_timeout_when_challenge_text_persists` — unresolved challenge still raises `AmazonOrdersError` and closes the browser.

`pytest tests/unit`: 230 passed, 6 skipped. `flake8` clean on changed files; `mypy` introduces no new errors (the one reported is a pre-existing `types-PyYAML` stub issue in `conf.py`, also present on `develop`). CHANGELOG updated under Unreleased → Fixed.

One honest limitation, unchanged from before: if Amazon escalates to an embedded visual puzzle, headless still can't solve it — that path is covered by the WAF-solver extras as documented.